### PR TITLE
refactor: 로그인/회원가입 페이지 UI 변경

### DIFF
--- a/frontend/src/components/Button/Button.styles.ts
+++ b/frontend/src/components/Button/Button.styles.ts
@@ -49,5 +49,6 @@ export const Button = styled.button<Props>`
   ${({ variant }) => variantCSS[variant]}
   ${({ size }) => sizeCSS[size]}
   width: ${({ fullWidth }) => (fullWidth ? '100%' : 'auto')};
+  border-radius: 0.125rem;
   cursor: pointer;
 `;

--- a/frontend/src/components/Header/Header.styles.ts
+++ b/frontend/src/components/Header/Header.styles.ts
@@ -4,26 +4,26 @@ import Layout from 'components/Layout/Layout';
 export const Header = styled.header`
   position: sticky;
   top: 0;
-  height: 4rem;
+  height: 3rem;
   background-color: ${({ theme }) => theme.white};
+  box-shadow: 0 0.25rem 0.25rem 0 ${({ theme }) => theme.shadow};
   z-index: 99;
-
-  svg {
-    padding: 0.875rem 0;
-    height: 100%;
-  }
 `;
 
 export const HeaderLayout = styled(Layout)`
   display: flex;
   align-items: center;
-  height: inherit;
-  width: 100%;
+  height: 100%;
+`;
+
+export const Logo = styled.div`
+  width: 1.75rem;
 `;
 
 export const Title = styled.h1`
-  font-size: 1.625rem;
+  font-size: 1.5rem;
   font-weight: 700;
-  margin-left: 0.375rem;
+  margin-left: 0.5rem;
+  vertical-align: middle;
   transform: translateY(-0.125rem);
 `;

