### PR TITLE
docs: 맵 삭제 API에 대한 restDocs 추가

### DIFF
--- a/backend/src/docs/asciidoc/map.adoc
+++ b/backend/src/docs/asciidoc/map.adoc
@@ -23,3 +23,9 @@ include::{snippets}/map/getAll/http-response.adoc[]
 include::{snippets}/map/put/http-request.adoc[]
 ==== Response
 include::{snippets}/map/put/http-response.adoc[]
+
+=== 맵 삭제
+==== Request
+include::{snippets}/map/delete/http-request.adoc[]
+==== Response
+include::{snippets}/map/delete/http-response.adoc[]


### PR DESCRIPTION
## 구현 기능
- 누락되어 있던 맵 삭제 api에 대한 restDocs를 추가했습니다.

Close #273 

