### PR TITLE
fix: `PanelContext`의 타입이 맞지 않는 문제 수정 (#76)

### DIFF
--- a/frontend/src/components/Panel/PanelContext.ts
+++ b/frontend/src/components/Panel/PanelContext.ts
@@ -1,9 +1,15 @@
 import { createContext } from 'react';
-import { Props as PanelProps } from './Panel';
 
-const PanelContext = createContext<PanelProps>({
+interface PanelContextValue {
+  expandable: boolean;
+  expanded: boolean;
+  onToggle: () => void;
+}
+
+const PanelContext = createContext<PanelContextValue>({
   expandable: true,
   expanded: false,
+  onToggle: () => {},
 });
 
 if (process.env.NODE_ENV !== 'production') {


### PR DESCRIPTION
## 구현 기능
- `PanelContext`의 타입이 맞지 않는 문제를 수정합니다.
  - `PanelContext`의 value가 사용하는 타입을 생성하여 적용했습니다.

## 기타
#56 에서 추가로 수정하는 과정에서 미처 발견하지 못하고 바로 머지를 해서 생긴 이슈입니다.

Close #76
