### PR TITLE
feat: 예약이 예약 가능 시간대에 예약되었는지 검증한다.

### DIFF
--- a/backend/src/main/java/com/woowacourse/zzimkkong/domain/Space.java
+++ b/backend/src/main/java/com/woowacourse/zzimkkong/domain/Space.java
@@ -133,12 +133,12 @@ public class Space {
         return mapImage;
     }
 
-    public boolean isBetweenAvailableTime(LocalDateTime startDateTime, LocalDateTime endDateTime) {
+    public boolean isNotBetweenAvailableTime(LocalDateTime startDateTime, LocalDateTime endDateTime) {
         boolean isEqualOrAfterStartTime = startDateTime.toLocalTime().equals(getAvailableStartTime()) ||
                 startDateTime.toLocalTime().isAfter(getAvailableStartTime());
         boolean isEqualOrBeforeEndTime = endDateTime.toLocalTime().equals(getAvailableEndTime()) ||
                 endDateTime.toLocalTime().isBefore(getAvailableEndTime());
-        return isEqualOrAfterStartTime && isEqualOrBeforeEndTime;
+        return !(isEqualOrAfterStartTime && isEqualOrBeforeEndTime);
     }
 
     public static class Builder {

--- a/backend/src/main/java/com/woowacourse/zzimkkong/domain/Space.java
+++ b/backend/src/main/java/com/woowacourse/zzimkkong/domain/Space.java
@@ -4,6 +4,7 @@ import org.hibernate.annotations.DynamicInsert;
 import org.hibernate.annotations.DynamicUpdate;
 
 import javax.persistence.*;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 
 @DynamicInsert
@@ -130,6 +131,14 @@ public class Space {
 
     public String getMapImage() {
         return mapImage;
+    }
+
+    public boolean isBetweenAvailableTime(LocalDateTime startDateTime, LocalDateTime endDateTime) {
+        boolean isEqualOrAfterStartTime = startDateTime.toLocalTime().equals(getAvailableStartTime()) ||
+                startDateTime.toLocalTime().isAfter(getAvailableStartTime());
+        boolean isEqualOrBeforeEndTime = endDateTime.toLocalTime().equals(getAvailableEndTime()) ||
+                endDateTime.toLocalTime().isBefore(getAvailableEndTime());
+        return isEqualOrAfterStartTime && isEqualOrBeforeEndTime;
     }
 
     public static class Builder {

--- a/backend/src/main/java/com/woowacourse/zzimkkong/exception/reservation/ConflictSpaceSettingException.java
+++ b/backend/src/main/java/com/woowacourse/zzimkkong/exception/reservation/ConflictSpaceSettingException.java
@@ -1,0 +1,11 @@
+package com.woowacourse.zzimkkong.exception.reservation;
+
+import org.springframework.http.HttpStatus;
+
+public class ConflictSpaceSettingException extends ReservationException {
+    private static final String MESSAGE = "공간의 예약조건을 확인해주세요.";
+
+    public ConflictSpaceSettingException() {
+        super(MESSAGE, HttpStatus.BAD_REQUEST, SETTING);
+    }
+}

--- a/backend/src/main/java/com/woowacourse/zzimkkong/exception/reservation/ReservationException.java
+++ b/backend/src/main/java/com/woowacourse/zzimkkong/exception/reservation/ReservationException.java
@@ -8,6 +8,7 @@ public class ReservationException extends ZzimkkongException {
     public static final String START_DATE_TIME = "startDateTime";
     public static final String END_DATE_TIME = "endDateTime";
     public static final String RESERVATION_PASSWORD = "password";
+    public static final String SETTING = "setting";
 
     public ReservationException(final String message, final HttpStatus status, final String field) {
         super(message, status, field);

--- a/backend/src/main/java/com/woowacourse/zzimkkong/service/ReservationService.java
+++ b/backend/src/main/java/com/woowacourse/zzimkkong/service/ReservationService.java
@@ -89,6 +89,10 @@ public abstract class ReservationService {
         LocalDateTime startDateTime = reservationCreateUpdateRequest.getStartDateTime();
         LocalDateTime endDateTime = reservationCreateUpdateRequest.getEndDateTime();
 
+        if (space.isBetweenAvailableTime(startDateTime, endDateTime)) {
+            throw new ConflictSpaceSettingException();
+        }
+
         List<Reservation> reservationsOnDate = getReservations(
                 Collections.singletonList(space.getId()),
                 startDateTime.toLocalDate());
@@ -96,12 +100,6 @@ public abstract class ReservationService {
         excludeTargetReservation(space, reservation, reservationsOnDate);
 
         validateTimeConflicts(startDateTime, endDateTime, reservationsOnDate);
-    }
-
-    private void excludeTargetReservation(final Space space, final Reservation reservation, final List<Reservation> reservationsOnDate) {
-        if (reservation.getSpace().equals(space)) {
-            reservationsOnDate.remove(reservation);
-        }
     }
 
     protected void validateAvailability(
@@ -119,6 +117,12 @@ public abstract class ReservationService {
                 startDateTime.toLocalDate());
 
         validateTimeConflicts(startDateTime, endDateTime, reservationsOnDate);
+    }
+
+    private void excludeTargetReservation(final Space space, final Reservation reservation, final List<Reservation> reservationsOnDate) {
+        if (reservation.getSpace().equals(space)) {
+            reservationsOnDate.remove(reservation);
+        }
     }
 
     private void validateTimeConflicts(

--- a/backend/src/main/java/com/woowacourse/zzimkkong/service/ReservationService.java
+++ b/backend/src/main/java/com/woowacourse/zzimkkong/service/ReservationService.java
@@ -16,7 +16,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.time.LocalTime;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -89,7 +88,7 @@ public abstract class ReservationService {
         LocalDateTime startDateTime = reservationCreateUpdateRequest.getStartDateTime();
         LocalDateTime endDateTime = reservationCreateUpdateRequest.getEndDateTime();
 
-        if (space.isBetweenAvailableTime(startDateTime, endDateTime)) {
+        if (space.isNotBetweenAvailableTime(startDateTime, endDateTime)) {
             throw new ConflictSpaceSettingException();
         }
 
@@ -108,7 +107,7 @@ public abstract class ReservationService {
         LocalDateTime startDateTime = reservationCreateUpdateRequest.getStartDateTime();
         LocalDateTime endDateTime = reservationCreateUpdateRequest.getEndDateTime();
 
-        if (space.isBetweenAvailableTime(startDateTime, endDateTime)) {
+        if (space.isNotBetweenAvailableTime(startDateTime, endDateTime)) {
             throw new ConflictSpaceSettingException();
         }
 

--- a/backend/src/main/java/com/woowacourse/zzimkkong/service/ReservationService.java
+++ b/backend/src/main/java/com/woowacourse/zzimkkong/service/ReservationService.java
@@ -16,7 +16,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.time.ZonedDateTime;
+import java.time.LocalTime;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -109,6 +109,10 @@ public abstract class ReservationService {
             final ReservationCreateUpdateRequest reservationCreateUpdateRequest) {
         LocalDateTime startDateTime = reservationCreateUpdateRequest.getStartDateTime();
         LocalDateTime endDateTime = reservationCreateUpdateRequest.getEndDateTime();
+
+        if (space.isBetweenAvailableTime(startDateTime, endDateTime)) {
+            throw new ConflictSpaceSettingException();
+        }
 
         List<Reservation> reservationsOnDate = getReservations(
                 Collections.singletonList(space.getId()),

--- a/backend/src/test/java/com/woowacourse/zzimkkong/CommonFixture.java
+++ b/backend/src/test/java/com/woowacourse/zzimkkong/CommonFixture.java
@@ -30,8 +30,8 @@ public class CommonFixture {
     public static Map SMALL_HOUSE = new Map(2L, "작은집", MAP_DRAWING_DATA, MAP_IMAGE_URL, POBI);
 
     public static Setting BE_SETTING = new Setting.Builder()
-            .availableStartTime(LocalTime.of(10, 0))
-            .availableEndTime(LocalTime.of(22, 0))
+            .availableStartTime(LocalTime.of(0, 0))
+            .availableEndTime(LocalTime.of(18, 0))
             .reservationTimeUnit(10)
             .reservationMinimumTimeUnit(10)
             .reservationMaximumTimeUnit(1440)
@@ -51,7 +51,7 @@ public class CommonFixture {
             .build();
     public static Setting FE_SETTING = new Setting.Builder()
             .availableStartTime(LocalTime.of(0, 0))
-            .availableEndTime(LocalTime.of(23, 59))
+            .availableEndTime(LocalTime.of(18, 0))
             .reservationTimeUnit(10)
             .reservationMinimumTimeUnit(10)
             .reservationMaximumTimeUnit(1440)
@@ -88,8 +88,8 @@ public class CommonFixture {
             .build();
 
     public static Reservation BE_NEXT_DAY_PM_SIX_TWELVE = new Reservation.Builder()
-            .startTime(TOMORROW.plusDays(1).atTime(18, 0, 0))
-            .endTime(TOMORROW.plusDays(1).atTime(23, 59, 59))
+            .startTime(TOMORROW.plusDays(1).atTime(6, 0, 0))
+            .endTime(TOMORROW.plusDays(1).atTime(12, 0, 0))
             .description("찜꽁 3차 회의")
             .userName(USER_NAME)
             .password("6789")
@@ -97,7 +97,7 @@ public class CommonFixture {
             .build();
 
     public static Reservation FE1_ZERO_ONE = new Reservation.Builder()
-            .startTime(TOMORROW.atStartOfDay())
+            .startTime(TOMORROW_START_TIME)
             .endTime(TOMORROW.atTime(1, 0, 0))
             .description("찜꽁 5차 회의")
             .userName(USER_NAME)

--- a/backend/src/test/java/com/woowacourse/zzimkkong/CommonFixture.java
+++ b/backend/src/test/java/com/woowacourse/zzimkkong/CommonFixture.java
@@ -30,8 +30,8 @@ public class CommonFixture {
     public static Map SMALL_HOUSE = new Map(2L, "작은집", MAP_DRAWING_DATA, MAP_IMAGE_URL, POBI);
 
     public static Setting BE_SETTING = new Setting.Builder()
-            .availableStartTime(LocalTime.of(0, 0))
-            .availableEndTime(LocalTime.of(23, 59))
+            .availableStartTime(LocalTime.of(10, 0))
+            .availableEndTime(LocalTime.of(22, 0))
             .reservationTimeUnit(10)
             .reservationMinimumTimeUnit(10)
             .reservationMaximumTimeUnit(1440)

--- a/backend/src/test/java/com/woowacourse/zzimkkong/controller/ManagerReservationControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/zzimkkong/controller/ManagerReservationControllerTest.java
@@ -58,8 +58,8 @@ public class ManagerReservationControllerTest extends AcceptanceTest {
 
         reservationCreateUpdateWithPasswordRequest = new ReservationCreateUpdateWithPasswordRequest(
                 BE.getId(),
-                TOMORROW_START_TIME.plusHours(1),
-                TOMORROW_START_TIME.plusHours(2),
+                TOMORROW.atTime(12,0),
+                TOMORROW.atTime(13,0),
                 SALLY_PASSWORD,
                 SALLY_NAME,
                 SALLY_DESCRIPTION);
@@ -87,17 +87,6 @@ public class ManagerReservationControllerTest extends AcceptanceTest {
         assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
     }
 
-    @DisplayName("토큰이 검증되지 않는다면, 예약을 등록할 수 없다.")
-    @Test
-    void save_invalidToken() {
-        //given, when
-        String api = "/api/managers/maps/" + LUTHER.getId() + "/reservations";
-        ExtractableResponse<Response> response = saveReservation(invalidToken, api, reservationCreateUpdateWithPasswordRequest);
-
-        //then
-        assertThat(response.statusCode()).isEqualTo(HttpStatus.UNAUTHORIZED.value());
-    }
-
     @DisplayName("올바른 토큰이 주어질 때, 예약을 삭제한다.")
     @Test
     void delete() {
@@ -111,21 +100,6 @@ public class ManagerReservationControllerTest extends AcceptanceTest {
 
         //then
         assertThat(response.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
-    }
-
-    @DisplayName("토큰이 검증되지 않는다면 예약을 삭제할 수 없다.")
-    @Test
-    void delete_invalidToken() {
-        //given
-        String saveApi = "/api/managers/maps/" + LUTHER.getId() + "/reservations";
-        ExtractableResponse<Response> saveResponse = saveReservation(token, saveApi, reservationCreateUpdateWithPasswordRequest);
-        String api = saveResponse.header("location");
-
-        //when
-        ExtractableResponse<Response> response = deleteReservation(invalidToken, api);
-
-        //then
-        assertThat(response.statusCode()).isEqualTo(HttpStatus.UNAUTHORIZED.value());
     }
 
     @DisplayName("map id, space id, 특정 날짜가 주어질 때 해당 맵, 해당 공간, 해당 날짜에 속하는 예약들만 찾아온다")
@@ -154,22 +128,6 @@ public class ManagerReservationControllerTest extends AcceptanceTest {
                 .isEqualTo(expectedResponse);
     }
 
-    @DisplayName("토큰이 검증되지 않는다면 해당 맵, 해당 공간, 해당 날짜에 속하는 예약들을 찾아올 수 없다.")
-    @Test
-    void find_invalidToken() {
-        //given
-        ExtractableResponse<Response> saveResponse = saveExampleReservations();
-        String spaceId = String.valueOf(reservationCreateUpdateWithPasswordRequest.getSpaceId());
-        String api = saveResponse.header("location")
-                .replaceAll("/reservations/[0-9]", "/spaces/" + spaceId + "/reservations");
-
-        //when
-        ExtractableResponse<Response> response = findReservations(invalidToken, api, TOMORROW.toString());
-
-        //then
-        assertThat(response.statusCode()).isEqualTo(HttpStatus.UNAUTHORIZED.value());
-    }
-
     @DisplayName("map id와 특정 날짜가 주어질 때 해당 맵, 해당 날짜의 모든 공간에 대한 예약을 조회한다.")
     @Test
     void findAll() {
@@ -194,21 +152,6 @@ public class ManagerReservationControllerTest extends AcceptanceTest {
                 .ignoringCollectionOrder()
                 .ignoringExpectedNullFields()
                 .isEqualTo(expectedResponse);
-    }
-
-    @DisplayName("토큰이 검증되지 않는다면, 해당 날짜의 모든 공간에 대한 예약을 조회할 수 없다.")
-    @Test
-    void findAll_invalidToken() {
-        //given
-        ExtractableResponse<Response> saveResponse = saveExampleReservations();
-        String api = saveResponse.header("location")
-                .replaceAll("/reservations/[0-9]", "/reservations");
-
-        //when
-        ExtractableResponse<Response> response = findAllReservations(invalidToken, api, TOMORROW.toString());
-
-        //then
-        assertThat(response.statusCode()).isEqualTo(HttpStatus.UNAUTHORIZED.value());
     }
 
     @DisplayName("공간 변경 없는 새로운 예약 정보가 주어지면 예약을 업데이트 한다")
@@ -291,28 +234,6 @@ public class ManagerReservationControllerTest extends AcceptanceTest {
                 .isEqualTo(expectedResponse);
     }
 
-    @DisplayName("올바르지 않은 토큰과 함께 예약 수정 요청을 하면 예약을 수정할 수 없다.")
-    @Test
-    void update_invalidToken() {
-        //given
-        ExtractableResponse<Response> saveResponse = saveExampleReservations();
-        String api = saveResponse.header("location");
-
-        ReservationCreateUpdateRequest reservationCreateUpdateRequestSameSpace = new ReservationCreateUpdateRequest(
-                reservationCreateUpdateWithPasswordRequest.getSpaceId(),
-                TOMORROW.atTime(1, 0, 0),
-                TOMORROW.atTime(2, 30, 0),
-                "sally",
-                "회의입니다."
-        );
-
-        //when
-        ExtractableResponse<Response> updateResponse = updateReservation(invalidToken, api, reservationCreateUpdateRequestSameSpace);
-
-        //then
-        assertThat(updateResponse.statusCode()).isEqualTo(HttpStatus.UNAUTHORIZED.value());
-    }
-
     @DisplayName("올바른 토큰과 함께 예약 수정을 위한 예약 조회 요청 시, 예약에 대한 정보를 반환한다")
     @Test
     void findOne() {
@@ -331,20 +252,6 @@ public class ManagerReservationControllerTest extends AcceptanceTest {
         assertThat(actualResponse).usingRecursiveComparison()
                 .ignoringExpectedNullFields()
                 .isEqualTo(expectedResponse);
-    }
-
-    @DisplayName("올바르지 않은 토큰과 함께 예약 수정을 위한 예약 조회 요청 시, 예약에 대한 정보를 받을 수 없다.")
-    @Test
-    void findOne_invalidToken() {
-        //given
-        ExtractableResponse<Response> saveResponse = saveExampleReservations();
-        String api = saveResponse.header("location");
-
-        //when
-        ExtractableResponse<Response> response = findReservation(invalidToken, api);
-
-        //then
-        assertThat(response.statusCode()).isEqualTo(HttpStatus.UNAUTHORIZED.value());
     }
 
     private ExtractableResponse<Response> saveExampleReservations() {

--- a/backend/src/test/java/com/woowacourse/zzimkkong/controller/SpaceControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/zzimkkong/controller/SpaceControllerTest.java
@@ -35,7 +35,7 @@ public class SpaceControllerTest extends AcceptanceTest {
 
         SettingsRequest settingsRequest = new SettingsRequest(
                 LocalTime.of(0, 0),
-                LocalTime.of(23, 59),
+                LocalTime.of(18, 0),
                 10,
                 10,
                 1440,
@@ -89,8 +89,8 @@ public class SpaceControllerTest extends AcceptanceTest {
     void save_default() {
         // given, when
         SettingsRequest settingsRequest = new SettingsRequest(
-                null,
-                null,
+                LocalTime.of(0,0),
+                LocalTime.of(18,0),
                 null,
                 null,
                 null,
@@ -108,7 +108,7 @@ public class SpaceControllerTest extends AcceptanceTest {
 
         Setting defaultSetting = new Setting.Builder()
                 .availableStartTime(LocalTime.of(0, 0))
-                .availableEndTime(LocalTime.of(23, 59))
+                .availableEndTime(LocalTime.of(18, 0))
                 .reservationTimeUnit(10)
                 .reservationMinimumTimeUnit(10)
                 .reservationMaximumTimeUnit(1440)
@@ -163,7 +163,7 @@ public class SpaceControllerTest extends AcceptanceTest {
         // given
         SettingsRequest feSettingsRequest = new SettingsRequest(
                 LocalTime.of(0, 0),
-                LocalTime.of(23, 59),
+                LocalTime.of(18, 0),
                 10,
                 10,
                 1440,
@@ -216,7 +216,7 @@ public class SpaceControllerTest extends AcceptanceTest {
                 MAP_SVG
         );
 
-        String api = "/api/managers/maps/" + LUTHER.getId() + "/spaces/" + BE.getId();
+        String api = "/api/managers/maps/" + LUTHER.getId() + "/spaces/1";
         ExtractableResponse<Response> response = updateSpace(api, updateSpaceCreateUpdateRequest);
 
         // then
@@ -227,7 +227,7 @@ public class SpaceControllerTest extends AcceptanceTest {
     @Test
     void delete() {
         // given, when
-        String api = "/api/managers/maps/" + LUTHER.getId() + "/spaces/" + BE.getId();
+        String api = "/api/managers/maps/" + LUTHER.getId() + "/spaces/1";
         ExtractableResponse<Response> response = deleteSpace(api);
 
         // then

--- a/backend/src/test/java/com/woowacourse/zzimkkong/domain/SpaceTest.java
+++ b/backend/src/test/java/com/woowacourse/zzimkkong/domain/SpaceTest.java
@@ -11,22 +11,22 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class SpaceTest {
     @Test
-    @DisplayName("예약하려는 시간이 공간의 예약 가능한 시간 내에 있다면 true를 반환한다")
-    void isBetweenAvailableTime() {
+    @DisplayName("예약하려는 시간이 공간의 예약 가능한 시간 내에 있다면 false를 반환한다")
+    void isNotBetweenAvailableTime() {
         LocalDateTime startDateTime = TOMORROW.atTime(10,0);
         LocalDateTime endDateTime = TOMORROW.atTime(22,0);
-        boolean actual = BE.isBetweenAvailableTime(startDateTime, endDateTime);
+        boolean actual = BE.isNotBetweenAvailableTime(startDateTime, endDateTime);
 
-        assertThat(actual).isTrue();
+        assertThat(actual).isFalse();
     }
 
     @Test
-    @DisplayName("예약하려는 시간이 공간의 예약 가능한 시간 외에 있다면 false를 반환한다")
-    void isNotBetweenAvailableTime() {
+    @DisplayName("예약하려는 시간이 공간의 예약 가능한 시간 외에 있다면 true를 반환한다")
+    void isNotBetweenAvailableTimeFail() {
         LocalDateTime startDateTime = TOMORROW.atTime(9,59);
         LocalDateTime endDateTime = TOMORROW.atTime(22,1);
-        boolean actual = BE.isBetweenAvailableTime(startDateTime, endDateTime);
+        boolean actual = BE.isNotBetweenAvailableTime(startDateTime, endDateTime);
 
-        assertThat(actual).isFalse();
+        assertThat(actual).isTrue();
     }
 }

--- a/backend/src/test/java/com/woowacourse/zzimkkong/domain/SpaceTest.java
+++ b/backend/src/test/java/com/woowacourse/zzimkkong/domain/SpaceTest.java
@@ -1,0 +1,32 @@
+package com.woowacourse.zzimkkong.domain;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static com.woowacourse.zzimkkong.CommonFixture.BE;
+import static com.woowacourse.zzimkkong.CommonFixture.TOMORROW;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SpaceTest {
+    @Test
+    @DisplayName("예약하려는 시간이 공간의 예약 가능한 시간 내에 있다면 true를 반환한다")
+    void isBetweenAvailableTime() {
+        LocalDateTime startDateTime = TOMORROW.atTime(10,0);
+        LocalDateTime endDateTime = TOMORROW.atTime(22,0);
+        boolean actual = BE.isBetweenAvailableTime(startDateTime, endDateTime);
+
+        assertThat(actual).isTrue();
+    }
+
+    @Test
+    @DisplayName("예약하려는 시간이 공간의 예약 가능한 시간 외에 있다면 false를 반환한다")
+    void isNotBetweenAvailableTime() {
+        LocalDateTime startDateTime = TOMORROW.atTime(9,59);
+        LocalDateTime endDateTime = TOMORROW.atTime(22,1);
+        boolean actual = BE.isBetweenAvailableTime(startDateTime, endDateTime);
+
+        assertThat(actual).isFalse();
+    }
+}

--- a/backend/src/test/java/com/woowacourse/zzimkkong/domain/SpaceTest.java
+++ b/backend/src/test/java/com/woowacourse/zzimkkong/domain/SpaceTest.java
@@ -14,7 +14,7 @@ public class SpaceTest {
     @DisplayName("예약하려는 시간이 공간의 예약 가능한 시간 내에 있다면 false를 반환한다")
     void isNotBetweenAvailableTime() {
         LocalDateTime startDateTime = TOMORROW.atTime(10,0);
-        LocalDateTime endDateTime = TOMORROW.atTime(22,0);
+        LocalDateTime endDateTime = TOMORROW.atTime(18,0);
         boolean actual = BE.isNotBetweenAvailableTime(startDateTime, endDateTime);
 
         assertThat(actual).isFalse();
@@ -24,7 +24,7 @@ public class SpaceTest {
     @DisplayName("예약하려는 시간이 공간의 예약 가능한 시간 외에 있다면 true를 반환한다")
     void isNotBetweenAvailableTimeFail() {
         LocalDateTime startDateTime = TOMORROW.atTime(9,59);
-        LocalDateTime endDateTime = TOMORROW.atTime(22,1);
+        LocalDateTime endDateTime = TOMORROW.atTime(18,1);
         boolean actual = BE.isNotBetweenAvailableTime(startDateTime, endDateTime);
 
         assertThat(actual).isTrue();

--- a/backend/src/test/java/com/woowacourse/zzimkkong/service/GuestReservationServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/zzimkkong/service/GuestReservationServiceTest.java
@@ -416,8 +416,8 @@ class GuestReservationServiceTest extends ServiceTest {
         //when, then
         assertDoesNotThrow(() -> guestReservationService.updateReservation(1L, reservation.getId(), new ReservationCreateUpdateWithPasswordRequest(
                 1L,
-                TOMORROW_START_TIME.plusHours(20),
-                TOMORROW_START_TIME.plusHours(21),
+                TOMORROW.atTime(10,0),
+                TOMORROW.atTime(11,0),
                 reservation.getPassword(),
                 CHANGED_NAME,
                 CHANGED_DESCRIPTION

--- a/backend/src/test/java/com/woowacourse/zzimkkong/service/ManagerReservationServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/zzimkkong/service/ManagerReservationServiceTest.java
@@ -215,6 +215,30 @@ public class ManagerReservationServiceTest extends ServiceTest {
                 .isInstanceOf(NonMatchingStartAndEndDateException.class);
     }
 
+    @Test
+    @DisplayName("예약 생성 요청 시, 공간의 예약가능 시간이 아니라면 예외가 발생한다.")
+    void saveInvalidTimeSetting() {
+        //given
+        reservationCreateUpdateWithPasswordRequest = new ReservationCreateUpdateWithPasswordRequest(
+                BE.getId(),
+                TOMORROW.atTime(9,59),
+                TOMORROW.atTime(22,1),
+                RESERVATION_PASSWORD,
+                USER_NAME,
+                DESCRIPTION
+        );
+
+        //when
+        saveMock();
+
+        //then
+        assertThatThrownBy(() -> managerReservationService.saveReservation(
+                LUTHER.getId(),
+                reservationCreateUpdateWithPasswordRequest,
+                POBI))
+                .isInstanceOf(ConflictSpaceSettingException.class);
+    }
+
     @DisplayName("예약 생성 요청 시, 이미 겹치는 시간이 존재하면 예외가 발생한다.")
     @ParameterizedTest
     @CsvSource(value = {"-10:10", "2:0", "0:1", "60:59", "-59:-59"}, delimiter = ':')
@@ -603,6 +627,37 @@ public class ManagerReservationServiceTest extends ServiceTest {
                 reservationCreateUpdateRequest,
                 POBI))
                 .isInstanceOf(ImpossibleReservationTimeException.class);
+    }
+
+    @DisplayName("예약 수정 요청 시, 공간의 예약가능 시간이 아니라면 에러가 발생한다.")
+    @Test
+    void updateInvalidTimeSetting() {
+        //given
+        given(maps.existsById(anyLong()))
+                .willReturn(true);
+        given(maps.findById(anyLong()))
+                .willReturn(Optional.of(LUTHER));
+        given(spaces.findById(anyLong()))
+                .willReturn(Optional.of(BE));
+        given(reservations.findById(anyLong()))
+                .willReturn(Optional.of(reservation));
+
+        //when
+        ReservationCreateUpdateRequest reservationCreateUpdateRequest = new ReservationCreateUpdateRequest(
+                BE.getId(),
+                TOMORROW.atTime(9,59),
+                TOMORROW.atTime(22,1),
+                CHANGED_NAME,
+                CHANGED_DESCRIPTION
+        );
+
+        //then
+        assertThatThrownBy(() -> managerReservationService.updateReservation(
+                LUTHER.getId(),
+                1L,
+                reservationCreateUpdateRequest,
+                POBI))
+                .isInstanceOf(ConflictSpaceSettingException.class);
     }
 
     @DisplayName("예약 삭제 요청이 옳다면 삭제한다.")

--- a/backend/src/test/java/com/woowacourse/zzimkkong/service/ManagerReservationServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/zzimkkong/service/ManagerReservationServiceTest.java
@@ -495,8 +495,8 @@ public class ManagerReservationServiceTest extends ServiceTest {
         // when
         ReservationCreateUpdateRequest reservationCreateUpdateRequest = new ReservationCreateUpdateRequest(
                 BE.getId(),
-                TOMORROW_START_TIME.plusHours(20),
-                TOMORROW_START_TIME.plusHours(21),
+                TOMORROW.atTime(10,0),
+                TOMORROW.atTime(11,0),
                 CHANGED_NAME,
                 CHANGED_DESCRIPTION
         );
@@ -645,7 +645,7 @@ public class ManagerReservationServiceTest extends ServiceTest {
         //when
         ReservationCreateUpdateRequest reservationCreateUpdateRequest = new ReservationCreateUpdateRequest(
                 BE.getId(),
-                TOMORROW.atTime(9,59),
+                TOMORROW.atTime(10,0),
                 TOMORROW.atTime(22,1),
                 CHANGED_NAME,
                 CHANGED_DESCRIPTION


### PR DESCRIPTION
## 구현 기능
-  space에 따른 setting이 설정됨에 따라 예약된 시간이 가능한 시간인지 확인합니다.
    availableStartTime, availableEndTime에 따른 검증을 진행합니다.
- 예약 추가와 수정 시 모두 검증하도록 구현했습니다.
- 공간관리자와 예약자 모두 검증하도록 상위클래스인 ReservationService에 구현했습니다.
- 검증로직에 대한 도메인 테스트와 서비스테스트를 작성했습니다.
- 추가된 api가 없으므로 ControllerTest는 작성하지 않았습니다.

## 공유하고 싶은 내용
- 공간 예약조건과 관련해서 다양한 예약조건 검증 시 활용할 수 있도록 ReservationException을 상속하는 `ConflictSpaceSettingException`을 만들었습니다.
- 예약 가능한 시작시간과 끝시간 검증 테스트를 위해 테스트 Fixture의 BE 예약가능 시간을 10~22시로 수정했습니다.

Close #241 

