### PR TITLE
refactor: 잘못된 비밀번호 입력 시 출력되는 예외 메시지를 수정한다.

### DIFF
--- a/backend/src/main/java/com/woowacourse/zzimkkong/dto/reservation/ReservationPasswordAuthenticationRequest.java
+++ b/backend/src/main/java/com/woowacourse/zzimkkong/dto/reservation/ReservationPasswordAuthenticationRequest.java
@@ -7,7 +7,7 @@ import static com.woowacourse.zzimkkong.dto.Validator.*;
 
 public class ReservationPasswordAuthenticationRequest {
     @NotBlank(message = EMPTY_MESSAGE)
-    @Pattern(regexp = RESERVATION_PASSWORD_FORMAT, message = MEMBER_PASSWORD_MESSAGE)
+    @Pattern(regexp = RESERVATION_PASSWORD_FORMAT, message = RESERVATION_PASSWORD_MESSAGE)
     private String password;
 
     public ReservationPasswordAuthenticationRequest() {


### PR DESCRIPTION
## 구현 기능
- 비밀번호를 4자리 숫자로 입력하지 않는 경우 "비밀번호는 숫자 4자리만 입력 가능합니다."를 출력한다.

Close #197

