### PR TITLE
refactor: DTO 정적팩토리 메서드 형식 통일

### DIFF
--- a/backend/src/main/java/com/woowacourse/zzimkkong/controller/ControllerAdvice.java
+++ b/backend/src/main/java/com/woowacourse/zzimkkong/controller/ControllerAdvice.java
@@ -31,25 +31,25 @@ public class ControllerAdvice {
         logger.warn(exception.getMessage());
         return ResponseEntity
                 .status(exception.getStatus())
-                .body(ErrorResponse.of(exception));
+                .body(ErrorResponse.from(exception));
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<ErrorResponse> invalidArgumentHandler(final MethodArgumentNotValidException exception) {
         logger.warn(exception.getMessage());
-        return ResponseEntity.badRequest().body(ErrorResponse.of(exception));
+        return ResponseEntity.badRequest().body(ErrorResponse.from(exception));
     }
 
     @ExceptionHandler(ConstraintViolationException.class)
     public ResponseEntity<ErrorResponse> invalidParamHandler(final ConstraintViolationException exception) {
         logger.warn(exception.getMessage());
-        return ResponseEntity.badRequest().body(ErrorResponse.of(exception));
+        return ResponseEntity.badRequest().body(ErrorResponse.from(exception));
     }
 
     @ExceptionHandler(AuthorizationHeaderUninvolvedException.class)
     public ResponseEntity<ErrorResponse> invalidTokenHandler(final AuthorizationHeaderUninvolvedException exception) {
         logger.warn(exception.getMessage());
-        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ErrorResponse.of(exception));
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ErrorResponse.from(exception));
     }
 
     @ExceptionHandler(DataAccessException.class)

--- a/backend/src/main/java/com/woowacourse/zzimkkong/dto/ErrorResponse.java
+++ b/backend/src/main/java/com/woowacourse/zzimkkong/dto/ErrorResponse.java
@@ -17,16 +17,16 @@ public class ErrorResponse {
         this.message = message;
     }
 
