### PR TITLE
feat: 예약조회 시 시간순으로 정렬하는 로직 추가

### DIFF
--- a/backend/src/main/java/com/woowacourse/zzimkkong/ZzimkkongApplication.java
+++ b/backend/src/main/java/com/woowacourse/zzimkkong/ZzimkkongApplication.java
@@ -3,9 +3,6 @@ package com.woowacourse.zzimkkong;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
-import javax.annotation.PostConstruct;
-import java.util.TimeZone;
-
 @SpringBootApplication
 public class ZzimkkongApplication {
 

--- a/backend/src/main/java/com/woowacourse/zzimkkong/dto/reservation/ReservationFindAllResponse.java
+++ b/backend/src/main/java/com/woowacourse/zzimkkong/dto/reservation/ReservationFindAllResponse.java
@@ -5,8 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.woowacourse.zzimkkong.domain.Reservation;
 import com.woowacourse.zzimkkong.domain.Space;
 
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.stream.Collectors;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -24,6 +23,8 @@ public class ReservationFindAllResponse {
     public static ReservationFindAllResponse of(List<Reservation> reservations) {
         Map<Space, List<Reservation>> reservationGroups = reservations.stream()
                 .collect(Collectors.groupingBy(Reservation::getSpace));
+
+        reservationGroups.values().forEach(each -> each.sort(Comparator.comparing(Reservation::getStartTime)));
 
         List<ReservationSpaceResponse> reservationSpaceResponses = reservationGroups.entrySet()
                 .stream()

--- a/backend/src/main/java/com/woowacourse/zzimkkong/dto/reservation/ReservationFindAllResponse.java
+++ b/backend/src/main/java/com/woowacourse/zzimkkong/dto/reservation/ReservationFindAllResponse.java
@@ -29,6 +29,7 @@ public class ReservationFindAllResponse {
         List<ReservationSpaceResponse> reservationSpaceResponses = reservationGroups.entrySet()
                 .stream()
                 .map(ReservationSpaceResponse::of)
+                .sorted(Comparator.comparing(ReservationSpaceResponse::getSpaceId))
                 .collect(Collectors.toList());
 
         return new ReservationFindAllResponse(reservationSpaceResponses);

--- a/backend/src/main/java/com/woowacourse/zzimkkong/dto/reservation/ReservationFindAllResponse.java
+++ b/backend/src/main/java/com/woowacourse/zzimkkong/dto/reservation/ReservationFindAllResponse.java
@@ -24,7 +24,9 @@ public class ReservationFindAllResponse {
         Map<Space, List<Reservation>> reservationGroups = reservations.stream()
                 .collect(Collectors.groupingBy(Reservation::getSpace));
 
-        reservationGroups.values().forEach(each -> each.sort(Comparator.comparing(Reservation::getStartTime)));
+        for (final List<Reservation> each : reservationGroups.values()) {
+            each.sort(Comparator.comparing(Reservation::getStartTime));
+        }
 
         List<ReservationSpaceResponse> reservationSpaceResponses = reservationGroups.entrySet()
                 .stream()

--- a/backend/src/main/java/com/woowacourse/zzimkkong/dto/reservation/ReservationFindResponse.java
+++ b/backend/src/main/java/com/woowacourse/zzimkkong/dto/reservation/ReservationFindResponse.java
@@ -3,6 +3,7 @@ package com.woowacourse.zzimkkong.dto.reservation;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.woowacourse.zzimkkong.domain.Reservation;
 
+import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -18,6 +19,8 @@ public class ReservationFindResponse {
     }
 
     public static ReservationFindResponse of(final List<Reservation> reservations) {
+        reservations.sort(Comparator.comparing(Reservation::getStartTime));
+
         List<ReservationResponse> reservationResponses = reservations.stream()
                 .map(ReservationResponse::of)
                 .collect(Collectors.toList());

--- a/backend/src/main/java/com/woowacourse/zzimkkong/dto/reservation/ReservationSpaceResponse.java
+++ b/backend/src/main/java/com/woowacourse/zzimkkong/dto/reservation/ReservationSpaceResponse.java
@@ -30,4 +30,8 @@ public class ReservationSpaceResponse {
 
         return new ReservationSpaceResponse(reservationsPerSpace.getKey().getId(), reservations);
     }
+
+    public Long getSpaceId() {
+        return spaceId;
+    }
 }

--- a/backend/src/main/java/com/woowacourse/zzimkkong/exception/member/NoSuchMemberException.java
+++ b/backend/src/main/java/com/woowacourse/zzimkkong/exception/member/NoSuchMemberException.java
@@ -1,6 +1,5 @@
 package com.woowacourse.zzimkkong.exception.member;
 
-import com.woowacourse.zzimkkong.exception.member.MemberException;
 import org.springframework.http.HttpStatus;
 
 public class NoSuchMemberException extends MemberException {

--- a/backend/src/main/java/com/woowacourse/zzimkkong/exception/member/PasswordMismatchException.java
+++ b/backend/src/main/java/com/woowacourse/zzimkkong/exception/member/PasswordMismatchException.java
@@ -1,6 +1,5 @@
 package com.woowacourse.zzimkkong.exception.member;
 
-import com.woowacourse.zzimkkong.exception.member.MemberException;
 import org.springframework.http.HttpStatus;
 
 public class PasswordMismatchException extends MemberException {

--- a/backend/src/main/java/com/woowacourse/zzimkkong/exception/reservation/NoSuchReservationException.java
+++ b/backend/src/main/java/com/woowacourse/zzimkkong/exception/reservation/NoSuchReservationException.java
@@ -1,6 +1,5 @@
 package com.woowacourse.zzimkkong.exception.reservation;
 
-import com.woowacourse.zzimkkong.exception.reservation.ReservationException;
 import org.springframework.http.HttpStatus;
 
 public class NoSuchReservationException extends ReservationException {

--- a/backend/src/main/java/com/woowacourse/zzimkkong/exception/reservation/NonMatchingStartAndEndDateException.java
+++ b/backend/src/main/java/com/woowacourse/zzimkkong/exception/reservation/NonMatchingStartAndEndDateException.java
@@ -1,6 +1,5 @@
 package com.woowacourse.zzimkkong.exception.reservation;
 
-import com.woowacourse.zzimkkong.exception.reservation.ReservationException;
 import org.springframework.http.HttpStatus;
 
 public class NonMatchingStartAndEndDateException extends ReservationException {

--- a/backend/src/main/java/com/woowacourse/zzimkkong/exception/reservation/ReservationPasswordException.java
+++ b/backend/src/main/java/com/woowacourse/zzimkkong/exception/reservation/ReservationPasswordException.java
@@ -1,6 +1,5 @@
 package com.woowacourse.zzimkkong.exception.reservation;
 
-import com.woowacourse.zzimkkong.exception.reservation.ReservationException;
 import org.springframework.http.HttpStatus;
 
 public class ReservationPasswordException extends ReservationException {

--- a/backend/src/main/java/com/woowacourse/zzimkkong/exception/space/NoSuchSpaceException.java
+++ b/backend/src/main/java/com/woowacourse/zzimkkong/exception/space/NoSuchSpaceException.java
@@ -1,6 +1,5 @@
 package com.woowacourse.zzimkkong.exception.space;
 
-import com.woowacourse.zzimkkong.exception.space.SpaceException;
 import org.springframework.http.HttpStatus;
 
 public class NoSuchSpaceException extends SpaceException {

--- a/backend/src/main/java/com/woowacourse/zzimkkong/service/ReservationService.java
+++ b/backend/src/main/java/com/woowacourse/zzimkkong/service/ReservationService.java
@@ -2,7 +2,6 @@ package com.woowacourse.zzimkkong.service;
 
 import com.woowacourse.zzimkkong.domain.Reservation;
 import com.woowacourse.zzimkkong.domain.Space;
-import com.woowacourse.zzimkkong.dto.reservation.ReservationCreateResponse;
 import com.woowacourse.zzimkkong.dto.reservation.*;
 import com.woowacourse.zzimkkong.exception.map.NoSuchMapException;
 import com.woowacourse.zzimkkong.exception.reservation.*;

--- a/backend/src/main/resources/application-local.properties
+++ b/backend/src/main/resources/application-local.properties
@@ -4,7 +4,7 @@ spring.datasource.username=root
 spring.datasource.password=1234
 spring.jpa.properties.hibernate.format_sql=true
 spring.jpa.show-sql=true
-spring.jpa.hibernate.ddl-auto=update
+spring.jpa.hibernate.ddl-auto=create-drop
 # logging
 logging.level.org.springframework.web=info
 logging.level.sql=debug

--- a/backend/src/test/java/com/woowacourse/zzimkkong/controller/ReservationControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/zzimkkong/controller/ReservationControllerTest.java
@@ -151,7 +151,7 @@ public class ReservationControllerTest extends AcceptanceTest {
         assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
     }
 
-    @DisplayName("map id, space id, 특정 날짜가 주어질 때 해당 맵, 해당 공간, 해당 날짜에 속하는 예약들만 찾아온다")
+    @DisplayName("map id, space id, 특정 날짜가 주어질 때 해당 맵, 해당 공간, 해당 날짜에 속하는 예약들만 조회한다.")
     @Test
     void find() {
         //when
@@ -174,7 +174,7 @@ public class ReservationControllerTest extends AcceptanceTest {
                 .isEqualTo(expectedResponse);
     }
 
-    @DisplayName("map id와 특정 날짜가 주어질 때 해당 맵, 해당 날짜의 모든 공간에 대한 예약 조회")
+    @DisplayName("map id와 특정 날짜가 주어질 때 해당 맵, 해당 날짜의 모든 공간에 대한 예약을 조회한다.")
     @Test
     void findAll() {
         //when


### PR DESCRIPTION
## 구현 기능
- 예약자가 맵의 모든 공간에 대한 예약을 조회하면,
  - spaceId 순서대로 먼저 정렬 후,
  - startTime 순서대로 정렬해서 보여준다.
- 예약자가 맵의 특정 공간에 대한 예약을 조회하면 startTime 순서대로 정렬해서 보여준다.

## 논의하고 싶은 내용
- 공간의 정렬기준은 공간 생성 시 자동으로 생성되는 spaceId 즉, `공간 생성순`입니다.
- 예약의 정렬기준은 예약 시작시간 startTime 즉, `예약 빠른순`입니다.

Close #100 
