### PR TITLE
fix: `/`를 제외한 페이지가 보여지지 않는 문제 수정

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,13 +3,13 @@ import { ReactQueryDevtools } from 'react-query/devtools';
 import { BrowserRouter as Router, Route, Switch } from 'react-router-dom';
 import { RecoilRoot } from 'recoil';
 import { ThemeProvider } from 'styled-components';
-import Main from 'pages/Main/Main';
-import ProviderReservationList from 'pages/ProviderReservationList/ProviderReservationList';
-import UserMain from 'pages/UserMain/UserMain';
 import { GlobalStyle, theme } from './App.styles';
 import PATH from './constants/path';
 import Join from './pages/Join/Join';
 import Login from './pages/Login/Login';
+import Main from './pages/Main/Main';
+import ProviderReservationList from './pages/ProviderReservationList/ProviderReservationList';
+import UserMain from './pages/UserMain/UserMain';
 import UserReservation from './pages/UserReservation/UserReservation';
 
 const queryClient = new QueryClient();
@@ -24,19 +24,19 @@ const App = (): JSX.Element => (
             <Route exact path={PATH.HOME}>
               <Main />
             </Route>
-            <Route path={PATH.LOGIN}>
+            <Route exact path={PATH.LOGIN}>
               <Login />
             </Route>
-            <Route path={PATH.JOIN}>
+            <Route exact path={PATH.JOIN}>
               <Join />
             </Route>
-            <Route path={PATH.USER_MAIN}>
+            <Route exact path={PATH.USER_MAIN}>
               <UserMain />
             </Route>
-            <Route path={PATH.RESERVATION}>
+            <Route exact path={PATH.RESERVATION}>
               <UserReservation />
             </Route>
-            <Route path={PATH.PROVIDER_RESERVATION_LIST}>
+            <Route exact path={PATH.PROVIDER_RESERVATION_LIST}>
               <ProviderReservationList />
             </Route>
           </Switch>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -21,7 +21,7 @@ const App = (): JSX.Element => (
         <GlobalStyle />
         <Router>
           <Switch>
-            <Route path={PATH.HOME}>
+            <Route exact path={PATH.HOME}>
               <Main />
             </Route>
             <Route path={PATH.LOGIN}>


### PR DESCRIPTION
## 구현 기능
- #186 의 문제를 해결합니다.

## 공유하고 싶은 내용
- 라우트 주소가 겹치도록 구현하는 경우 꼭 `exact` 속성을 추가해주세요!
  - 혹은 무조건 `exact` 속성을 추가하는 것도 괜찮다고 생각합니다. 이 부분은 논의 후 적용하는 것도 좋아보입니다.

Close #186 

