### PR TITLE
fix: 예약 후 메인 페이지의 날짜가 올바르게 변경되지 않는 문제 수정

### DIFF
--- a/frontend/src/pages/UserMain/UserMain.tsx
+++ b/frontend/src/pages/UserMain/UserMain.tsx
@@ -178,7 +178,7 @@ const UserMain = (): JSX.Element => {
   const getReservations = useReservations({
     mapId,
     spaceId: Number(selectedSpaceId),
-    date: targetDate ? formatDate(targetDate) : date,
+    date,
   });
   const reservations = getReservations.data?.data?.reservations ?? [];
 


### PR DESCRIPTION
## 수정 내역
- 예약 후 메인 페이지의 날짜를 변경해도 예약 목록을 올바르게 조회하지 못하는 문제를 수정합니다.

Close #153

