### PR TITLE
feat: 공간관리자 회원가입 기능 구현 (#47)

### DIFF
--- a/frontend/src/api/join.ts
+++ b/frontend/src/api/join.ts
@@ -1,7 +1,7 @@
 import { QueryFunction } from 'react-query';
 import api from './api';
 
-interface JoinProps {
+interface JoinParams {
   email: string;
   password: string;
   organization: string;
@@ -13,6 +13,6 @@ export const queryValidateEmail: QueryFunction = ({ queryKey }) => {
   return api.get(`/members/?email=${email}`);
 };
 
-export const postJoin = ({ email, password, organization }: JoinProps) => {
+export const postJoin = ({ email, password, organization }: JoinParams) => {
   return api.post('/members', { email, password, organization });
 };

--- a/frontend/src/api/join.ts
+++ b/frontend/src/api/join.ts
@@ -8,7 +8,7 @@ interface JoinProps {
 }
 
 export const queryValidateEmail: QueryFunction = ({ queryKey }) => {
-  const [_, email] = queryKey;
+  const [, email] = queryKey;
 
   return api.get(`/members/?email=${email}`);
 };

--- a/frontend/src/api/join.ts
+++ b/frontend/src/api/join.ts
@@ -1,8 +1,18 @@
-import { QueryFunction } from 'react-query';
+import { MutateFunction, QueryFunction } from 'react-query';
 import api from './api';
+
+interface PostJoinProps {
+  email: string;
+  password: string;
+  organization: string;
+}
 
 export const getValidateEmail: QueryFunction = ({ queryKey }) => {
   const [, email] = queryKey;
 
   return api.get(`/members/?email=${email}`);
+};
+
+export const postJoin = ({ email, password, organization }: PostJoinProps) => {
+  return api.post('/members', { email, password, organization });
 };

--- a/frontend/src/api/join.ts
+++ b/frontend/src/api/join.ts
@@ -1,18 +1,18 @@
-import { MutateFunction, QueryFunction } from 'react-query';
+import { QueryFunction } from 'react-query';
 import api from './api';
 
-interface PostJoinProps {
+interface JoinProps {
   email: string;
   password: string;
   organization: string;
 }
 
-export const getValidateEmail: QueryFunction = ({ queryKey }) => {
-  const [, email] = queryKey;
+export const queryValidateEmail: QueryFunction = ({ queryKey }) => {
+  const [_, email] = queryKey;
 
   return api.get(`/members/?email=${email}`);
 };
 
-export const postJoin = ({ email, password, organization }: PostJoinProps) => {
+export const postJoin = ({ email, password, organization }: JoinProps) => {
   return api.post('/members', { email, password, organization });
 };

--- a/frontend/src/components/Input/Input.styles.ts
+++ b/frontend/src/components/Input/Input.styles.ts
@@ -65,7 +65,7 @@ export const Input = styled.input<Props>`
 
 export const Message = styled.p<Props>`
   ${({ status = 'default' }) => statusCSS[status]};
-  font-size: 1rem;
+  font-size: 0.75rem;
   position: absolute;
   bottom: -1.5rem;
   left: 0.75rem;

--- a/frontend/src/constants/message.ts
+++ b/frontend/src/constants/message.ts
@@ -4,9 +4,9 @@ const MESSAGE = {
     FAILURE: '회원가입에 실패했습니다.',
     VALID_EMAIL: '사용 가능한 이메일입니다.',
     VALID_PASSWORD: '사용 가능한 비밀번호입니다.',
-    INVALID_PASSWORD: '비밀번호는 영어와 숫자를 포함해서 8자 이상 20자 이내로 입력해주세요.',
-    VALID_PASSWORD_CONFIRM: '입력하신 비밀번호와 일치합니다.',
-    INVALID_PASSWORD_CONFIRM: '비밀번호와 비밀번호 확인란에 입력하신 문자가 다릅니다.',
+    INVALID_PASSWORD: '영어와 숫자를 포함하여 8~20자로 입력해주세요.',
+    VALID_PASSWORD_CONFIRM: '비밀번호가 일치합니다.',
+    INVALID_PASSWORD_CONFIRM: '비밀번호가 서로 다릅니다.',
     UNEXPECTED_ERROR: '이메일 중복 확인에 문제가 발생했습니다. 잠시 후에 다시 시도해주세요.',
   },
 };

--- a/frontend/src/constants/message.ts
+++ b/frontend/src/constants/message.ts
@@ -1,6 +1,12 @@
 const MESSAGE = {
   JOIN: {
+    SUCCESS: '회원가입에 성공했습니다.',
+    FAILURE: '회원가입에 실패했습니다.',
     VALID_EMAIL: '사용 가능한 이메일입니다.',
+    VALID_PASSWORD: '사용 가능한 비밀번호입니다.',
+    INVALID_PASSWORD: '비밀번호는 영어와 숫자를 포함해서 8자 이상 20자 이내로 입력해주세요.',
+    VALID_PASSWORD_CONFIRM: '입력하신 비밀번호와 일치합니다.',
+    INVALID_PASSWORD_CONFIRM: '비밀번호와 비밀번호 확인란에 입력하신 문자가 다릅니다.',
     UNEXPECTED_ERROR: '이메일 중복 확인에 문제가 발생했습니다. 잠시 후에 다시 시도해주세요.',
   },
 };

--- a/frontend/src/constants/regexp.ts
+++ b/frontend/src/constants/regexp.ts
@@ -1,0 +1,5 @@
+const REGEXP = {
+  PASSWORD: /^(?=.*[a-zA-Z])(?=.*[0-9]).{8,20}$/,
+};
+
+export default REGEXP;

--- a/frontend/src/pages/Join/Join.tsx
+++ b/frontend/src/pages/Join/Join.tsx
@@ -1,4 +1,4 @@
-import { getValidateEmail, postJoin } from 'api/join';
+import { postJoin, queryValidateEmail } from 'api/join';
 import { AxiosError } from 'axios';
 import Button from 'components/Button/Button';
 import Header from 'components/Header/Header';
@@ -8,7 +8,7 @@ import MESSAGE from 'constants/message';
 import PATH from 'constants/path';
 import REGEXP from 'constants/regexp';
 import useInput from 'hooks/useInput';
-import { FormEventHandler, useState } from 'react';
+import { FormEventHandler, useEffect, useState } from 'react';
 import { useMutation, useQuery } from 'react-query';
 import { useHistory } from 'react-router-dom';
 import * as Styled from './Join.styles';
@@ -55,29 +55,29 @@ const Join = (): JSX.Element => {
     isValidEmail.refetch();
   };
 
-  const handleValidatePassword = () => {
-    if (!REGEXP.PASSWORD.test(password)) {
-      setPasswordMessage(MESSAGE.JOIN.INVALID_PASSWORD);
-    } else {
-      setPasswordMessage(MESSAGE.JOIN.VALID_PASSWORD);
-    }
-  };
-
-  const handleValidatePasswordConfirm = () => {
-    if (password !== passwordConfirm) {
-      setPasswordConfirmMessage(MESSAGE.JOIN.INVALID_PASSWORD_CONFIRM);
-    } else {
-      setPasswordConfirmMessage(MESSAGE.JOIN.VALID_PASSWORD_CONFIRM);
-    }
-  };
-
   const handleSubmitJoinForm: FormEventHandler<HTMLFormElement> = (event) => {
     event.preventDefault();
 
     if (!email || !password || !passwordConfirm || !organization) return;
 
-    postJoinMutation.mutate({ email, password, organization });
+    joinUser.mutate({ email, password, organization });
   };
+
+  useEffect(() => {
+    if (password !== passwordConfirm) {
+      setPasswordConfirmMessage(MESSAGE.JOIN.INVALID_PASSWORD_CONFIRM);
+    } else {
+      setPasswordConfirmMessage(MESSAGE.JOIN.VALID_PASSWORD_CONFIRM);
+    }
+  }, [passwordConfirm]);
+
+  useEffect(() => {
+    if (!REGEXP.PASSWORD.test(password)) {
+      setPasswordMessage(MESSAGE.JOIN.INVALID_PASSWORD);
+    } else {
+      setPasswordMessage(MESSAGE.JOIN.VALID_PASSWORD);
+    }
+  }, [password]);
 
   return (
     <>
@@ -103,7 +103,6 @@ const Join = (): JSX.Element => {
               minLength={8}
               value={password}
               onChange={onChangePassword}
-              onBlur={handleValidatePassword}
               message={passwordMessage}
               status={REGEXP.PASSWORD.test(password) ? 'success' : 'error'}
               required
@@ -114,7 +113,6 @@ const Join = (): JSX.Element => {
               minLength={8}
               value={passwordConfirm}
               onChange={onChangePasswordConfirm}
-              onBlur={handleValidatePasswordConfirm}
               message={passwordConfirmMessage}
               status={password === passwordConfirm ? 'success' : 'error'}
               required

--- a/frontend/src/pages/Join/Join.tsx
+++ b/frontend/src/pages/Join/Join.tsx
@@ -36,7 +36,7 @@ const Join = (): JSX.Element => {
     },
 
     onError: (error: AxiosError) => {
-      setEmailMessage(error?.response?.data.message);
+      setEmailMessage(error.response?.data.message);
     },
   });
 

--- a/frontend/src/pages/Join/Join.tsx
+++ b/frontend/src/pages/Join/Join.tsx
@@ -25,6 +25,8 @@ const Join = (): JSX.Element => {
 
   const history = useHistory();
 
+  const isPassword = REGEXP.PASSWORD.test(password);
+
   const isValidEmail = useQuery(['isValidEmail', email], queryValidateEmail, {
     enabled: false,
     retry: false,
@@ -66,10 +68,10 @@ const Join = (): JSX.Element => {
   useEffect(() => {
     if (!password) return;
 
-    !REGEXP.PASSWORD.test(password)
+    !isPassword
       ? setPasswordMessage(MESSAGE.JOIN.INVALID_PASSWORD)
       : setPasswordMessage(MESSAGE.JOIN.VALID_PASSWORD);
-  }, [password]);
+  }, [password, isPassword]);
 
   useEffect(() => {
     if (!password || !passwordConfirm) return;
@@ -104,7 +106,7 @@ const Join = (): JSX.Element => {
               value={password}
               onChange={onChangePassword}
               message={passwordMessage}
-              status={REGEXP.PASSWORD.test(password) ? 'success' : 'error'}
+              status={isPassword ? 'success' : 'error'}
               required
             />
             <Input

--- a/frontend/src/pages/Join/Join.tsx
+++ b/frontend/src/pages/Join/Join.tsx
@@ -64,19 +64,15 @@ const Join = (): JSX.Element => {
   };
 
   useEffect(() => {
-    if (password !== passwordConfirm) {
-      setPasswordConfirmMessage(MESSAGE.JOIN.INVALID_PASSWORD_CONFIRM);
-    } else {
-      setPasswordConfirmMessage(MESSAGE.JOIN.VALID_PASSWORD_CONFIRM);
-    }
+    password !== passwordConfirm
+      ? setPasswordConfirmMessage(MESSAGE.JOIN.INVALID_PASSWORD_CONFIRM)
+      : setPasswordConfirmMessage(MESSAGE.JOIN.VALID_PASSWORD_CONFIRM);
   }, [passwordConfirm]);
 
   useEffect(() => {
-    if (!REGEXP.PASSWORD.test(password)) {
-      setPasswordMessage(MESSAGE.JOIN.INVALID_PASSWORD);
-    } else {
-      setPasswordMessage(MESSAGE.JOIN.VALID_PASSWORD);
-    }
+    !REGEXP.PASSWORD.test(password)
+      ? setPasswordMessage(MESSAGE.JOIN.INVALID_PASSWORD)
+      : setPasswordMessage(MESSAGE.JOIN.VALID_PASSWORD);
   }, [password]);
 
   return (

--- a/frontend/src/pages/Join/Join.tsx
+++ b/frontend/src/pages/Join/Join.tsx
@@ -77,7 +77,7 @@ const Join = (): JSX.Element => {
     password !== passwordConfirm
       ? setPasswordConfirmMessage(MESSAGE.JOIN.INVALID_PASSWORD_CONFIRM)
       : setPasswordConfirmMessage(MESSAGE.JOIN.VALID_PASSWORD_CONFIRM);
-  }, [passwordConfirm]);
+  }, [password, passwordConfirm]);
 
   return (
     <>

--- a/frontend/src/pages/Join/Join.tsx
+++ b/frontend/src/pages/Join/Join.tsx
@@ -64,16 +64,20 @@ const Join = (): JSX.Element => {
   };
 
   useEffect(() => {
-    password !== passwordConfirm
-      ? setPasswordConfirmMessage(MESSAGE.JOIN.INVALID_PASSWORD_CONFIRM)
-      : setPasswordConfirmMessage(MESSAGE.JOIN.VALID_PASSWORD_CONFIRM);
-  }, [passwordConfirm]);
+    if (!password) return;
 
-  useEffect(() => {
     !REGEXP.PASSWORD.test(password)
       ? setPasswordMessage(MESSAGE.JOIN.INVALID_PASSWORD)
       : setPasswordMessage(MESSAGE.JOIN.VALID_PASSWORD);
   }, [password]);
+
+  useEffect(() => {
+    if (!password || !passwordConfirm) return;
+
+    password !== passwordConfirm
+      ? setPasswordConfirmMessage(MESSAGE.JOIN.INVALID_PASSWORD_CONFIRM)
+      : setPasswordConfirmMessage(MESSAGE.JOIN.VALID_PASSWORD_CONFIRM);
+  }, [passwordConfirm]);
 
   return (
     <>

--- a/frontend/src/pages/Join/Join.tsx
+++ b/frontend/src/pages/Join/Join.tsx
@@ -25,7 +25,7 @@ const Join = (): JSX.Element => {
 
   const history = useHistory();
 
-  const isValidEmail = useQuery(['isValidEmail', email], getValidateEmail, {
+  const isValidEmail = useQuery(['isValidEmail', email], queryValidateEmail, {
     enabled: false,
     retry: false,
 
@@ -38,7 +38,7 @@ const Join = (): JSX.Element => {
     },
   });
 
-  const postJoinMutation = useMutation(postJoin, {
+  const joinUser = useMutation(postJoin, {
     onSuccess: () => {
       alert(MESSAGE.JOIN.SUCCESS);
       history.push(PATH.LOGIN);

--- a/frontend/src/pages/Join/Join.tsx
+++ b/frontend/src/pages/Join/Join.tsx
@@ -129,7 +129,7 @@ const Join = (): JSX.Element => {
               variant="primary"
               size="large"
               fullWidth
-              disabled={email && password && passwordConfirm && organization ? false : true}
+              disabled={!(email && password && passwordConfirm && organization)}
             >
               회원가입
             </Button>


### PR DESCRIPTION

## 배운 점

### 1. react-query에서 `useQuery`와 `useMutation`의 차이

- useQuery
    - `async`요청을 통해 데이터를 변경하지 않을 때 사용
    - `GET`
- useMutation
    - `async`요청을 통해 데이터를 변경시킬 때 사용
    - `POST`, `UPDATE`, `PUT` 등

### 2. `useQuery`, `useMutation` 코드 예시
- useQuery
```tsx
  const isValidEmail = useQuery(['isValidEmail', email], getValidateEmail, {
    enabled: false,
    retry: false,

    onSuccess: () => {
      setEmailMessage(MESSAGE.JOIN.VALID_EMAIL);
    },

    onError: (error: AxiosError) => {
      setEmailMessage(error?.response?.data.message);
    },
  });
```

- useMutation
```tsx
  const mutation = useMutation(postJoin, {
    onSuccess: () => {
      alert(MESSAGE.JOIN.SUCCESS);
      history.push(PATH.LOGIN);
    },

    onError: () => {
      alert(MESSAGE.JOIN.FAILURE);
    },
  });

  const handleSubmitJoinForm: FormEventHandler<HTMLFormElement> = (event) => {
    event.preventDefault();

    if (!email || !password || !passwordConfirm || !organization) return;

    mutation.mutate({ email, password, organization });
  };
```

- `useQuery`는 사용할 함수를 등록하는 시점에서 변수를 넘긴다.
- `useMutation`은 mutate를 호출하는 시점에서 변수를 넘긴다.
     - `mutation.mutate({ email, password, organization })`;

## 논의하고 싶은 부분

1. mutation의 변수명
    - 현재 ${api함수명} + 'Mutation'인데 적절한지 고민입니다.
2. snackbar
    - 회원가입 성공, 실패등의 알림 처리를 현재는 `alert`로 처리 했습니다.
    - `snackbar`를 직접 구현할지 `notistack`등의 서드파티 라이브러리를 사용할지 논의해보면 좋을거 같습니다.

## UI 및 동작
![image](https://user-images.githubusercontent.com/61097373/125162513-3f314d00-e1c3-11eb-8636-a5b388b8a9c7.png)

![zzkk](https://user-images.githubusercontent.com/61097373/125162973-e4e5bb80-e1c5-11eb-870c-da8af523a53d.gif)


close #47 