--- a/frontend/src/components/Header/Header.tsx
+++ b/frontend/src/components/Header/Header.tsx
@@ -4,7 +4,9 @@ import * as Styled from './Header.styles';
 const Header = (): JSX.Element => (
   <Styled.Header>
     <Styled.HeaderLayout>
-      <LogoIcon />
+      <Styled.Logo>
+        <LogoIcon />
+      </Styled.Logo>
       <Styled.Title>찜꽁</Styled.Title>
     </Styled.HeaderLayout>
   </Styled.Header>

--- a/frontend/src/components/Input/Input.styles.ts
+++ b/frontend/src/components/Input/Input.styles.ts
@@ -36,11 +36,12 @@ export const Label = styled.label<LabelProps>`
 export const LabelText = styled.span`
   position: absolute;
   display: inline-block;
-  top: -0.5rem;
+  top: -0.375rem;
   left: 0.75rem;
   padding: 0 0.25rem;
-  font-size: 1rem;
+  font-size: 0.75rem;
   background-color: white;
+  color: ${({ theme }) => theme.gray[500]};
 `;
 
 export const Icon = styled.div`
@@ -56,8 +57,9 @@ export const Icon = styled.div`
 export const Input = styled.input<InputProps>`
   padding: 0.75rem;
   width: 100%;
-  font-size: 1.25rem;
-  border: 1px solid ${({ theme }) => theme.black[400]};
+  font-size: 1rem;
+  border: 1px solid ${({ theme }) => theme.gray[500]};
+  border-radius: 0.125rem;
   background: none;
   outline: none;
   ${({ icon }) => (icon ? 'padding-left: 3rem' : '')};

--- a/frontend/src/components/Input/Input.styles.ts
+++ b/frontend/src/components/Input/Input.styles.ts
@@ -22,7 +22,7 @@ const statusCSS = {
     color: ${({ theme }) => theme.red[500]};
   `,
   default: css`
-    color: inherit;
+    color: ${({ theme }) => theme.gray[500]};
   `,
 };
 
@@ -74,8 +74,5 @@ export const Message = styled.p<MessageProps>`
   ${({ status = 'default' }) => statusCSS[status]};
   font-size: 0.75rem;
   position: absolute;
-  bottom: -1.5rem;
-  left: 0.75rem;
-  height: 1.5rem;
-  line-height: 1.5rem;
+  margin: 0.25rem 0.75rem;
 `;

--- a/frontend/src/pages/Join/Join.styles.ts
+++ b/frontend/src/pages/Join/Join.styles.ts
@@ -8,13 +8,32 @@ export const Container = styled.div`
 
 export const PageTitle = styled.h2`
   font-size: 1.5rem;
-  font-weight: 700;
+  font-weight: 400;
   text-align: center;
-  margin: 1.5rem auto;
+  margin: 2.125rem auto;
 `;
 
 export const Form = styled.form`
+  margin: 3.75rem 0;
+
   label {
-    margin: 2.5rem 0;
+    margin-bottom: 3rem;
+  }
+`;
+
+export const JoinLinkMessage = styled.p`
+  margin: 1rem 0;
+  text-align: center;
+  font-size: 0.75rem;
+  color: ${({ theme }) => theme.gray[500]};
+
+  a {
+    color: ${({ theme }) => theme.primary[400]};
+    text-decoration: none;
+    margin-left: 0.375rem;
+
+    &:hover {
+      font-weight: 700;
+    }
   }
 `;

--- a/frontend/src/pages/Join/Join.tsx
+++ b/frontend/src/pages/Join/Join.tsx
@@ -1,7 +1,7 @@
 import { AxiosError } from 'axios';
 import { FormEventHandler, useEffect, useState } from 'react';
 import { useMutation, useQuery } from 'react-query';
-import { useHistory } from 'react-router-dom';
+import { Link, useHistory } from 'react-router-dom';
 import { postJoin, queryValidateEmail } from 'api/join';
 import Button from 'components/Button/Button';
 import Header from 'components/Header/Header';
@@ -99,8 +99,8 @@ const Join = (): JSX.Element => {
     <>
       <Header />
       <Layout>
-        <Styled.PageTitle>회원가입</Styled.PageTitle>
         <Styled.Container>
+          <Styled.PageTitle>회원가입</Styled.PageTitle>
           <Styled.Form onSubmit={handleSubmitJoinForm}>
             <Input
               type="email"
@@ -111,6 +111,7 @@ const Join = (): JSX.Element => {
               message={emailMessage}
               status={isValidEmail.isSuccess ? 'success' : 'error'}
               required
+              autoFocus
             />
             <Input
               type="password"
@@ -152,6 +153,10 @@ const Join = (): JSX.Element => {
             >
               회원가입
             </Button>
+            <Styled.JoinLinkMessage>
+              이미 회원이신가요?
+              <Link to="/login">로그인하기</Link>
+            </Styled.JoinLinkMessage>
           </Styled.Form>
         </Styled.Container>
       </Layout>

--- a/frontend/src/pages/Join/Join.tsx
+++ b/frontend/src/pages/Join/Join.tsx
@@ -155,7 +155,7 @@ const Join = (): JSX.Element => {
             </Button>
             <Styled.JoinLinkMessage>
               이미 회원이신가요?
-              <Link to="/login">로그인하기</Link>
+              <Link to={PATH.LOGIN}>로그인하기</Link>
             </Styled.JoinLinkMessage>
           </Styled.Form>
         </Styled.Container>

--- a/frontend/src/pages/Login/Login.styles.ts
+++ b/frontend/src/pages/Login/Login.styles.ts
@@ -19,15 +19,6 @@ export const Form = styled.form`
   label {
     margin-bottom: 3rem;
   }
-
-  label:nth-last-of-type(1) {
-    margin-bottom: 0;
-  }
-`;
-
-export const LoginErrorMessage = styled.p`
-  padding: 1.5rem 0;
-  color: ${({ theme }) => theme.red[500]};
 `;
 
 export const JoinLinkMessage = styled.p`

--- a/frontend/src/pages/Login/Login.styles.ts
+++ b/frontend/src/pages/Login/Login.styles.ts
@@ -8,30 +8,33 @@ export const Container = styled.div`
 
 export const PageTitle = styled.h2`
   font-size: 1.5rem;
-  font-weight: 700;
+  font-weight: 400;
   text-align: center;
-  margin: 1.5rem auto;
+  margin: 2.125rem auto;
 `;
 
 export const Form = styled.form`
+  margin: 3.75rem 0;
+
   label {
-    margin: 2.5rem 0;
+    margin-bottom: 3rem;
   }
 
   label:nth-last-of-type(1) {
-    margin: 0;
+    margin-bottom: 0;
   }
 `;
 
 export const LoginErrorMessage = styled.p`
-  height: 3rem;
-  padding: 1.25rem 0 0.75rem;
+  padding: 1.5rem 0;
   color: ${({ theme }) => theme.red[500]};
 `;
 
 export const JoinLinkMessage = styled.p`
   margin: 1rem 0;
   text-align: center;
+  font-size: 0.75rem;
+  color: ${({ theme }) => theme.gray[500]};
 
   a {
     color: ${({ theme }) => theme.primary[400]};

--- a/frontend/src/pages/Login/Login.tsx
+++ b/frontend/src/pages/Login/Login.tsx
@@ -97,7 +97,7 @@ const Login = (): JSX.Element => {
             </Button>
             <Styled.JoinLinkMessage>
               아직 회원이 아니신가요?
-              <Link to="/join">회원가입하기</Link>
+              <Link to={PATH.JOIN}>회원가입하기</Link>
             </Styled.JoinLinkMessage>
           </Styled.Form>
         </Styled.Container>

--- a/frontend/src/pages/Login/Login.tsx
+++ b/frontend/src/pages/Login/Login.tsx
@@ -52,8 +52,8 @@ const Login = (): JSX.Element => {
     <>
       <Header />
       <Layout>
-        <Styled.PageTitle>로그인</Styled.PageTitle>
         <Styled.Container>
+          <Styled.PageTitle>로그인</Styled.PageTitle>
           <Styled.Form onSubmit={handleSubmit}>
             <Input
               type="email"
@@ -76,11 +76,11 @@ const Login = (): JSX.Element => {
             <Button variant="primary" size="large" fullWidth>
               로그인
             </Button>
+            <Styled.JoinLinkMessage>
+              아직 회원이 아니신가요?
+              <Link to="/join">회원가입하기</Link>
+            </Styled.JoinLinkMessage>
           </Styled.Form>
-          <Styled.JoinLinkMessage>
-            아직 회원이 아니신가요?
-            <Link to="/join">회원가입하기</Link>
-          </Styled.JoinLinkMessage>
         </Styled.Container>
       </Layout>
     </>

--- a/frontend/src/types/response.ts
+++ b/frontend/src/types/response.ts
@@ -1,5 +1,10 @@
 import { Reservation, Space } from './common';
 
+export interface ErrorResponse {
+  message?: string;
+  field?: string;
+}
+
 export interface LoginSuccess {
   accessToken: string;
 }


### PR DESCRIPTION
## 구현 기능
- [x] `Input` 컴포넌트 스타일 변경
- [x] `Header` 컴포넌트 스타일 변경
- [x] `Button` 컴포넌트 스타일 변경
- [x] 로그인 및 회원가입 페이지 디자인 변경

![image](https://user-images.githubusercontent.com/2542730/126860988-8231aef5-9ad0-4be1-a2cc-26336e18bb97.png)
![image](https://user-images.githubusercontent.com/2542730/126861019-cf74edb5-339c-43d0-9f09-f88729d1d105.png)

## 논의하고 싶은 내용
- 중간에 나오는 메시지 영역의 공간을 미리 확보하지 않고 메시지 길이에 맞춰서 보이도록 구현되었기 때문에, 메시지가 길 경우 버튼이 아래로 내려가는 문제가 있습니다. 이 정도 UI도 나쁘지는 않다고 생각하는데, 다른 크루들의 생각도 듣고 싶습니다.
  - 메시지의 텍스트 크기도 좀 크다는 인상이 강하네요.
![zk10](https://user-images.githubusercontent.com/2542730/126861116-e50a268e-7350-4129-b195-253c61a644f3.gif)


## 기타
- figma 상의 `Input` 컴포넌트 색상은 #999999인데, 이미 팔레트가 GRAY가 정의되어 있으므로 이를 그대로 이용하여 `GRAY[500]` 색상으로 스타일링했습니다.

Close #209 

