### PR TITLE
feat: 토큰 유효성 검증 API를 구현한다.

### DIFF
--- a/backend/src/docs/asciidoc/member.adoc
+++ b/backend/src/docs/asciidoc/member.adoc
@@ -18,3 +18,8 @@ include::{snippets}/member/login/http-request.adoc[]
 ==== Response
 include::{snippets}/member/login/http-response.adoc[]
 
+=== 토큰 유효성 검증
+==== Request
+include::{snippets}/member/token/http-request.adoc[]
+==== Response
+include::{snippets}/member/token/http-response.adoc[]

--- a/backend/src/docs/asciidoc/member.adoc
+++ b/backend/src/docs/asciidoc/member.adoc
@@ -20,6 +20,8 @@ include::{snippets}/member/login/http-response.adoc[]
 
 === 토큰 유효성 검증
 ==== Request
-include::{snippets}/member/token/http-request.adoc[]
-==== Response
-include::{snippets}/member/token/http-response.adoc[]
+include::{snippets}/member/token/success/http-request.adoc[]
+==== Success Response
+include::{snippets}/member/token/success/http-response.adoc[]
+==== Fail Response
+include::{snippets}/member/token/fail/http-response.adoc[]

--- a/backend/src/main/java/com/woowacourse/zzimkkong/AuthenticationPrincipalConfig.java
+++ b/backend/src/main/java/com/woowacourse/zzimkkong/AuthenticationPrincipalConfig.java
@@ -3,9 +3,10 @@ package com.woowacourse.zzimkkong;
 import com.woowacourse.zzimkkong.infrastructure.LoginInterceptor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
