### PR TITLE
feat: 예약자 메인 페이지 기능 구현 및 예약 현황 조회 API 연동

### DIFF
--- a/frontend/src/App.styles.ts
+++ b/frontend/src/App.styles.ts
@@ -9,6 +9,13 @@ export const theme: DefaultTheme = {
   gray: PALETTE.GRAY,
   white: PALETTE.WHITE,
   modalOverlay: PALETTE.OPACITY_GRAY,
+  breakpoints: {
+    sm: 576,
+    md: 768,
+    lg: 992,
+    xl: 1200,
+    xxl: 1400,
+  },
 };
 
 const resetCSS = css`

--- a/frontend/src/api/space.ts
+++ b/frontend/src/api/space.ts
@@ -1,0 +1,19 @@
+import { AxiosResponse } from 'axios';
+import { QueryFunction, QueryKey } from 'react-query';
+import { QuerySpacesSuccess } from 'types/response';
+import api from './api';
+
+export interface QuerySpacesParams {
+  mapId: number;
+  date: string;
+}
+
+export const querySpaces: QueryFunction<
+  AxiosResponse<QuerySpacesSuccess>,
+  [QueryKey, QuerySpacesParams]
+> = ({ queryKey }) => {
+  const [, data] = queryKey;
+  const { mapId, date } = data;
+
+  return api.get(`/maps/${mapId}/reservations?date=${date}`);
+};

--- a/frontend/src/components/DateInput/DateInput.styles.ts
+++ b/frontend/src/components/DateInput/DateInput.styles.ts
@@ -26,6 +26,7 @@ export const DateInput = styled.input`
   font-size: 1.5rem;
   color: ${({ theme }) => theme.gray[500]};
   border: none;