-    public static ErrorResponse of(final RuntimeException exception) {
+    public static ErrorResponse from(final RuntimeException exception) {
         return new ErrorResponse(exception.getMessage());
     }
 
-    public static ErrorResponse of(final MethodArgumentNotValidException exception) {
+    public static ErrorResponse from(final MethodArgumentNotValidException exception) {
         String message = exception.getBindingResult().getAllErrors().get(0).getDefaultMessage();
         return new ErrorResponse(message);
     }
 
-    public static ErrorResponse of(final ConstraintViolationException exception) {
+    public static ErrorResponse from(final ConstraintViolationException exception) {
         String message = exception.getConstraintViolations().iterator().next().getMessage();
         return new ErrorResponse(message);
     }

--- a/backend/src/main/java/com/woowacourse/zzimkkong/dto/member/MemberSaveResponse.java
+++ b/backend/src/main/java/com/woowacourse/zzimkkong/dto/member/MemberSaveResponse.java
@@ -13,7 +13,7 @@ public class MemberSaveResponse {
         this.id = id;
     }
 
-    public static MemberSaveResponse from(Member member) {
+    public static MemberSaveResponse from(final Member member) {
         return new MemberSaveResponse(member.getId());
     }
 

--- a/backend/src/main/java/com/woowacourse/zzimkkong/dto/member/MemberSaveResponse.java
+++ b/backend/src/main/java/com/woowacourse/zzimkkong/dto/member/MemberSaveResponse.java
@@ -13,7 +13,7 @@ public class MemberSaveResponse {
         this.id = id;
     }
 
-    public static MemberSaveResponse of(Member member) {
+    public static MemberSaveResponse from(Member member) {
         return new MemberSaveResponse(member.getId());
     }
 

--- a/backend/src/main/java/com/woowacourse/zzimkkong/dto/member/TokenResponse.java
+++ b/backend/src/main/java/com/woowacourse/zzimkkong/dto/member/TokenResponse.java
@@ -14,7 +14,7 @@ public class TokenResponse {
         return accessToken;
     }
 
-    public static TokenResponse of(String token) {
+    public static TokenResponse from(String token) {
         return new TokenResponse(token);
     }
 }

--- a/backend/src/main/java/com/woowacourse/zzimkkong/dto/member/TokenResponse.java
+++ b/backend/src/main/java/com/woowacourse/zzimkkong/dto/member/TokenResponse.java
@@ -14,7 +14,7 @@ public class TokenResponse {
         return accessToken;
     }
 
-    public static TokenResponse from(String token) {
+    public static TokenResponse from(final String token) {
         return new TokenResponse(token);
     }
 }

--- a/backend/src/main/java/com/woowacourse/zzimkkong/dto/reservation/ReservationCreateResponse.java
+++ b/backend/src/main/java/com/woowacourse/zzimkkong/dto/reservation/ReservationCreateResponse.java
@@ -13,7 +13,7 @@ public class ReservationCreateResponse {
         this.id = id;
     }
 
-    public static ReservationCreateResponse from(Reservation reservation) {
+    public static ReservationCreateResponse from(final Reservation reservation) {
         return new ReservationCreateResponse(reservation.getId());
     }
 

--- a/backend/src/main/java/com/woowacourse/zzimkkong/dto/reservation/ReservationCreateResponse.java
+++ b/backend/src/main/java/com/woowacourse/zzimkkong/dto/reservation/ReservationCreateResponse.java
@@ -13,7 +13,7 @@ public class ReservationCreateResponse {
         this.id = id;
     }
 
-    public static ReservationCreateResponse of(Reservation reservation) {
+    public static ReservationCreateResponse from(Reservation reservation) {
         return new ReservationCreateResponse(reservation.getId());
     }
 

--- a/backend/src/main/java/com/woowacourse/zzimkkong/dto/reservation/ReservationFindAllResponse.java
+++ b/backend/src/main/java/com/woowacourse/zzimkkong/dto/reservation/ReservationFindAllResponse.java
@@ -20,7 +20,7 @@ public class ReservationFindAllResponse {
         this.data = data;
     }
 
-    public static ReservationFindAllResponse from(List<Reservation> reservations) {
+    public static ReservationFindAllResponse from(final List<Reservation> reservations) {
         Map<Space, List<Reservation>> reservationGroups = reservations.stream()
                 .collect(Collectors.groupingBy(Reservation::getSpace));
 

--- a/backend/src/main/java/com/woowacourse/zzimkkong/dto/reservation/ReservationFindAllResponse.java
+++ b/backend/src/main/java/com/woowacourse/zzimkkong/dto/reservation/ReservationFindAllResponse.java
@@ -20,7 +20,7 @@ public class ReservationFindAllResponse {
         this.data = data;
     }
 
-    public static ReservationFindAllResponse of(List<Reservation> reservations) {
+    public static ReservationFindAllResponse from(List<Reservation> reservations) {
         Map<Space, List<Reservation>> reservationGroups = reservations.stream()
                 .collect(Collectors.groupingBy(Reservation::getSpace));
 
@@ -30,7 +30,7 @@ public class ReservationFindAllResponse {
 
         List<ReservationSpaceResponse> reservationSpaceResponses = reservationGroups.entrySet()
                 .stream()
-                .map(ReservationSpaceResponse::of)
+                .map(ReservationSpaceResponse::from)
                 .sorted(Comparator.comparing(ReservationSpaceResponse::getSpaceId))
                 .collect(Collectors.toList());
 

--- a/backend/src/main/java/com/woowacourse/zzimkkong/dto/reservation/ReservationFindResponse.java
+++ b/backend/src/main/java/com/woowacourse/zzimkkong/dto/reservation/ReservationFindResponse.java
@@ -18,11 +18,11 @@ public class ReservationFindResponse {
         this.reservations = reservations;
     }
 
-    public static ReservationFindResponse of(final List<Reservation> reservations) {
+    public static ReservationFindResponse from(final List<Reservation> reservations) {
         reservations.sort(Comparator.comparing(Reservation::getStartTime));
 
         List<ReservationResponse> reservationResponses = reservations.stream()
-                .map(ReservationResponse::of)
+                .map(ReservationResponse::from)
                 .collect(Collectors.toList());
 
         return new ReservationFindResponse(reservationResponses);

--- a/backend/src/main/java/com/woowacourse/zzimkkong/dto/reservation/ReservationResponse.java
+++ b/backend/src/main/java/com/woowacourse/zzimkkong/dto/reservation/ReservationResponse.java
@@ -36,7 +36,7 @@ public class ReservationResponse {
         this.description = description;
     }
 
-    public static ReservationResponse of(final Reservation reservation) {
+    public static ReservationResponse from(final Reservation reservation) {
         return new ReservationResponse(
                 reservation.getId(),
                 reservation.getStartTime(),

--- a/backend/src/main/java/com/woowacourse/zzimkkong/dto/reservation/ReservationSpaceResponse.java
+++ b/backend/src/main/java/com/woowacourse/zzimkkong/dto/reservation/ReservationSpaceResponse.java
@@ -27,10 +27,10 @@ public class ReservationSpaceResponse {
         this.reservations = reservations;
     }
 
-    public static ReservationSpaceResponse of(final Map.Entry<Space, List<Reservation>> reservationsPerSpace) {
+    public static ReservationSpaceResponse from(final Map.Entry<Space, List<Reservation>> reservationsPerSpace) {
         List<ReservationResponse> reservations = reservationsPerSpace.getValue()
                 .stream()
-                .map(ReservationResponse::of)
+                .map(ReservationResponse::from)
                 .collect(Collectors.toList());
 
         Space space = reservationsPerSpace.getKey();

--- a/backend/src/main/java/com/woowacourse/zzimkkong/dto/slack/Attachment.java
+++ b/backend/src/main/java/com/woowacourse/zzimkkong/dto/slack/Attachment.java
@@ -27,12 +27,12 @@ public class Attachment {
     }
 
     public static Attachment of(
-            String fallback,
-            String color,
-            String pretext,
-            String title,
-            String titleLink,
-            SlackResponse slackResponse) {
+            final String fallback,
+            final String color,
+            final String pretext,
+            final String title,
+            final String titleLink,
+            final SlackResponse slackResponse) {
         return new Attachment(fallback, color, pretext, title, titleLink, slackResponse);
     }
 

--- a/backend/src/main/java/com/woowacourse/zzimkkong/dto/slack/Attachments.java
+++ b/backend/src/main/java/com/woowacourse/zzimkkong/dto/slack/Attachments.java
@@ -16,7 +16,7 @@ public class Attachments {
         this.attachments = attachments;
     }
 
-    public static Attachments updateMessageFrom(SlackResponse slackResponse) {
+    public static Attachments updateMessageFrom(final SlackResponse slackResponse) {
         Attachment attachment = Attachment.of(
                 "✏️ 예약 수정 알림 ✏️",
                 COLOR,
@@ -27,7 +27,7 @@ public class Attachments {
         return Attachments.from(attachment);
     }
 
-    public static Attachments deleteMessageFrom(SlackResponse slackResponse) {
+    public static Attachments deleteMessageFrom(final SlackResponse slackResponse) {
         Attachment attachment = Attachment.of(
                 "🗑 예약 삭제 알림 🗑",
                 COLOR,
@@ -38,7 +38,7 @@ public class Attachments {
         return Attachments.from(attachment);
     }
 
-    private static Attachments from(Attachment attachment) {
+    private static Attachments from(final Attachment attachment) {
         List<Attachment> attachments = new ArrayList<>();
         attachments.add(attachment);
         return new Attachments(attachments);

--- a/backend/src/main/java/com/woowacourse/zzimkkong/dto/slack/SlackResponse.java
+++ b/backend/src/main/java/com/woowacourse/zzimkkong/dto/slack/SlackResponse.java
@@ -25,7 +25,7 @@ public class SlackResponse {
         this.description = "예약내용 : " + description;
     }
 
-    public static SlackResponse from(Reservation reservation) {
+    public static SlackResponse from(final Reservation reservation) {
         return new SlackResponse(
                 reservation.getSpace().getName(),
                 reservation.getUserName(),

--- a/backend/src/main/java/com/woowacourse/zzimkkong/service/AuthService.java
+++ b/backend/src/main/java/com/woowacourse/zzimkkong/service/AuthService.java
@@ -32,7 +32,7 @@ public class AuthService {
 
         String token = issueToken(findMember);
 
-        return TokenResponse.of(token);
+        return TokenResponse.from(token);
     }
 
     private String issueToken(Member findMember) {

--- a/backend/src/main/java/com/woowacourse/zzimkkong/service/MemberService.java
+++ b/backend/src/main/java/com/woowacourse/zzimkkong/service/MemberService.java
@@ -26,7 +26,7 @@ public class MemberService {
                 memberSaveRequest.getOrganization()
         );
         Member saveMember = members.save(member);
-        return MemberSaveResponse.of(saveMember);
+        return MemberSaveResponse.from(saveMember);
     }
 
     @Transactional(readOnly = true)

--- a/backend/src/main/java/com/woowacourse/zzimkkong/service/ReservationService.java
+++ b/backend/src/main/java/com/woowacourse/zzimkkong/service/ReservationService.java
@@ -58,7 +58,7 @@ public class ReservationService {
                         .space(space)
                         .build());
 
-        return ReservationCreateResponse.of(reservation);
+        return ReservationCreateResponse.from(reservation);
     }
 
     @Transactional(readOnly = true)
@@ -68,7 +68,7 @@ public class ReservationService {
 
         List<Reservation> reservations = getReservations(Collections.singletonList(spaceId), date);
 
-        return ReservationFindResponse.of(reservations);
+        return ReservationFindResponse.from(reservations);
     }
 
     @Transactional(readOnly = true)
@@ -82,7 +82,7 @@ public class ReservationService {
 
         List<Reservation> reservations = getReservations(spaceIds, date);
 
-        return ReservationFindAllResponse.of(reservations);
+        return ReservationFindAllResponse.from(reservations);
     }
 
     @Transactional(readOnly = true)
@@ -94,7 +94,7 @@ public class ReservationService {
 
         Reservation reservation = getReservation(reservationId);
         checkCorrectPassword(reservation, reservationPasswordAuthenticationRequest.getPassword());
-        return ReservationResponse.of(reservation);
+        return ReservationResponse.from(reservation);
     }
 
     public SlackResponse updateReservation(

--- a/backend/src/test/java/com/woowacourse/zzimkkong/controller/ReservationControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/zzimkkong/controller/ReservationControllerTest.java
@@ -115,7 +115,7 @@ public class ReservationControllerTest extends AcceptanceTest {
         ExtractableResponse<Response> response = findReservations(api, TOMORROW.toString());
 
         ReservationFindResponse actualResponse = response.as(ReservationFindResponse.class);
-        ReservationFindResponse expectedResponse = ReservationFindResponse.of(
+        ReservationFindResponse expectedResponse = ReservationFindResponse.from(
                 Arrays.asList(savedReservation,
                         BE_AM_ZERO_ONE,
                         BE_PM_ONE_TWO));
@@ -140,7 +140,7 @@ public class ReservationControllerTest extends AcceptanceTest {
         ExtractableResponse<Response> response = findAllReservations(api, TOMORROW.toString());
 
         ReservationFindAllResponse actualResponse = response.as(ReservationFindAllResponse.class);
-        ReservationFindAllResponse expectedResponse = ReservationFindAllResponse.of(
+        ReservationFindAllResponse expectedResponse = ReservationFindAllResponse.from(
                 List.of(savedReservation,
                         BE_AM_ZERO_ONE,
                         BE_PM_ONE_TWO,
@@ -175,7 +175,7 @@ public class ReservationControllerTest extends AcceptanceTest {
         ExtractableResponse<Response> findResponse = findReservation(api, new ReservationPasswordAuthenticationRequest(SALLY_PASSWORD));
 
         ReservationResponse actualResponse = findResponse.body().as(ReservationResponse.class);
-        ReservationResponse expectedResponse = ReservationResponse.of(new Reservation.Builder()
+        ReservationResponse expectedResponse = ReservationResponse.from(new Reservation.Builder()
                 .startTime(reservationCreateUpdateRequestSameSpace.getStartDateTime())
                 .endTime(reservationCreateUpdateRequestSameSpace.getEndDateTime())
                 .description(reservationCreateUpdateRequestSameSpace.getDescription())
@@ -216,7 +216,7 @@ public class ReservationControllerTest extends AcceptanceTest {
                 TOMORROW.toString());
 
         ReservationFindResponse actualResponse = findResponse.as(ReservationFindResponse.class);
-        ReservationFindResponse expectedResponse = ReservationFindResponse.of(
+        ReservationFindResponse expectedResponse = ReservationFindResponse.from(
                 Arrays.asList(
                         new Reservation.Builder()
                                 .startTime(reservationCreateUpdateRequestDifferentSpace.getStartDateTime())
@@ -250,7 +250,7 @@ public class ReservationControllerTest extends AcceptanceTest {
         ExtractableResponse<Response> response = findReservation(api, reservationPasswordAuthenticationRequest);
 
         ReservationResponse actualResponse = response.as(ReservationResponse.class);
-        ReservationResponse expectedResponse = ReservationResponse.of(savedReservation);
+        ReservationResponse expectedResponse = ReservationResponse.from(savedReservation);
 
         //then
         assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());

--- a/backend/src/test/java/com/woowacourse/zzimkkong/service/MemberServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/zzimkkong/service/MemberServiceTest.java
@@ -41,7 +41,7 @@ class MemberServiceTest extends ServiceTest {
                 .willReturn(savedMember);
 
         //then
-        MemberSaveResponse memberSaveResponse = MemberSaveResponse.of(savedMember);
+        MemberSaveResponse memberSaveResponse = MemberSaveResponse.from(savedMember);
         assertThat(memberService.saveMember(memberSaveRequest)).usingRecursiveComparison()
                 .isEqualTo(memberSaveResponse);
     }

--- a/backend/src/test/java/com/woowacourse/zzimkkong/service/ReservationServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/zzimkkong/service/ReservationServiceTest.java
@@ -261,7 +261,7 @@ class ReservationServiceTest extends ServiceTest {
                 .willReturn(foundReservations);
 
         //then
-        ReservationFindResponse reservationFindResponse = ReservationFindResponse.of(foundReservations);
+        ReservationFindResponse reservationFindResponse = ReservationFindResponse.from(foundReservations);
         assertThat(reservationService.findReservations(1L, 1L, TOMORROW))
                 .usingRecursiveComparison()
                 .isEqualTo(reservationFindResponse);
@@ -297,13 +297,13 @@ class ReservationServiceTest extends ServiceTest {
                 .willReturn(Collections.emptyList());
 
         //then
-        ReservationFindResponse reservationFindResponse = ReservationFindResponse.of(Collections.emptyList());
+        ReservationFindResponse reservationFindResponse = ReservationFindResponse.from(Collections.emptyList());
         assertThat(reservationService.findReservations(1L, 1L, TOMORROW))
                 .usingRecursiveComparison()
                 .isEqualTo(reservationFindResponse);
         assertThat(reservationService.findAllReservations(1L, TOMORROW))
                 .usingRecursiveComparison()
-                .isEqualTo(ReservationFindAllResponse.of(Collections.emptyList()));
+                .isEqualTo(ReservationFindAllResponse.from(Collections.emptyList()));
     }
 
     @Test
@@ -343,7 +343,7 @@ class ReservationServiceTest extends ServiceTest {
                 .willReturn(foundReservations);
 
         //then
-        ReservationFindAllResponse reservationFindAllResponse = ReservationFindAllResponse.of(foundReservations);
+        ReservationFindAllResponse reservationFindAllResponse = ReservationFindAllResponse.from(foundReservations);
         assertThat(reservationService.findAllReservations(1L, TOMORROW))
                 .usingRecursiveComparison()
                 .isEqualTo(reservationFindAllResponse);
@@ -366,7 +366,7 @@ class ReservationServiceTest extends ServiceTest {
 
         //then
         assertThat(actualResponse).usingRecursiveComparison()
-                .isEqualTo(ReservationResponse.of(reservation));
+                .isEqualTo(ReservationResponse.from(reservation));
     }
 
     @Test


### PR DESCRIPTION
## 구현 기능
- 인자가 한 개인 정적팩토리 메서드명을 from으로 수정했습니다.

## 논의하고 싶은 내용
- 정적 팩토리 메서드를 사용할 때 인자가 한 개이면 `from`, 여러 개이면 `of`를 사용하는 것으로 통일하겠습니다.
- 정적 팩토리 메서드의 **인자에도 final 붙이는 것**으로 통일하겠습니다.
- 불가피한 경우를 제외하고 정적팩토리 메서드는 **객체를 인자로 받아 메서드 내부에서 getter를 사용하는 것**으로 통일하겠습니다.

Close #135 

