### PR TITLE
chore: webpack 중복되는 설정 제거 및 mode 설정 추가

### DIFF
--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -6,6 +6,8 @@ module.exports = () => {
   const isDevelopment = process.env.NODE_ENV !== 'production';
 
   return {
+    mode: isDevelopment ? 'development' : 'production',
+    devtool: isDevelopment ? 'eval-source-map' : 'source-map',
     entry: './src/index.tsx',
     output: {
       filename: 'bundle.js',
@@ -14,16 +16,13 @@ module.exports = () => {
     },
     resolve: {
       extensions: ['.ts', '.tsx', '.js', '.jsx'],
+      plugins: [new TsconfigPathsPlugin({})],
     },
     devServer: {
       port: 3000,
+      open: true,
       hot: true,
       historyApiFallback: true,
-    },
-    devtool: isDevelopment ? 'eval-source-map' : 'source-map',
-    resolve: {
-      extensions: ['.ts', '.tsx', '.js', '.jsx'],
-      plugins: [new TsconfigPathsPlugin({})],
     },
     module: {
       rules: [


### PR DESCRIPTION
## 구현 기능
- [x] webpack config 중복 설정 제거
- [x] webpack config mode 설정 추가  

## 공유하고 싶은 내용
### 제거한 내용
- 중복되는 'resolve' 옵션

### 추가한 내용
- mode 옵션
- devServer open 옵션
```js
module.exports = () => {
  const isDevelopment = process.env.NODE_ENV !== 'production';

  return {
    mode: isDevelopment ? 'development' : 'production', // <-- new 🌟
    devServer: {
      port: 3000,
      open: true, // <-- new 🌟
      hot: true,
      historyApiFallback: true,
    },

    ...
};

```




Close #141 

