### PR TITLE
feat: 예약자가 공간을 예약할 수 있는 기능 구현 및 API 연동

### DIFF
--- a/frontend/src/api/reservation.ts
+++ b/frontend/src/api/reservation.ts
@@ -1,0 +1,38 @@
+import { AxiosResponse } from 'axios';
+import { QueryFunction, QueryKey } from 'react-query';
+import { QueryReservationsSuccess } from 'types/response';
+import api from './api';
+
+export interface QueryReservationsParams {
+  mapId: number;
+  spaceId: number;
+  date: string;
+}
+
+interface PostReservationParams {
+  reservation: {
+    spaceId: number;
+    startDateTime: Date;
+    endDateTime: Date;
+    password: string;
+    name: string;
+    description: string;
+  };
+  mapId: number;
+}
+
+export const queryReservations: QueryFunction<
+  AxiosResponse<QueryReservationsSuccess>,
+  [QueryKey, QueryReservationsParams]
+> = ({ queryKey }) => {
+  const [, data] = queryKey;
+  const { mapId, spaceId, date } = data;
+
+  return api.get(`/maps/${mapId}/spaces/${spaceId}/reservations?date=${date}`);
+};
+
+export const postReservation = ({
+  reservation,
+  mapId,
+}: PostReservationParams): Promise<AxiosResponse<never>> =>
+  api.post(`/maps/${mapId}/reservations`, reservation);

--- a/frontend/src/components/Input/Input.styles.ts
+++ b/frontend/src/components/Input/Input.styles.ts
@@ -1,9 +1,17 @@
 import { ReactNode } from 'react';
 import styled, { css } from 'styled-components';
 
