### PR TITLE
feat: Modal 컴포넌트 구현

### DIFF
--- a/frontend/src/App.styles.ts
+++ b/frontend/src/App.styles.ts
@@ -8,7 +8,7 @@ export const theme: DefaultTheme = {
   black: PALETTE.BLACK,
   gray: PALETTE.GRAY,
   white: PALETTE.WHITE,
-  modalOverlay: PALETTE.MODAL_OVERLAY,
+  modalOverlay: PALETTE.OPACITY_GRAY,
 };
 
 const resetCSS = css`

--- a/frontend/src/App.styles.ts
+++ b/frontend/src/App.styles.ts
@@ -6,8 +6,9 @@ export const theme: DefaultTheme = {
   red: PALETTE.RED,
   green: PALETTE.GREEN,
   black: PALETTE.BLACK,
-  white: PALETTE.WHITE,
   gray: PALETTE.GRAY,
+  white: PALETTE.WHITE,
+  modalOverlay: PALETTE.MODAL_OVERLAY,
 };
 
 const resetCSS = css`

--- a/frontend/src/api/login.ts
+++ b/frontend/src/api/login.ts
@@ -1,3 +1,4 @@
+import { AxiosResponse } from 'axios';
 import api from './api';
 
 interface LoginParams {
@@ -5,6 +6,6 @@ interface LoginParams {
   password: string;
 }
 
-export const postLogin = (loginData: LoginParams) => {
+export const postLogin = (loginData: LoginParams): Promise<AxiosResponse> => {
   return api.post('/login/token', loginData);
 };

--- a/frontend/src/assets/svg/close.svg
+++ b/frontend/src/assets/svg/close.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 0 24 24" width="24px" fill="#000000"><path d="M0 0h24v24H0V0z" fill="none"/><path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12 19 6.41z"/></svg>

--- a/frontend/src/assets/svg/close.svg
+++ b/frontend/src/assets/svg/close.svg
@@ -1,1 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 0 24 24" width="24px" fill="#000000"><path d="M0 0h24v24H0V0z" fill="none"/><path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12 19 6.41z"/></svg>
+<svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 0 24 24" width="24px" fill="#000000">
+<path d="M0 0h24v24H0V0z" fill="none"/>
+<path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12 19 6.41z"/>
+</svg>

--- a/frontend/src/components/Modal/Modal.stories.tsx
+++ b/frontend/src/components/Modal/Modal.stories.tsx
@@ -66,7 +66,6 @@ PasswordInput.args = {
 const Box = styled.div`
   display: flex;
   flex-direction: column;
-  width: 80vw;
 `;
 
 const SelectButton = styled.button`

--- a/frontend/src/components/Modal/Modal.stories.tsx
+++ b/frontend/src/components/Modal/Modal.stories.tsx
@@ -1,0 +1,122 @@
+import { Story } from '@storybook/react';
+import { PropsWithChildren } from 'react';
+import styled from 'styled-components';
+import Input from 'components/Input/Input';
+import Modal, { Props } from './Modal';
+
+export default {
+  title: 'shared/Modal',
+  component: Modal,
+};
+
+const Template: Story<PropsWithChildren<Props>> = (args) => <Modal {...args} />;
+
+export const Default = Template.bind({});
+Default.args = {
+  open: true,
+  children: <h1>Inner에 들어가있지 않은 콘텐츠입니다.(패딩 X)</h1>,
+};
+
+export const Inner = Template.bind({});
+Inner.args = {
+  open: true,
+  children: (
+    <Modal.Inner>
+      <h1>Inner에 들어있는 콘텐츠입니다.(패딩 O)</h1>
+    </Modal.Inner>
+  ),
+};
+
+const Container = styled.div`
+  display: flex;
+  justify-content: space-between;
+`;
+
+const Button = styled.button`
+  border: none;
+  cursor: pointer;
+  margin-left: 1rem;
+  background-color: white;
+
+  &:hover {
+    opacity: 0.7;
+  }
+`;
+
+export const PasswordInput = Template.bind({});
+PasswordInput.args = {
+  open: true,
+  children: (
+    <>
+      <Modal.Header>예약시 사용하신 비밀번호를 입력해주세요.</Modal.Header>
+      <Modal.Inner>
+        <Input type="password" label="비밀번호" minLength={4} maxLength={4} />
+        <Container>
+          <div></div>
+          <div>
+            <Button>취소</Button>
+            <Button>확인</Button>
+          </div>
+        </Container>
+      </Modal.Inner>
+    </>
+  ),
+};
+
+const Box = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: 80vw;
+`;
+
+const SelectButton = styled.button`
+  border: none;
+  cursor: pointer;
+  background-color: white;
+  padding: 1rem 1.5rem;
+  text-align: left;
+  font-size: 1.25rem;
+
+  &:hover {
+    opacity: 0.7;
+  }
+
+  &:first-child {
+    border-bottom: 1px solid rgba(196, 196, 196, 0.3);
+  }
+`;
+
+export const Select = Template.bind({});
+Select.args = {
+  open: true,
+  children: (
+    <>
+      <Box>
+        <SelectButton>🛠 수정하기</SelectButton>
+        <SelectButton>🗑 삭제하기</SelectButton>
+      </Box>
+    </>
+  ),
+};
+
+export const CloseButton = Template.bind({});
+CloseButton.args = {
+  open: true,
+  showCloseButton: true,
+  children: (
+    <>
+      <Modal.Header>Ipsum Lorem</Modal.Header>
+      <Modal.Inner>
+        <p>
+          Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has
+          been the industry's standard dummy text ever since the 1500s, when an unknown printer took
+          a galley of type and scrambled it to make a type specimen book. It has survived not only
+          five centuries, but also the leap into electronic typesetting, remaining essentially
+          unchanged. It was popularised in the 1960s with the release of Letraset sheets containing
+          Lorem Ipsum passages, and more recently with desktop publishing software like Aldus
+          PageMaker including versions of Lorem Ipsum.
+        </p>
+      </Modal.Inner>
+    </>
+  ),
+};

--- a/frontend/src/components/Modal/Modal.styles.ts
+++ b/frontend/src/components/Modal/Modal.styles.ts
@@ -6,6 +6,9 @@ interface Props {
 
 export const Overlay = styled.div<Props>`
   display: ${({ open }) => (open ? 'flex' : 'none')};
+  position: fixed;
+  top: 0;
+  left: 0;
   width: 100vw;
   height: 100vh;
   justify-content: center;

--- a/frontend/src/components/Modal/Modal.styles.ts
+++ b/frontend/src/components/Modal/Modal.styles.ts
@@ -6,7 +6,7 @@ interface Props {
 
 export const Overlay = styled.div<Props>`
   display: ${({ open }) => (open ? 'flex' : 'none')};
-  width: 100%;
+  width: 100vw;
   height: 100vh;
   justify-content: center;
   align-items: center;
@@ -14,7 +14,9 @@ export const Overlay = styled.div<Props>`
 `;
 
 export const Modal = styled.div`
-  width: 90%;
+  width: 80%;
+  min-width: 320px;
+  max-width: 768px;
   position: relative;
   background-color: ${({ theme }) => theme.white};
 `;

--- a/frontend/src/components/Modal/Modal.styles.ts
+++ b/frontend/src/components/Modal/Modal.styles.ts
@@ -24,12 +24,15 @@ export const Modal = styled.div`
   background-color: ${({ theme }) => theme.white};
 `;
 
-export const CloseButton = styled.div`
+export const CloseButton = styled.button`
   position: absolute;
+  padding: 0.5rem;
   top: 0.5rem;
-  right: 1rem;
+  right: 1.5rem;
   width: 1rem;
   cursor: pointer;
+  border: none;
+  background: none;
 
   &:hover {
     opacity: 0.7;

--- a/frontend/src/components/Modal/Modal.styles.ts
+++ b/frontend/src/components/Modal/Modal.styles.ts
@@ -32,13 +32,12 @@ export const CloseButton = styled.div`
 `;
 
 export const Inner = styled.div`
-  padding: 1rem;
+  padding: 0.5rem 1rem;
 `;
 
 export const Header = styled.h1`
   font-weight: 700;
-  padding: 1.125rem;
-  border-bottom: 1px solid ${({ theme }) => theme.gray[400]};
+  padding: 1rem;
 `;
 
 export const Content = styled.div``;

--- a/frontend/src/components/Modal/Modal.styles.ts
+++ b/frontend/src/components/Modal/Modal.styles.ts
@@ -1,0 +1,44 @@
+import styled from 'styled-components';
+
+interface Props {
+  open?: boolean;
+}
+
+export const Overlay = styled.div<Props>`
+  display: ${({ open }) => (open ? 'flex' : 'none')};
+  width: 100%;
+  height: 100vh;
+  justify-content: center;
+  align-items: center;
+  background-color: ${({ theme }) => theme.modalOverlay};
+`;
+
+export const Modal = styled.div`
+  width: 90%;
+  position: relative;
+  background-color: ${({ theme }) => theme.white};
+`;
+
+export const CloseButton = styled.div`
+  position: absolute;
+  top: 0.5rem;
+  right: 1rem;
+  width: 1rem;
+  cursor: pointer;
+
+  &:hover {
+    opacity: 0.7;
+  }
+`;
+
+export const Inner = styled.div`
+  padding: 1rem;
+`;
+
+export const Header = styled.h1`
+  font-weight: 700;
+  padding: 1.125rem;
+  border-bottom: 1px solid ${({ theme }) => theme.gray[400]};
+`;
+
+export const Content = styled.div``;

--- a/frontend/src/components/Modal/Modal.styles.ts
+++ b/frontend/src/components/Modal/Modal.styles.ts
@@ -9,8 +9,8 @@ export const Overlay = styled.div<Props>`
   position: fixed;
   top: 0;
   left: 0;
-  width: 100vw;
-  height: 100vh;
+  right: 0;
+  bottom: 0;
   justify-content: center;
   align-items: center;
   background-color: ${({ theme }) => theme.modalOverlay};

--- a/frontend/src/components/Modal/Modal.tsx
+++ b/frontend/src/components/Modal/Modal.tsx
@@ -25,7 +25,7 @@ const Modal = ({
   };
 
   return (
-    <Styled.Overlay id="modal-overlay" open={open} onClick={handleDimmedClick}>
+    <Styled.Overlay open={open} onClick={handleDimmedClick}>
       <Styled.Modal>
         {showCloseButton && (
           <Styled.CloseButton onClick={handleClose}>

--- a/frontend/src/components/Modal/Modal.tsx
+++ b/frontend/src/components/Modal/Modal.tsx
@@ -4,18 +4,18 @@ import * as Styled from './Modal.styles';
 
 export interface Props {
   open?: boolean;
-  dimmed?: boolean;
+  isClosableDimmer?: boolean;
   showCloseButton?: boolean;
 }
 
 const Modal = ({
   open,
-  dimmed,
+  isClosableDimmer,
   showCloseButton,
   children,
 }: PropsWithChildren<Props>): JSX.Element => {
   const handleDimmedClick: MouseEventHandler<HTMLDivElement> = ({ target, currentTarget }) => {
-    if (dimmed && target === currentTarget) {
+    if (isClosableDimmer && target === currentTarget) {
       open = false;
     }
   };

--- a/frontend/src/components/Modal/Modal.tsx
+++ b/frontend/src/components/Modal/Modal.tsx
@@ -1,0 +1,45 @@
+import { MouseEventHandler, PropsWithChildren } from 'react';
+import { ReactComponent as CloseIcon } from 'assets/svg/close.svg';
+import * as Styled from './Modal.styles';
+
+export interface Props {
+  open?: boolean;
+  dimmed?: boolean;
+  showCloseButton?: boolean;
+}
+
+const Modal = ({
+  open,
+  dimmed,
+  showCloseButton,
+  children,
+}: PropsWithChildren<Props>): JSX.Element => {
+  const handleDimmedClick: MouseEventHandler<HTMLDivElement> = ({ target, currentTarget }) => {
+    if (dimmed && target === currentTarget) {
+      open = false;
+    }
+  };
+
+  const handleClose = () => {
+    open = false;
+  };
+
+  return (
+    <Styled.Overlay id="modal-overlay" open={open} onClick={handleDimmedClick}>
+      <Styled.Modal>
+        {showCloseButton && (
+          <Styled.CloseButton onClick={handleClose}>
+            <CloseIcon />
+          </Styled.CloseButton>
+        )}
+        {children}
+      </Styled.Modal>
+    </Styled.Overlay>
+  );
+};
+
+Modal.Inner = Styled.Inner;
+Modal.Header = Styled.Header;
+Modal.Content = Styled.Content;
+
+export default Modal;

--- a/frontend/src/constants/palette.ts
+++ b/frontend/src/constants/palette.ts
@@ -58,6 +58,7 @@ const PALETTE = {
   },
 
   WHITE: '#fff',
+  MODAL_OVERLAY: 'rgba(196, 196, 196, 0.3)',
 };
 
 export default PALETTE;

--- a/frontend/src/constants/palette.ts
+++ b/frontend/src/constants/palette.ts
@@ -57,8 +57,8 @@ const PALETTE = {
     900: '#18181B',
   },
 
+  OPACITY_GRAY: 'rgba(212, 212, 216, 0.3)',
   WHITE: '#fff',
-  MODAL_OVERLAY: 'rgba(196, 196, 196, 0.3)',
 };
 
 export default PALETTE;

--- a/frontend/src/types/styled.d.ts
+++ b/frontend/src/types/styled.d.ts
@@ -23,5 +23,6 @@ declare module 'styled-components' {
     black: Palette;
     gray: Palette;
     white: Color;
+    modalOverlay: Color;
   }
 }

--- a/frontend/src/utils/datetime.ts
+++ b/frontend/src/utils/datetime.ts
@@ -1,5 +1,5 @@
 // Note: YYYY-MM-DD 형식으로 변환함
-export const formatDate = (date: Date) => {
+export const formatDate = (date: Date): string => {
   const year = date.getFullYear();
   const month = `${date.getMonth() + 1}`.padStart(2, '0');
   const day = `${date.getDate()}`.padStart(2, '0');


### PR DESCRIPTION
## 구현 기능

- [x] 범용적으로 사용가능한 `Modal` 컴포넌트 구현
- [x] Storybook에 수정/삭제 `Modal` 작성
- [x] Storybook에 비밀번호 입력 `Modal` 작성

## 논의하고 싶은 부분

- 현재 `hover`시 opacity를 줄이는 방법으로 Style을 줬는데 `hover`시 나타내는 방법을 통일하면 좋을거 같습니다.

![Jul-14-2021 18-16-47](https://user-images.githubusercontent.com/61097373/125597306-094d6c5a-85fd-4bda-bccc-d2839d0bb4f9.gif)
 
![Jul-14-2021 18-17-04](https://user-images.githubusercontent.com/61097373/125597312-ba3df682-f660-4938-9609-190d4321e759.gif)


## 기타

### props

| prop            | Type      | Description                                                  |
| --------------- | --------- | ------------------------------------------------------------ |
| `open`          | boolean   | true: Modal이 열림.<br />false: Modal이 닫힘.                |
| dimmed          | boolean   | true: dimmed영역 클릭시 Modal이 닫힌다.<br />false: dimmed영역 클릭시 Modal이 닫히지 않는다. |
| showCloseButton | boolean   | true: close button이 보인다.<br />false: close button이 보이지 않는다. |
| children        | ReactNode | Children                                                     |

### UI
- 수정/삭제 Modal
<img width="377" alt="스크린샷 2021-07-14 오후 5 52 46" src="https://user-images.githubusercontent.com/61097373/125596636-f10c6f50-c048-45a5-a4c8-af68c225b20b.png">

- 비밀번호 입력 Modal
<img width="380" alt="스크린샷 2021-07-14 오후 5 52 41" src="https://user-images.githubusercontent.com/61097373/125596664-3ff7c740-5395-43d2-8042-dc7032acbb91.png">


- CloseButton Modal
<img width="357" alt="스크린샷 2021-07-14 오후 5 52 58" src="https://user-images.githubusercontent.com/61097373/125596682-6912ef7d-265a-4af1-bb57-eb903719d08b.png">



Close #95

