### PR TITLE
feat: Button 컴포넌트가 disabled 됐을 때 색을 변경하는 기능

### DIFF
--- a/frontend/src/components/Button/Button.stories.tsx
+++ b/frontend/src/components/Button/Button.stories.tsx
@@ -10,36 +10,42 @@ const Template: Story<Props> = (args) => <Button {...args} />;
 
 export const Default = Template.bind({});
 Default.args = {
+  disabled: false,
   variant: 'default',
   children: 'Button Test',
 };
 
 export const Primary = Template.bind({});
 Primary.args = {
+  disabled: false,
   variant: 'primary',
   children: 'Button Test',
 };
 
 export const Small = Template.bind({});
 Small.args = {
+  disabled: false,
   size: 'small',
   children: 'Button Test',
 };
 
 export const Medium = Template.bind({});
 Medium.args = {
+  disabled: false,
   size: 'medium',
   children: 'Button Test',
 };
 
 export const Large = Template.bind({});
 Large.args = {
+  disabled: false,
   size: 'large',
   children: 'Button Test',
 };
 
 export const FullWidth = Template.bind({});
 FullWidth.args = {
+  disabled: false,
   fullWidth: true,
   children: 'Button Test',
 };

--- a/frontend/src/components/Button/Button.styles.ts
+++ b/frontend/src/components/Button/Button.styles.ts
@@ -11,10 +11,19 @@ const variantCSS = {
     background: ${({ theme }) => theme.primary[400]};
     color: ${({ theme }) => theme.white};
     border: none;
+
+    &:disabled {
+      background: ${({ theme }) => theme.primary[100]};
+    }
   `,
   default: css`
     background: ${({ theme }) => theme.white};
     border: 1px solid ${({ theme }) => theme.black[400]};
+
+    &:disabled {
+      color: ${({ theme }) => theme.gray[400]};
+      border: 1px solid ${({ theme }) => theme.gray[400]};
+    }
   `,
 };
 


### PR DESCRIPTION
## 구현 기능
- [x] Button 컴포넌트가 disabled 됐을 시 배경색 변경을 통해 disabled상태인 것을 사용자가 알 수 있게 한다.

## 공유하고 싶은 내용
### Primary Button 
- background - primary[400] -> primary[100]
    
![400- 100-primary](https://user-images.githubusercontent.com/61097373/125724325-80e92c75-1b77-4cd3-819c-64faa1f541b5.gif)
---
### Default Button 
- text: black[400] -> gray[400]
- border: black[400] -> gray[400]
    
![400](https://user-images.githubusercontent.com/61097373/125724402-c08ca96b-ddea-4207-8228-32476038c70e.gif)



Close #108 