+  background: none;
   line-height: 1em;
 
   &::-webkit-calendar-picker-indicator {

--- a/frontend/src/components/DateInput/DateInput.tsx
+++ b/frontend/src/components/DateInput/DateInput.tsx
@@ -2,12 +2,12 @@ import { InputHTMLAttributes } from 'react';
 import { ReactComponent as CalendarIcon } from 'assets/svg/calendar.svg';
 import * as Styled from './DateInput.styles';
 
-export type Props = InputHTMLAttributes<HTMLInputElement>;
+export type Props = Omit<InputHTMLAttributes<HTMLInputElement>, 'type'>;
 
-const DateInput = ({ value }: Props): JSX.Element => {
+const DateInput = ({ ...props }: Props): JSX.Element => {
   return (
     <Styled.DateWrapper>
-      <Styled.DateInput type="date" value={value} />
+      <Styled.DateInput type="date" {...props} />
       <CalendarIcon />
     </Styled.DateWrapper>
   );

--- a/frontend/src/components/Panel/Panel.styles.ts
+++ b/frontend/src/components/Panel/Panel.styles.ts
@@ -11,5 +11,5 @@ export const Title = styled.p`
 `;
 
 export const Inner = styled.div`
-  padding: 0.8rem;
+  padding: 0.75rem;
 `;

--- a/frontend/src/components/Panel/PanelHeader.styles.ts
+++ b/frontend/src/components/Panel/PanelHeader.styles.ts
@@ -43,7 +43,7 @@ export const HeaderContent = styled.div`
 `;
 
 export const Toggle = styled.div<ToggleProps>`
-  margin-right: 0.8rem;
+  margin-right: 0.75rem;
   background: none;
   border: none;
   line-height: 0;

--- a/frontend/src/components/PinRadio/PinRadio.tsx
+++ b/frontend/src/components/PinRadio/PinRadio.tsx
@@ -3,7 +3,7 @@ import { Coordinate } from 'types/common';
 import { Color } from 'types/styled';
 import * as Styled from './PinRadio.styles';
 
-export interface Props extends InputHTMLAttributes<HTMLInputElement> {
+export interface Props extends Omit<InputHTMLAttributes<HTMLInputElement>, 'type'> {
   text: string;
   textPosition?: 'left' | 'right' | 'top' | 'bottom';
   coordinate: Coordinate;

--- a/frontend/src/hooks/useInput.ts
+++ b/frontend/src/hooks/useInput.ts
@@ -1,12 +1,10 @@
 import { useState, ChangeEventHandler } from 'react';
 
-const useInput = <T extends unknown>(
-  initialValue: T
-): [T, ChangeEventHandler<HTMLInputElement>] => {
+const useInput = (initialValue = ''): [typeof value, ChangeEventHandler<HTMLInputElement>] => {
   const [value, setValue] = useState(initialValue);
 
   const onChange: ChangeEventHandler<HTMLInputElement> = (event) => {
-    setValue(event.target.value as T);
+    setValue(event.target.value);
   };
 
   return [value, onChange];

--- a/frontend/src/hooks/useSpaces.ts
+++ b/frontend/src/hooks/useSpaces.ts
@@ -1,0 +1,17 @@
+import { AxiosError, AxiosResponse } from 'axios';
+import { QueryKey, useQuery, UseQueryOptions, UseQueryResult } from 'react-query';
+import { querySpaces, QuerySpacesParams } from 'api/space';
+import { QuerySpacesSuccess } from 'types/response';
+
+const useSpaces = <TData = AxiosResponse<QuerySpacesSuccess>>(
+  { mapId, date }: QuerySpacesParams,
+  options?: UseQueryOptions<
+    AxiosResponse<QuerySpacesSuccess>,
+    AxiosError<Error>,
+    TData,
+    [QueryKey, QuerySpacesParams]
+  >
+): UseQueryResult<TData, AxiosError<Error>> =>
+  useQuery(['getSpaces', { mapId, date }], querySpaces, options);
+
+export default useSpaces;

--- a/frontend/src/pages/UserMain/UserMain.styles.ts
+++ b/frontend/src/pages/UserMain/UserMain.styles.ts
@@ -15,6 +15,10 @@ export const MapContainer = styled.div`
   overflow: auto;
   display: flex;
   justify-content: center;
+
+  @media (max-width: ${(props) => props.theme.breakpoints.md}px) {
+    height: auto;
+  }
 `;
 
 export const Map = styled.div`
@@ -46,3 +50,5 @@ export const ReservationList = styled.div`
     }
   }
 `;
+
+export const Message = styled.p``;

--- a/frontend/src/pages/UserMain/UserMain.styles.ts
+++ b/frontend/src/pages/UserMain/UserMain.styles.ts
@@ -32,13 +32,14 @@ export const PanelContainer = styled.div`
 `;
 
 export const ReservationLink = styled(Link)`
-  display: inline-block;
-  padding: 0.625rem 0.875rem;
+  display: block;
   background: ${({ theme }) => theme.primary[400]};
   color: ${({ theme }) => theme.white};
   border-right: 1px solid ${({ theme }) => theme.black[400]};
   margin-right: 1rem;
   text-decoration: none;
+  float: left;
+  line-height: 1.1em;
 `;
 
 export const ReservationList = styled.div`

--- a/frontend/src/pages/UserMain/UserMain.tsx
+++ b/frontend/src/pages/UserMain/UserMain.tsx
@@ -170,6 +170,8 @@ const UserMain = (): JSX.Element => {
   const location = useLocation<UserMainState>();
   const spaceId = location.state?.spaceId;
   const targetDate = location.state?.targetDate;
+  const now = new Date();
+  const todayDate = new Date(now.getFullYear(), now.getMonth(), now.getDate());
 
   const [date, onChangeDate] = useInput(formatDate(targetDate ?? new Date()));
   const [selectedSpaceId, onChangeSelectedSpaceId] = useInput(`${spaceId ?? spaceList[0].spaceId}`);
@@ -209,20 +211,24 @@ const UserMain = (): JSX.Element => {
         <Styled.PanelContainer>
           <Panel>
             <Panel.Header bgColor={selectedSpace.color}>
-              <Styled.ReservationLink
-                to={{
-                  pathname: PATH.RESERVATION,
-                  state: {
-                    mapId,
-                    spaceId: Number(selectedSpaceId),
-                    spaceName: selectedSpace.spaceName,
-                    selectedDate: date,
-                  },
-                }}
-              >
-                예약
-              </Styled.ReservationLink>
-              <Panel.Title>{selectedSpace.spaceName}</Panel.Title>
+              {new Date(date) > todayDate && (
+                <Styled.ReservationLink
+                  to={{
+                    pathname: PATH.RESERVATION,
+                    state: {
+                      mapId,
+                      spaceId: Number(selectedSpaceId),
+                      spaceName: selectedSpace.spaceName,
+                      selectedDate: date,
+                    },
+                  }}
+                >
+                  <Panel.Inner>예약</Panel.Inner>
+                </Styled.ReservationLink>
+              )}
+              <Panel.Inner>
+                <Panel.Title>{selectedSpace.spaceName}</Panel.Title>
+              </Panel.Inner>
             </Panel.Header>
             <Panel.Content>
               <>

--- a/frontend/src/pages/UserReservation/UserReservation.tsx
+++ b/frontend/src/pages/UserReservation/UserReservation.tsx
@@ -1,7 +1,7 @@
 import { AxiosError } from 'axios';
 import { FormEventHandler } from 'react';
 import { useMutation } from 'react-query';
-import { useHistory } from 'react-router-dom';
+import { useHistory, useLocation } from 'react-router-dom';
 import { postReservation } from 'api/reservation';
 import { ReactComponent as CalendarIcon } from 'assets/svg/calendar.svg';
 import Button from 'components/Button/Button';
@@ -10,35 +10,53 @@ import Input from 'components/Input/Input';
 import Layout from 'components/Layout/Layout';
 import ReservationListItem from 'components/ReservationListItem/ReservationListItem';
 import MESSAGE from 'constants/message';
+import PATH from 'constants/path';
 import REGEXP from 'constants/regexp';
 import useInput from 'hooks/useInput';
 import useReservations from 'hooks/useReservations';
+import { UserMainState } from 'pages/UserMain/UserMain';
+import { Space } from 'types/common';
 import { formatDate, formatTime } from 'utils/datetime';
 import * as Styled from './UserReservation.styles';
 
-const UserReservation = (): JSX.Element => {
-  // Note: 1번 맵의 1번 공간에 대해서만 예약되도록 임시 구현
-  const mapId = 1;
-  const spaceId = 1;
-  const spaceName = '회의실 1';
-  const now = new Date();
+interface UserReservationState {
+  mapId: number;
+  spaceId: Space['spaceId'];
+  spaceName: Space['spaceName'];
+  selectedDate: string;
+}
 
-  const history = useHistory();
+const UserReservation = (): JSX.Element => {
+  const location = useLocation<UserReservationState>();
+  const history = useHistory<UserMainState>();
+
+  const { mapId, spaceId, spaceName, selectedDate } = location.state;
+
+  if (!mapId || !spaceId || !spaceName) history.replace(PATH.USER_MAIN);
+
+  const now = new Date();
+  const initialStartTime = formatTime(now);
+  const initialEndTime = formatTime(new Date(new Date().getTime() + 1000 * 60 * 60));
 
   const [name, onChangeName] = useInput('');
   const [description, onChangeDescription] = useInput('');
-  const [date, onChangeDate] = useInput(formatDate(now));
-  const [startTime, onChangeStartTime] = useInput(formatTime(now));
-  const [endTime, onChangeEndTime] = useInput(formatTime(new Date(now.getTime() + 1000 * 60 * 60)));
+  const [date, onChangeDate] = useInput(selectedDate);
+  const [startTime, onChangeStartTime] = useInput(initialStartTime);
+  const [endTime, onChangeEndTime] = useInput(initialEndTime);
   const [password, onChangePassword] = useInput('');
 
-  const getReservations = useReservations({ mapId, spaceId, date });
+  const startDateTime = new Date(`${date}T${startTime}Z`);
+  const endDateTime = new Date(`${date}T${endTime}Z`);
 
+  const getReservations = useReservations({ mapId, spaceId, date });
   const reservations = getReservations.data?.data?.reservations ?? [];
 
   const createReservation = useMutation(postReservation, {
     onSuccess: () => {
-      history.push('/');
+      history.push(PATH.USER_MAIN, {
+        spaceId,
+        targetDate: startDateTime,
+      });
     },
     onError: (error: AxiosError<Error>) => {
       alert(error.response?.data.message ?? MESSAGE.RESERVATION.UNEXPECTED_ERROR);
@@ -50,12 +68,9 @@ const UserReservation = (): JSX.Element => {
 
     if (createReservation.isLoading) return;
 
-    const startDateTime = new Date(`${date}T${startTime}Z`);
-    const endDateTime = new Date(`${date}T${endTime}Z`);
-
     const mapId = 1;
     const reservation = {
-      spaceId: 1,
+      spaceId,
       name,
       description,
       password,
@@ -125,12 +140,24 @@ const UserReservation = (): JSX.Element => {
             </Styled.InputWrapper>
           </Styled.Section>
           <Styled.Section>
-            <Styled.PageHeader>{date}의 예약 목록</Styled.PageHeader>
-            {getReservations.isLoading && <Styled.Message>불러오는 중입니다...</Styled.Message>}
-            {getReservations.isFetched && reservations.length === 0 && (
+            <Styled.PageHeader>
+              {date}
+              {date && '의'} 예약 목록
+            </Styled.PageHeader>
+            {getReservations.isLoadingError && (
+              <Styled.Message>
+                예약 목록을 불러오는 데 문제가 생겼어요!
+                <br />
+                새로 고침으로 다시 시도해주세요.
+              </Styled.Message>
+            )}
+            {getReservations.isLoading && !getReservations.isLoadingError && (
+              <Styled.Message>불러오는 중입니다...</Styled.Message>
+            )}
+            {getReservations.isSuccess && reservations.length === 0 && (
               <Styled.Message>오늘의 첫 예약을 잡아보세요!</Styled.Message>
             )}
-            {getReservations.isFetched && reservations.length > 0 && (
+            {getReservations.isSuccess && reservations.length > 0 && (
               <Styled.ReservationList role="list">
                 {reservations?.map((reservation) => (
                   <ReservationListItem key={reservation.id} reservation={reservation} />

--- a/frontend/src/types/common.ts
+++ b/frontend/src/types/common.ts
@@ -1,3 +1,5 @@
+import { Color } from './styled';
+
 export interface Coordinate {
   x: number;
   y: number;
@@ -9,4 +11,12 @@ export interface Reservation {
   endDateTime: string;
   name: string;
   description: string;
+}
+
+export interface Space {
+  spaceId: number;
+  spaceName: string;
+  color: Color;
+  textPosition: 'left' | 'right' | 'top' | 'bottom';
+  coordinate: Coordinate;
 }

--- a/frontend/src/types/response.ts
+++ b/frontend/src/types/response.ts
@@ -1,4 +1,4 @@
-import { Reservation } from './common';
+import { Reservation, Space } from './common';
 
 export interface LoginSuccess {
   accessToken: string;
@@ -6,4 +6,8 @@ export interface LoginSuccess {
 
 export interface QueryReservationsSuccess {
   reservations: Reservation[];
+}
+
+export interface QuerySpacesSuccess {
+  data: Space[];
 }

--- a/frontend/src/types/styled.d.ts
+++ b/frontend/src/types/styled.d.ts
@@ -15,6 +15,14 @@ interface Palette {
   900?: Color;
 }
 
+interface BreakPoints {
+  sm?: number;
+  md?: number;
+  lg?: number;
+  xl?: number;
+  xxl?: number;
+}
+
 declare module 'styled-components' {
   export interface DefaultTheme {
     primary: Palette;
@@ -24,5 +32,6 @@ declare module 'styled-components' {
     gray: Palette;
     white: Color;
     modalOverlay: Color;
+    breakpoints: BreakPoints;
   }
 }


### PR DESCRIPTION
## 구현 기능
- 예약자 메인 페이지 기능 구현
  - 공간 선택 시 예약 현황을 조회할 수 있다
  - 공간 선택 후 [예약] 버튼을 누르면 예약 페이지로 이동한다.

- 공간 목록을 불러오는 `useSpaces` 커스텀 훅 구현
  - 추후 지도상의 모든 공간을 조회할 수 있는 API가 구현되었을 때 적용 요망
 
- `useInput` 커스텀 훅이 제너릭이 아닌 string 타입의 값만 받도록 수정함
  - `onChange` 메소드의 `event.target.value`가 항상 string 타입이기 때문에 `onChange`로 값이 변경될 때 실제 값이 항상 string인 문제가 있어 `value`를 항상 string으로 받도록 강제하였습니다.


## 공유하고 싶은 내용
- 특정 확대 비율 및 특정 기기에서 `Panel.Header` 컴포넌트 내부가 꽉 차지 않는 문제가 있습니다. 추후 수정이 필요합니다.
![image](https://user-images.githubusercontent.com/2542730/126070502-d785a800-a79d-4310-89d1-5309599a9928.png)

- 예약 현황 수정 및 삭제 기능 및 UI는 구현되지 않았으니, 별도의 이슈와 PR에서 구현해야 합니다.
  - #23
  - #24

Close #146 

