### PR TITLE
feat: Header 로고 선택 시 메인 화면으로 이동

### DIFF
--- a/frontend/src/components/Header/Header.styles.ts
+++ b/frontend/src/components/Header/Header.styles.ts
@@ -1,3 +1,4 @@
+import { Link } from 'react-router-dom';
 import styled from 'styled-components';
 import Layout from 'components/Layout/Layout';
 import { Z_INDEX } from 'constants/style';
@@ -15,6 +16,14 @@ export const HeaderLayout = styled(Layout)`
   display: flex;
   align-items: center;
   height: 100%;
+`;
+
+export const HeaderLink = styled(Link)`
+  display: flex;
+  align-items: center;
+  text-decoration: none;
+  color: ${({ theme }) => theme.black[400]};
+  cursor: pointer;
 `;
 
 export const Logo = styled.div`

--- a/frontend/src/components/Header/Header.tsx
+++ b/frontend/src/components/Header/Header.tsx
@@ -1,10 +1,14 @@
-import { Link, useParams } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
 import { ReactComponent as LogoIcon } from 'assets/svg/logo.svg';
 import PATH from 'constants/path';
 import * as Styled from './Header.styles';
 
+interface Params {
+  publicMapId?: string;
+}
+
 const Header = (): JSX.Element => {
-  const params = useParams<{ publicMapId: string }>();
+  const params = useParams<Params>();
   const publicMapId = params?.publicMapId;
 
   return (

--- a/frontend/src/components/Header/Header.tsx
+++ b/frontend/src/components/Header/Header.tsx
@@ -1,15 +1,24 @@
+import { Link, useParams } from 'react-router-dom';
 import { ReactComponent as LogoIcon } from 'assets/svg/logo.svg';
+import PATH from 'constants/path';
 import * as Styled from './Header.styles';
 
-const Header = (): JSX.Element => (
-  <Styled.Header>
-    <Styled.HeaderLayout>
-      <Styled.Logo>
-        <LogoIcon />
-      </Styled.Logo>
-      <Styled.Title>찜꽁</Styled.Title>
-    </Styled.HeaderLayout>
-  </Styled.Header>
-);
+const Header = (): JSX.Element => {
+  const params = useParams<{ publicMapId: string }>();
+  const publicMapId = params?.publicMapId;
+
+  return (
+    <Styled.Header>
+      <Styled.HeaderLayout>
+        <Styled.HeaderLink to={publicMapId ? `/guest/${publicMapId}` : PATH.MANAGER_MAIN}>
+          <Styled.Logo>
+            <LogoIcon />
+          </Styled.Logo>
+          <Styled.Title>찜꽁</Styled.Title>
+        </Styled.HeaderLink>
+      </Styled.HeaderLayout>
+    </Styled.Header>
+  );
+};
 
 export default Header;


### PR DESCRIPTION
## 구현 기능
- Header 컴포넌트의 로고 선택 시 메인화면으로 이동
  - 주소에 `:publicMapId`가 존재한다면 '/guest/:publicMapId'로 이동
  - 아니라면 '/'로 이동

Close #341 

