### PR TITLE
feat: 맵(Map)에 대한 예약 조회시 공간(Space)의 이름도 같이 응답 

### DIFF
--- a/backend/src/main/java/com/woowacourse/zzimkkong/controller/ReservationController.java
+++ b/backend/src/main/java/com/woowacourse/zzimkkong/controller/ReservationController.java
@@ -31,21 +31,21 @@ public class ReservationController {
                 .build();
     }
 
-    @GetMapping("/spaces/{spaceId}/reservations")
-    public ResponseEntity<ReservationFindResponse> find(
-            @PathVariable Long mapId,
-            @PathVariable Long spaceId,
-            @RequestParam @DateTimeFormat(pattern = DATE_FORMAT) LocalDate date) {
-        ReservationFindResponse reservationFindResponse = reservationService.findReservations(mapId, spaceId, date);
-        return ResponseEntity.ok().body(reservationFindResponse);
-    }
-
     @GetMapping("/reservations")
     public ResponseEntity<ReservationFindAllResponse> findAll(
             @PathVariable Long mapId,
             @RequestParam @DateTimeFormat(pattern = DATE_FORMAT) LocalDate date) {
         ReservationFindAllResponse reservationFindAllResponse = reservationService.findAllReservations(mapId, date);
         return ResponseEntity.ok().body(reservationFindAllResponse);
+    }
+
+    @PutMapping("/reservations/{reservationId}")
+    public ResponseEntity<Void> update(
+            @PathVariable Long mapId,
+            @PathVariable Long reservationId,
+            @RequestBody @Valid ReservationCreateUpdateRequest reservationCreateUpdateRequest) {
+        reservationService.updateReservation(mapId, reservationId, reservationCreateUpdateRequest);
+        return ResponseEntity.ok().build();
     }
 
     @DeleteMapping("/reservations/{reservationId}")
@@ -57,6 +57,15 @@ public class ReservationController {
         return ResponseEntity.noContent().build();
     }
 
+    @GetMapping("/spaces/{spaceId}/reservations")
+    public ResponseEntity<ReservationFindResponse> find(
+            @PathVariable Long mapId,
+            @PathVariable Long spaceId,
+            @RequestParam @DateTimeFormat(pattern = DATE_FORMAT) LocalDate date) {
+        ReservationFindResponse reservationFindResponse = reservationService.findReservations(mapId, spaceId, date);
+        return ResponseEntity.ok().body(reservationFindResponse);
+    }
+
     @PostMapping("/reservations/{reservationId}")
     public ResponseEntity<ReservationResponse> findOne(
             @PathVariable Long mapId,
@@ -64,14 +73,5 @@ public class ReservationController {
             @RequestBody @Valid ReservationPasswordAuthenticationRequest reservationPasswordAuthenticationRequest) {
         ReservationResponse reservationResponse = reservationService.findReservation(mapId, reservationId, reservationPasswordAuthenticationRequest);
         return ResponseEntity.ok().body(reservationResponse);
-    }
-
-    @PutMapping("/reservations/{reservationId}")
-    public ResponseEntity<Void> update(
-            @PathVariable Long mapId,
-            @PathVariable Long reservationId,
-            @RequestBody @Valid ReservationCreateUpdateRequest reservationCreateUpdateRequest) {
-        reservationService.updateReservation(mapId, reservationId, reservationCreateUpdateRequest);
-        return ResponseEntity.ok().build();
     }
 }

--- a/backend/src/main/java/com/woowacourse/zzimkkong/domain/Space.java
+++ b/backend/src/main/java/com/woowacourse/zzimkkong/domain/Space.java
@@ -24,6 +24,10 @@ public class Space {
     }
 
     public Long getId() {
-        return id;
+        return this.id;
+    }
+
+    public String getName() {
+        return this.name;
     }
 }

--- a/backend/src/main/java/com/woowacourse/zzimkkong/dto/reservation/ReservationSpaceResponse.java
+++ b/backend/src/main/java/com/woowacourse/zzimkkong/dto/reservation/ReservationSpaceResponse.java
@@ -11,14 +11,19 @@ import java.util.stream.Collectors;
 public class ReservationSpaceResponse {
     @JsonProperty
     private Long spaceId;
+
+    @JsonProperty
+    private String spaceName;
+
     @JsonProperty
     private List<ReservationResponse> reservations;
 
     public ReservationSpaceResponse() {
     }
 
-    private ReservationSpaceResponse(final Long spaceId, final List<ReservationResponse> reservations) {
+    private ReservationSpaceResponse(final Long spaceId, final String spaceName, final List<ReservationResponse> reservations) {
         this.spaceId = spaceId;
+        this.spaceName = spaceName;
         this.reservations = reservations;
     }
 
@@ -28,7 +33,7 @@ public class ReservationSpaceResponse {
                 .map(ReservationResponse::of)
                 .collect(Collectors.toList());
 
-        return new ReservationSpaceResponse(reservationsPerSpace.getKey().getId(), reservations);
+        return new ReservationSpaceResponse(reservationsPerSpace.getKey().getId(), reservationsPerSpace.getKey().getName(), reservations);
     }
 
     public Long getSpaceId() {

--- a/backend/src/main/java/com/woowacourse/zzimkkong/dto/reservation/ReservationSpaceResponse.java
+++ b/backend/src/main/java/com/woowacourse/zzimkkong/dto/reservation/ReservationSpaceResponse.java
@@ -33,7 +33,8 @@ public class ReservationSpaceResponse {
                 .map(ReservationResponse::of)
                 .collect(Collectors.toList());
 
-        return new ReservationSpaceResponse(reservationsPerSpace.getKey().getId(), reservationsPerSpace.getKey().getName(), reservations);
+        Space space = reservationsPerSpace.getKey();
+        return new ReservationSpaceResponse(space.getId(), space.getName(), reservations);
     }
 
     public Long getSpaceId() {


### PR DESCRIPTION
## 구현 기능
- 특정 맵에 대한 전체 예약을 조회할 때 공간별로 분류되어 예약이 조회되는데, 이 때 공간의 Id값만 응답되고 있었습니다.
- 이 때 공간의 이름도 같이 제공합니다.

## 논의하고 싶은 내용
- ReservatonController 메소드의 순서가 헷갈려 다시 정렬해보았습니다. 문제가 없을까 싶습니다~

Close #109
