### PR TITLE
fix: 예약자 예약 페이지 입력 폼에 최대 입력 길이 및 기타 폼 설정 추가

### DIFF
--- a/frontend/src/constants/reservation.ts
+++ b/frontend/src/constants/reservation.ts
@@ -1,0 +1,14 @@
+const RESERVATION = {
+  NAME: {
+    MAX_LENGTH: 20,
+  },
+  DESCRIPTION: {
+    MAX_LENGTH: 100,
+  },
+  PASSWORD: {
+    MIN_LENGTH: 4,
+    MAX_LENGTH: 4,
+  },
+};
+
+export default RESERVATION;

--- a/frontend/src/pages/UserReservation/UserReservation.tsx
+++ b/frontend/src/pages/UserReservation/UserReservation.tsx
@@ -11,6 +11,7 @@ import Layout from 'components/Layout/Layout';
 import ReservationListItem from 'components/ReservationListItem/ReservationListItem';
 import MESSAGE from 'constants/message';
 import REGEXP from 'constants/regexp';
+import RESERVATION from 'constants/reservation';
 import useInput from 'hooks/useInput';
 import useReservations from 'hooks/useReservations';
 import { formatDate, formatTime } from 'utils/datetime';
@@ -74,13 +75,21 @@ const UserReservation = (): JSX.Element => {
           <Styled.Section>
             <Styled.PageHeader>{spaceName}</Styled.PageHeader>
             <Styled.InputWrapper>
-              <Input label="이름" value={name} onChange={onChangeName} autoFocus required />
+              <Input
+                label="이름"
+                value={name}
+                onChange={onChangeName}
+                maxLength={RESERVATION.NAME.MAX_LENGTH}
+                autoFocus
+                required
+              />
             </Styled.InputWrapper>
             <Styled.InputWrapper>
               <Input
                 label="사용 목적"
                 value={description}
                 onChange={onChangeDescription}
+                maxLength={RESERVATION.DESCRIPTION.MAX_LENGTH}
                 required
               />
             </Styled.InputWrapper>
@@ -118,7 +127,10 @@ const UserReservation = (): JSX.Element => {
                 label="비밀번호"
                 value={password}
                 onChange={onChangePassword}
+                minLength={RESERVATION.PASSWORD.MIN_LENGTH}
+                maxLength={RESERVATION.PASSWORD.MAX_LENGTH}
                 pattern={REGEXP.RESERVATION_PASSWORD.source}
+                inputMode="numeric"
                 message="숫자 4자리를 입력해주세요."
                 required
               />


### PR DESCRIPTION
## 수정한 기능

- 이름은 최대 20자까지만 입력할 수 있도록 수정
  - `maxlength` 적용

- 사용 목적은 최대 100자까지만 입력할 수 있도록 수정
  - `maxlength` 적용

- 비밀번호 입력 시 4자까지만 입력할 수 있도록 수정하고, 모바일에서 숫자 키보드가 먼저 보이도록 수정
  - `minlength`, `maxlength`, `inputmode="numeric"` 적용


Close #133

