### PR TITLE
fix: depth가 2 이상인 url로 접속 시 manifest, bundle.js를 찾지 못하는 문제

### DIFF
--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -11,6 +11,7 @@ module.exports = () => {
     devtool: isDevelopment ? 'eval-source-map' : 'source-map',
     entry: './src/index.tsx',
     output: {
+      publicPath: '/',
       filename: 'bundle.js',
       path: path.resolve(__dirname, 'dist'),
       clean: true,
@@ -65,6 +66,7 @@ module.exports = () => {
       }),
       new FaviconsWebpackPlugin({
         logo: 'src/assets/images/logo.png',
+        publicPath: '/',
         manifest: 'public/manifest.json',
       }),
     ],


### PR DESCRIPTION
Co-authored-by: JO YUN HO <yujo.dev@gmail.com>
Co-authored-by: Shim MunSeong <puterism.k@gmail.com>

Close #235 

