### PR TITLE
refactor: 중복되는 라우터 제거

### DIFF
--- a/frontend/src/constants/routes.tsx
+++ b/frontend/src/constants/routes.tsx
@@ -28,14 +28,6 @@ export const PUBLIC_ROUTES: Route[] = [
     component: <ManagerJoin />,
   },
   {
-    path: PATH.MANAGER_MAP_CREATE,
-    component: <ManagerMapCreate />,
-  },
-  {
-    path: PATH.MANAGER_MAP_EDIT,
-    component: <ManagerMapCreate />,
-  },
-  {
     path: PATH.GUEST_MAIN,
     component: <GuestMain />,
   },
@@ -57,6 +49,11 @@ export const PRIVATE_ROUTES: PrivateRoute[] = [
   },
   {
     path: PATH.MANAGER_MAP_CREATE,
+    component: <ManagerMapCreate />,
+    redirectPath: PATH.MANAGER_LOGIN,
+  },
+  {
+    path: PATH.MANAGER_MAP_EDIT,
     component: <ManagerMapCreate />,
     redirectPath: PATH.MANAGER_LOGIN,
   },


### PR DESCRIPTION
## 구현 기능
- [x] 중복되는 라우터 제거

## 공유하고 싶은 내용

- `PUBLIC_ROUTE`, `PRIVATE_ROUTE` 에 `/map/create` 가 중복되어 들어가 있어 제거했습니다.

Close #384 