-public class AuthenticationPrincipalConfig extends WebConfig {
+public class AuthenticationPrincipalConfig implements WebMvcConfigurer {
     private final LoginInterceptor loginInterceptor;
 
     public AuthenticationPrincipalConfig(LoginInterceptor loginInterceptor) {

--- a/backend/src/main/java/com/woowacourse/zzimkkong/AuthenticationPrincipalConfig.java
+++ b/backend/src/main/java/com/woowacourse/zzimkkong/AuthenticationPrincipalConfig.java
@@ -1,0 +1,20 @@
+package com.woowacourse.zzimkkong;
+
+import com.woowacourse.zzimkkong.infrastructure.LoginInterceptor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+
+@Configuration
+public class AuthenticationPrincipalConfig extends WebConfig {
+    private final LoginInterceptor loginInterceptor;
+
+    public AuthenticationPrincipalConfig(LoginInterceptor loginInterceptor) {
+        this.loginInterceptor = loginInterceptor;
+    }
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(loginInterceptor)
+                .addPathPatterns("/api/members/token");
+    }
+}

--- a/backend/src/main/java/com/woowacourse/zzimkkong/controller/AuthController.java
+++ b/backend/src/main/java/com/woowacourse/zzimkkong/controller/AuthController.java
@@ -4,10 +4,7 @@ import com.woowacourse.zzimkkong.dto.member.LoginRequest;
 import com.woowacourse.zzimkkong.dto.member.TokenResponse;
 import com.woowacourse.zzimkkong.service.AuthService;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
 
@@ -24,5 +21,10 @@ public class AuthController {
     public ResponseEntity<TokenResponse> login(@RequestBody @Valid final LoginRequest loginRequest) {
         return ResponseEntity.ok()
                 .body(authService.login(loginRequest));
+    }
+
+    @PostMapping("/members/token")
+    public ResponseEntity<TokenResponse> token() {
+        return ResponseEntity.ok().build();
     }
 }

--- a/backend/src/main/java/com/woowacourse/zzimkkong/controller/ControllerAdvice.java
+++ b/backend/src/main/java/com/woowacourse/zzimkkong/controller/ControllerAdvice.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.exc.InvalidFormatException;
 import com.woowacourse.zzimkkong.dto.ErrorResponse;
 import com.woowacourse.zzimkkong.exception.ZzimkkongException;
 import com.woowacourse.zzimkkong.exception.authorization.AuthorizationException;
+import com.woowacourse.zzimkkong.exception.authorization.AuthorizationHeaderUninvolvedException;
 import com.woowacourse.zzimkkong.exception.map.MapException;
 import com.woowacourse.zzimkkong.exception.member.MemberException;
 import com.woowacourse.zzimkkong.exception.reservation.ReservationException;
@@ -11,6 +12,7 @@ import com.woowacourse.zzimkkong.exception.space.SpaceException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.dao.DataAccessException;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -42,6 +44,12 @@ public class ControllerAdvice {
     public ResponseEntity<ErrorResponse> invalidParamHandler(final ConstraintViolationException exception) {
         logger.warn(exception.getMessage());
         return ResponseEntity.badRequest().body(ErrorResponse.of(exception));
+    }
+
+    @ExceptionHandler(AuthorizationHeaderUninvolvedException.class)
+    public ResponseEntity<ErrorResponse> invalidTokenHandler(final AuthorizationHeaderUninvolvedException exception) {
+        logger.warn(exception.getMessage());
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ErrorResponse.of(exception));
     }
 
     @ExceptionHandler(DataAccessException.class)

--- a/backend/src/test/java/com/woowacourse/zzimkkong/controller/AuthControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/zzimkkong/controller/AuthControllerTest.java
@@ -1,5 +1,6 @@
 package com.woowacourse.zzimkkong.controller;
 
+import com.woowacourse.zzimkkong.dto.ErrorResponse;
 import com.woowacourse.zzimkkong.dto.member.LoginRequest;
 import com.woowacourse.zzimkkong.dto.member.MemberSaveRequest;
 import com.woowacourse.zzimkkong.dto.member.TokenResponse;
@@ -50,6 +51,36 @@ class AuthControllerTest extends AcceptanceTest {
         assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
     }
 
+    @Test
+    @DisplayName("유효한 토큰으로 요청이 오면 200 ok가 반환된다.")
+    void validToken() {
+        // given
+        saveMember(new MemberSaveRequest(EMAIL, PASSWORD, ORGANIZATION));
+
+        LoginRequest loginRequest = new LoginRequest(EMAIL, PASSWORD);
+        ExtractableResponse<Response> loginResponse = login(loginRequest);
+        TokenResponse responseBody = loginResponse.body().as(TokenResponse.class);
+
+        //when
+        ExtractableResponse<Response> response = token(responseBody.getAccessToken());
+
+        //then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+    }
+
+    @Test
+    @DisplayName("유효하지 않은 토큰으로 요청이 오면 401 UnAuthorized가 반환된다.")
+    void invalidToken() {
+        //given
+        String invalidToken = "strangeTokenIsComing";
+
+        //when
+        ExtractableResponse<Response> response = token(invalidToken);
+
+        //then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.UNAUTHORIZED.value());
+    }
+
     private ExtractableResponse<Response> login(final LoginRequest loginRequest) {
         return RestAssured
                 .given(getRequestSpecification()).log().all()
@@ -58,6 +89,17 @@ class AuthControllerTest extends AcceptanceTest {
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .body(loginRequest)
                 .when().post("/api/login/token")
+                .then().log().all().extract();
+    }
+
+    private ExtractableResponse<Response> token(String token) {
+        return RestAssured
+                .given(getRequestSpecification()).log().all()
+                .accept("application/json")
+                .header("Authorization", "Bearer " + token)
+                .filter(document("member/token", getRequestPreprocessor(), getResponsePreprocessor()))
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when().post("/api/members/token")
                 .then().log().all().extract();
     }
 }

--- a/backend/src/test/java/com/woowacourse/zzimkkong/controller/AuthControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/zzimkkong/controller/AuthControllerTest.java
@@ -62,7 +62,7 @@ class AuthControllerTest extends AcceptanceTest {
         TokenResponse responseBody = loginResponse.body().as(TokenResponse.class);
 
         //when
-        ExtractableResponse<Response> response = token(responseBody.getAccessToken());
+        ExtractableResponse<Response> response = token(responseBody.getAccessToken(), "success");
 
         //then
         assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
@@ -75,7 +75,7 @@ class AuthControllerTest extends AcceptanceTest {
         String invalidToken = "strangeTokenIsComing";
 
         //when
-        ExtractableResponse<Response> response = token(invalidToken);
+        ExtractableResponse<Response> response = token(invalidToken,"fail");
 
         //then
         assertThat(response.statusCode()).isEqualTo(HttpStatus.UNAUTHORIZED.value());
@@ -92,12 +92,12 @@ class AuthControllerTest extends AcceptanceTest {
                 .then().log().all().extract();
     }
 
-    private ExtractableResponse<Response> token(String token) {
+    private ExtractableResponse<Response> token(String token, String docName) {
         return RestAssured
                 .given(getRequestSpecification()).log().all()
                 .accept("application/json")
                 .header("Authorization", "Bearer " + token)
-                .filter(document("member/token", getRequestPreprocessor(), getResponsePreprocessor()))
+                .filter(document("member/token/" + docName, getRequestPreprocessor(), getResponsePreprocessor()))
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .when().post("/api/members/token")
                 .then().log().all().extract();


### PR DESCRIPTION
## 구현 기능
- 토큰 유효성 검증하는 API를 구현한다.
![스크린샷 2021-07-15 오후 6 55 18](https://user-images.githubusercontent.com/43775108/125768974-eed8d417-459b-4bb7-a592-ea8e31d53534.png)

## 논의하고 싶은 내용
- WebConfig와 AuthenticationPrincipalConfig가 모두 WebConfigurer를 구현하는 것이 싫어서 AuthenticationPrincipalConfig가 WebConfig를 상속하도록 했습니다. 어떤가요?
- 김김의 구현에서 LoginInterceptor와 JwtUtil이 모두 Bean으로 등록되어 있어서 Config에서 두 의존성을 주입받아야 했는데 이 부분은 어떤가요?

Close #118