-interface Props {
-  icon?: ReactNode;
-  status?: 'success' | 'error' | 'default';
+interface LabelProps {
+  hasMessage: boolean;
+  hasLabel: boolean;
+}
+
+interface InputProps {
+  icon: ReactNode;
+}
+
+interface MessageProps {
+  status: 'success' | 'error' | 'default';
 }
 
 const statusCSS = {
@@ -18,11 +26,11 @@ const statusCSS = {
   `,
 };
 
-export const Label = styled.label`
+export const Label = styled.label<LabelProps>`
   display: block;
   position: relative;
-  margin-top: 0.5rem;
-  margin-bottom: 1.625rem;
+  margin-top: ${({ hasLabel }) => (hasLabel ? '0.5rem' : '0')};
+  margin-bottom: ${({ hasMessage }) => (hasMessage ? '1.625rem' : '0')};
 `;
 
 export const LabelText = styled.span`
@@ -45,7 +53,7 @@ export const Icon = styled.div`
   padding: 0.75rem 0.5rem;
 `;
 
-export const Input = styled.input<Props>`
+export const Input = styled.input<InputProps>`
   padding: 0.75rem;
   width: 100%;
   font-size: 1.25rem;
@@ -58,13 +66,9 @@ export const Input = styled.input<Props>`
     border-color: ${({ theme }) => theme.primary[400]};
     box-shadow: inset 0px 0px 0px 1px ${({ theme }) => theme.primary[400]};
   }
-
-  &::-webkit-calendar-picker-indicator {
-    display: none;
-  }
 `;
 
-export const Message = styled.p<Props>`
+export const Message = styled.p<MessageProps>`
   ${({ status = 'default' }) => statusCSS[status]};
   font-size: 0.75rem;
   position: absolute;

--- a/frontend/src/components/Input/Input.tsx
+++ b/frontend/src/components/Input/Input.tsx
@@ -8,13 +8,17 @@ export interface Props extends InputHTMLAttributes<HTMLInputElement> {
   message?: string;
 }
 
-const Input = ({ icon, label, status = 'default', message, ...props }: Props): JSX.Element => (
-  <Styled.Label>
-    {label && <Styled.LabelText>{label}</Styled.LabelText>}
-    {icon && <Styled.Icon>{icon}</Styled.Icon>}
-    <Styled.Input icon={icon} {...props} />
-    <Styled.Message status={status}>{message}</Styled.Message>
-  </Styled.Label>
-);
+const Input = ({ icon, label, status = 'default', message, ...props }: Props): JSX.Element => {
+  const hasMessage = message !== undefined && message !== null;
+
+  return (
+    <Styled.Label hasMessage={hasMessage} hasLabel={!!label}>
+      {label && <Styled.LabelText>{label}</Styled.LabelText>}
+      {icon && <Styled.Icon>{icon}</Styled.Icon>}
+      <Styled.Input icon={icon} {...props} />
+      {hasMessage && <Styled.Message status={status}>{message}</Styled.Message>}
+    </Styled.Label>
+  );
+};
 
 export default Input;

--- a/frontend/src/components/ReservationListItem/ReservationListItem.stories.tsx
+++ b/frontend/src/components/ReservationListItem/ReservationListItem.stories.tsx
@@ -13,20 +13,22 @@ const Template: Story<Props> = (args) => <ReservationListItem {...args} />;
 export const Default = Template.bind({});
 Default.args = {
   reservation: {
+    id: 1,
     name: '체프',
     description: '맛있는 커피를 내리는 법',
-    startDateTime: new Date('2021-07-09T20:00:00'),
-    endDateTime: new Date('2021-07-09T21:00:00'),
+    startDateTime: '2021-07-09T20:00:00',
+    endDateTime: '2021-07-09T21:00:00',
   },
 };
 
 export const Control = Template.bind({});
 Control.args = {
   reservation: {
+    id: 2,
     name: '체프',
     description: '맛있는 커피를 내리는 법',
-    startDateTime: new Date('2021-07-09T20:00:00'),
-    endDateTime: new Date('2021-07-09T21:00:00'),
+    startDateTime: '2021-07-09T20:00:00',
+    endDateTime: '2021-07-09T21:00:00',
   },
   control: (
     <>

--- a/frontend/src/components/ReservationListItem/ReservationListItem.tsx
+++ b/frontend/src/components/ReservationListItem/ReservationListItem.tsx
@@ -1,22 +1,18 @@
 import { ReactNode } from 'react';
+import { Reservation } from 'types/common';
 import { formatTime } from 'utils/datetime';
 import * as Styled from './ReservationListItem.styles';
 
 export interface Props {
-  reservation: {
-    name: string;
-    description: string;
-    startDateTime: Date;
-    endDateTime: Date;
-  };
+  reservation: Reservation;
   control?: ReactNode;
 }
 
 const ReservationListItem = ({ reservation, control }: Props): JSX.Element => {
   const { name, description, startDateTime, endDateTime } = reservation;
 
-  const start = formatTime(startDateTime);
-  const end = formatTime(endDateTime);
+  const start = formatTime(new Date(startDateTime));
+  const end = formatTime(new Date(endDateTime));
 
   return (
     <Styled.Item role="listitem">

--- a/frontend/src/constants/message.ts
+++ b/frontend/src/constants/message.ts
@@ -12,6 +12,9 @@ const MESSAGE = {
   LOGIN: {
     UNEXPECTED_ERROR: '로그인에 문제가 발생했습니다. 잠시 후에 다시 시도해주세요.',
   },
+  RESERVATION: {
+    UNEXPECTED_ERROR: '예약하는 중에 문제가 발생했습니다. 잠시 후에 다시 시도해주세요.',
+  },
 };
 
 export default MESSAGE;

--- a/frontend/src/constants/regexp.ts
+++ b/frontend/src/constants/regexp.ts
@@ -1,5 +1,6 @@
 const REGEXP = {
   PASSWORD: /^(?=.*[a-zA-Z])(?=.*[0-9]).{8,20}$/,
+  RESERVATION_PASSWORD: /^[0-9]{4}$/,
 };
 
 export default REGEXP;

--- a/frontend/src/hooks/useReservations.ts
+++ b/frontend/src/hooks/useReservations.ts
@@ -1,0 +1,17 @@
+import { AxiosError, AxiosResponse } from 'axios';
+import { QueryKey, useQuery, UseQueryOptions, UseQueryResult } from 'react-query';
+import { queryReservations, QueryReservationsParams } from 'api/reservation';
+import { QueryReservationsSuccess } from 'types/response';
+
+const useReservations = <TData = AxiosResponse<QueryReservationsSuccess>>(
+  { mapId, spaceId, date }: QueryReservationsParams,
+  options?: UseQueryOptions<
+    AxiosResponse<QueryReservationsSuccess>,
+    AxiosError<Error>,
+    TData,
+    [QueryKey, QueryReservationsParams]
+  >
+): UseQueryResult<TData, AxiosError<Error>> =>
+  useQuery(['getReservations', { mapId, spaceId, date }], queryReservations, options);
+
+export default useReservations;

--- a/frontend/src/pages/UserReservation/UserReservation.styles.ts
+++ b/frontend/src/pages/UserReservation/UserReservation.styles.ts
@@ -15,8 +15,10 @@ export const PageHeader = styled.h2`
 `;
 
 export const InputWrapper = styled.div`
+  position: relative;
   display: flex;
   gap: 1rem;
+  margin: 1.625rem 0;
 
   label {
     flex: 1;
@@ -37,7 +39,19 @@ export const ReservationList = styled.div`
 
 export const ButtonWrapper = styled.div`
   position: fixed;
-  width: 100%;
   bottom: 0;
   left: 0;
+  width: 100vw;
 `;
+
+export const TimeFormMessage = styled.p`
+  position: absolute;
+  left: 0.75rem;
+  bottom: -1.5rem;
+  height: 1.5rem;
+  line-height: 1.5rem;
+  font-size: 0.75rem;
+  color: ${({ theme }) => theme.red[500]};
+`;
+
+export const Message = styled.p``;

--- a/frontend/src/pages/UserReservation/UserReservation.tsx
+++ b/frontend/src/pages/UserReservation/UserReservation.tsx
@@ -125,7 +125,7 @@ const UserReservation = (): JSX.Element => {
             </Styled.InputWrapper>
           </Styled.Section>
           <Styled.Section>
-            <Styled.PageHeader>오늘의 예약 목록</Styled.PageHeader>
+            <Styled.PageHeader>{date}의 예약 목록</Styled.PageHeader>
             {getReservations.isLoading && <Styled.Message>불러오는 중입니다...</Styled.Message>}
             {getReservations.isFetched && reservations.length === 0 && (
               <Styled.Message>오늘의 첫 예약을 잡아보세요!</Styled.Message>

--- a/frontend/src/pages/UserReservation/UserReservation.tsx
+++ b/frontend/src/pages/UserReservation/UserReservation.tsx
@@ -1,27 +1,78 @@
+import { AxiosError } from 'axios';
+import { FormEventHandler } from 'react';
+import { useMutation } from 'react-query';
+import { useHistory } from 'react-router-dom';
+import { postReservation } from 'api/reservation';
 import { ReactComponent as CalendarIcon } from 'assets/svg/calendar.svg';
 import Button from 'components/Button/Button';
 import Header from 'components/Header/Header';
 import Input from 'components/Input/Input';
 import Layout from 'components/Layout/Layout';
 import ReservationListItem from 'components/ReservationListItem/ReservationListItem';
+import MESSAGE from 'constants/message';
+import REGEXP from 'constants/regexp';
 import useInput from 'hooks/useInput';
+import useReservations from 'hooks/useReservations';
 import { formatDate, formatTime } from 'utils/datetime';
 import * as Styled from './UserReservation.styles';
 
 const UserReservation = (): JSX.Element => {
+  // Note: 1번 맵의 1번 공간에 대해서만 예약되도록 임시 구현
+  const mapId = 1;
+  const spaceId = 1;
+  const spaceName = '회의실 1';
+  const now = new Date();
+
+  const history = useHistory();
+
   const [name, onChangeName] = useInput('');
   const [description, onChangeDescription] = useInput('');
-  const [date, onChangeDate] = useInput(formatDate(new Date()));
-  const [startTime, onChangeStartTime] = useInput(formatTime(new Date()));
-  const [endTime, onChangeEndTime] = useInput(formatTime(new Date()));
+  const [date, onChangeDate] = useInput(formatDate(now));
+  const [startTime, onChangeStartTime] = useInput(formatTime(now));
+  const [endTime, onChangeEndTime] = useInput(formatTime(new Date(now.getTime() + 1000 * 60 * 60)));
+  const [password, onChangePassword] = useInput('');
+
+  const getReservations = useReservations({ mapId, spaceId, date });
+
+  const reservations = getReservations.data?.data?.reservations ?? [];
+
+  const createReservation = useMutation(postReservation, {
+    onSuccess: () => {
+      history.push('/');
+    },
+    onError: (error: AxiosError<Error>) => {
+      alert(error.response?.data.message ?? MESSAGE.RESERVATION.UNEXPECTED_ERROR);
+    },
+  });
+
+  const handleSubmit: FormEventHandler<HTMLFormElement> = (event) => {
+    event.preventDefault();
+
+    if (createReservation.isLoading) return;
+
+    const startDateTime = new Date(`${date}T${startTime}Z`);
+    const endDateTime = new Date(`${date}T${endTime}Z`);
+
+    const mapId = 1;
+    const reservation = {
+      spaceId: 1,
+      name,
+      description,
+      password,
+      startDateTime,
+      endDateTime,
+    };
+
+    createReservation.mutate({ reservation, mapId });
+  };
 
   return (
     <>
       <Header />
       <Layout>
-        <Styled.ReservationForm>
+        <Styled.ReservationForm onSubmit={handleSubmit}>
           <Styled.Section>
-            <Styled.PageHeader>회의실 1</Styled.PageHeader>
+            <Styled.PageHeader>{spaceName}</Styled.PageHeader>
             <Styled.InputWrapper>
               <Input label="이름" value={name} onChange={onChangeName} autoFocus required />
             </Styled.InputWrapper>
@@ -39,6 +90,7 @@ const UserReservation = (): JSX.Element => {
                 label="날짜"
                 icon={<CalendarIcon />}
                 value={date}
+                min={formatDate(now)}
                 onChange={onChangeDate}
                 required
               />
@@ -55,40 +107,38 @@ const UserReservation = (): JSX.Element => {
                 type="time"
                 label="종료 시간"
                 value={endTime}
+                min={startTime}
                 onChange={onChangeEndTime}
+                required
+              />
+            </Styled.InputWrapper>
+            <Styled.InputWrapper>
+              <Input
+                type="password"
+                label="비밀번호"
+                value={password}
+                onChange={onChangePassword}
+                pattern={REGEXP.RESERVATION_PASSWORD.source}
+                message="숫자 4자리를 입력해주세요."
                 required
               />
             </Styled.InputWrapper>
           </Styled.Section>
           <Styled.Section>
-            <Styled.PageHeader>기존 예약 목록</Styled.PageHeader>
-            <Styled.ReservationList role="list">
-              <ReservationListItem
-                reservation={{
-                  name: '체프',
-                  description: '맛있는 커피를 내리는 법',
-                  startDateTime: new Date('2021-07-12T18:00:00'),
-                  endDateTime: new Date('2021-07-12T19:00:00'),
-                }}
-              />
-              <ReservationListItem
-                reservation={{
-                  name: '썬',
-                  description: '도예 원데이 클래스',
-                  startDateTime: new Date('2021-07-12T19:00:00'),
-                  endDateTime: new Date('2021-07-12T20:00:00'),
-                }}
-              />
-              <ReservationListItem
-                reservation={{
-                  name: '체프',
-                  description: '맛있는 커피를 내리는 법',
-                  startDateTime: new Date('2021-07-12T18:00:00'),
-                  endDateTime: new Date('2021-07-12T19:00:00'),
-                }}
-              />
-            </Styled.ReservationList>
+            <Styled.PageHeader>오늘의 예약 목록</Styled.PageHeader>
+            {getReservations.isLoading && <Styled.Message>불러오는 중입니다...</Styled.Message>}
+            {getReservations.isFetched && reservations.length === 0 && (
+              <Styled.Message>오늘의 첫 예약을 잡아보세요!</Styled.Message>
+            )}
+            {getReservations.isFetched && reservations.length > 0 && (
+              <Styled.ReservationList role="list">
+                {reservations?.map((reservation) => (
+                  <ReservationListItem key={reservation.id} reservation={reservation} />
+                ))}
+              </Styled.ReservationList>
+            )}
           </Styled.Section>
+
           <Styled.ButtonWrapper>
             <Button fullWidth variant="primary" size="large">
               예약하기

--- a/frontend/src/types/common.ts
+++ b/frontend/src/types/common.ts
@@ -1,0 +1,7 @@
+export interface Reservation {
+  id: number;
+  startDateTime: string;
+  endDateTime: string;
+  name: string;
+  description: string;
+}

--- a/frontend/src/types/response.ts
+++ b/frontend/src/types/response.ts
@@ -1,3 +1,9 @@
+import { Reservation } from './common';
+
 export interface LoginSuccess {
   accessToken: string;
+}
+
+export interface QueryReservationsSuccess {
+  reservations: Reservation[];
 }


### PR DESCRIPTION
## 구현 기능
- 예약자가 공간을 예약할 수 있는 기능 및 API 연동
![zk3](https://user-images.githubusercontent.com/2542730/125612505-ec86378c-316e-4376-b07d-49a512a01e28.gif)
- `Input` 컴포넌트의 `message` prop이 nullish일 때, 메시지 영역만큼의 여백이 생기지 않도록 수정

## 공유하고 싶은 내용
- `mapId`가 1이고 `spaceId`가 1인 경우에 한정하여 예약이 가능하도록 기능을 구현했습니다. 추후 공간을 선택하는 페이지가 구현되었을 때, 별도의 PR에서 추가 수정할 예정입니다.

Close #27
Close #99 
