### PR TITLE
fix: 예약자 메인 페이지에서 공간 관리자의 API가 호출되고 있던 문제 수정

### DIFF
--- a/frontend/src/api/guestSpace.ts
+++ b/frontend/src/api/guestSpace.ts
@@ -3,16 +3,16 @@ import { QueryFunction, QueryKey } from 'react-query';
 import { QuerySpacesSuccess } from 'types/response';
 import api from './api';
 
-export interface QuerySpacesParams {
+export interface QueryGuestSpacesParams {
   mapId: number;
 }
 
-export const querySpaces: QueryFunction<
+export const queryGuestSpaces: QueryFunction<
   AxiosResponse<QuerySpacesSuccess>,
-  [QueryKey, QuerySpacesParams]
+  [QueryKey, QueryGuestSpacesParams]
 > = ({ queryKey }) => {
   const [, data] = queryKey;
   const { mapId } = data;
 
-  return api.get(`/managers/maps/${mapId}/spaces`);
+  return api.get(`/guests/maps/${mapId}/spaces`);
 };

--- a/frontend/src/hooks/useGuestReservations.ts
+++ b/frontend/src/hooks/useGuestReservations.ts
@@ -12,6 +12,6 @@ const useGuestReservations = <TData = AxiosResponse<QueryGuestReservationsSucces
     [QueryKey, QuerySpaceReservationsParams]
   >
 ): UseQueryResult<TData, AxiosError<ErrorResponse>> =>
-  useQuery(['getReservations', { mapId, spaceId, date }], queryGuestReservations, options);
+  useQuery(['getGuestReservations', { mapId, spaceId, date }], queryGuestReservations, options);
 
 export default useGuestReservations;

--- a/frontend/src/hooks/useGuestSpaces.ts
+++ b/frontend/src/hooks/useGuestSpaces.ts
@@ -1,17 +1,17 @@
 import { AxiosError, AxiosResponse } from 'axios';
 import { QueryKey, useQuery, UseQueryOptions, UseQueryResult } from 'react-query';
-import { querySpaces, QuerySpacesParams } from 'api/space';
+import { queryGuestSpaces, QueryGuestSpacesParams } from 'api/guestSpace';
 import { ErrorResponse, QuerySpacesSuccess } from 'types/response';
 
-const useSpaces = <TData = AxiosResponse<QuerySpacesSuccess>>(
-  { mapId }: QuerySpacesParams,
+const useGuestSpaces = <TData = AxiosResponse<QuerySpacesSuccess>>(
+  { mapId }: QueryGuestSpacesParams,
   options?: UseQueryOptions<
     AxiosResponse<QuerySpacesSuccess>,
     AxiosError<ErrorResponse>,
     TData,
-    [QueryKey, QuerySpacesParams]
+    [QueryKey, QueryGuestSpacesParams]
   >
 ): UseQueryResult<TData, AxiosError<ErrorResponse>> =>
-  useQuery(['getSpaces', { mapId }], querySpaces, options);
+  useQuery(['getGuestSpaces', { mapId }], queryGuestSpaces, options);
 
-export default useSpaces;
+export default useGuestSpaces;

--- a/frontend/src/pages/GuestMap/GuestMap.tsx
+++ b/frontend/src/pages/GuestMap/GuestMap.tsx
@@ -18,8 +18,8 @@ import MESSAGE from 'constants/message';
 import PALETTE from 'constants/palette';
 import useGuestMap from 'hooks/useGuestMap';
 import useGuestReservations from 'hooks/useGuestReservations';
+import useGuestSpaces from 'hooks/useGuestSpaces';
 import useInput from 'hooks/useInput';
-import useSpaces from 'hooks/useSpaces';
 import { Area, MapDrawing, MapItem, Reservation, ScrollPosition, Space } from 'types/common';
 import { ErrorResponse } from 'types/response';
 import { formatDate } from 'utils/datetime';
@@ -81,7 +81,7 @@ const GuestMap = (): JSX.Element => {
     return result;
   }, [spaceList]);
 
-  const getSpaces = useSpaces(
+  const getSpaces = useGuestSpaces(
     { mapId: map?.mapId as number },
     {
       enabled: map?.mapId !== undefined,


### PR DESCRIPTION
## 구현 기능
- 예약자 메인 페이지에서 공간 관리자의 API가 호출되고 있던 문제 수정
- 파일 네이밍 컨벤션에 맞추어 File rename함
  - `useSpaces.ts` -> `useGuestSpaces.ts`
  - `api/space.ts` -> `api/guestSpace.ts`

Close #394 

