### PR TITLE
feat: 공간 편집, 맵 편집에서 메인 페이지로 이동 시 편집하던 맵이 자동 선택되는 기능

### DIFF
--- a/frontend/src/constants/message.ts
+++ b/frontend/src/constants/message.ts
@@ -25,6 +25,10 @@ const MESSAGE = {
       '정보를 불러오는 중에 문제가 발생했습니다. 잠시 후에 다시 시도해주세요.',
     UNEXPECTED_MAP_DELETE_ERROR:
       '맵을 삭제하는 중에 문제가 발생했습니다. 잠시 후에 다시 시도해주세요.',
+    MAP_DELETED: '맵이 삭제되었습니다.',
+    SELECT_MAP: '맵을 선택해주세요.',
+    COPIED_SHARE_LINK: '맵의 공유링크가 클립보드에 복사되었습니다!',
+    UNEXPECTED_COPY_SHARE_LINK: '공유링크를 복사하는 데 문제가 발생했습니다.',
   },
   MANAGER_SPACE: {
     GET_UNEXPECTED_ERROR:

--- a/frontend/src/hooks/useListenManagerMainState.ts
+++ b/frontend/src/hooks/useListenManagerMainState.ts
@@ -1,0 +1,23 @@
+import { useEffect } from 'react';
+import { useHistory } from 'react-router-dom';
+import PATH from 'constants/path';
+
+interface Props {
+  mapId?: number | null;
+}
+
+const useListenManagerMainState = ({ mapId }: Props): void => {
+  const history = useHistory();
+
+  useEffect(
+    () =>
+      history.listen((location) => {
+        if (location.pathname === PATH.MANAGER_MAIN) {
+          location.state = { mapId };
+        }
+      }),
+    [history, mapId]
+  );
+};
+
+export default useListenManagerMainState;

--- a/frontend/src/pages/ManagerMain/ManagerMain.tsx
+++ b/frontend/src/pages/ManagerMain/ManagerMain.tsx
@@ -1,7 +1,7 @@
 import { AxiosError } from 'axios';
 import { useEffect, useMemo, useState } from 'react';
 import { useMutation } from 'react-query';
-import { useHistory } from 'react-router-dom';
+import { useHistory, useLocation } from 'react-router-dom';
 import { deleteMap } from 'api/managerMap';
 import { ReactComponent as DeleteIcon } from 'assets/svg/delete.svg';
 import { ReactComponent as EditIcon } from 'assets/svg/edit.svg';
@@ -24,14 +24,21 @@ import useManagerMaps from 'hooks/useManagerMaps';
 import useManagerReservations from 'hooks/useManagerReservations';
 import { ErrorResponse, MapItemResponse } from 'types/response';
 import { formatDate } from 'utils/datetime';
+import { isNullish } from 'utils/type';
 import * as Styled from './ManagerMain.styles';
+
+interface LocationState {
+  mapId?: number | null;
+}
 
 const ManagerMain = (): JSX.Element => {
   const history = useHistory();
+  const location = useLocation<LocationState>();
 
   const [date, setDate] = useState(new Date());
   const [open, setOpen] = useState(false);
-  const [selectedMapId, setSelectedMapId] = useState<number | null>(null);
+
+  const [selectedMapId, setSelectedMapId] = useState<number | null>(location.state?.mapId ?? null);
   const [selectedMapName, setSelectedMapName] = useState('');
 
   const onRequestError = (error: AxiosError<ErrorResponse>) => {
@@ -51,7 +58,7 @@ const ManagerMain = (): JSX.Element => {
       date: formatDate(date),
     },
     {
-      enabled: selectedMapId ? true : false,
+      enabled: !(selectedMapId === null),
       onError: onRequestError,
     }
   );
@@ -122,9 +129,19 @@ const ManagerMain = (): JSX.Element => {
   };
 
   useEffect(() => {
-    setSelectedMapId(maps.length ? maps[0].mapId : null);
-    setSelectedMapName(maps.length ? maps[0].mapName : '');
-  }, [maps]);
+    const prevMapId = location.state?.mapId ?? null;
+    const prevMapName = maps.find(({ mapId }) => mapId === prevMapId)?.mapName ?? '';
+
+    if (isNullish(prevMapId)) {
+      setSelectedMapId(maps.length ? maps[0].mapId : null);
+      setSelectedMapName(maps.length ? maps[0].mapName : '');
+
+      return;
+    }
+
+    setSelectedMapId(prevMapId);
+    setSelectedMapName(prevMapName);
+  }, [location.state?.mapId, maps]);
 
   return (
     <>

--- a/frontend/src/pages/ManagerMain/ManagerMain.tsx
+++ b/frontend/src/pages/ManagerMain/ManagerMain.tsx
@@ -67,7 +67,7 @@ const ManagerMain = (): JSX.Element => {
 
   const removeMap = useMutation(deleteMap, {
     onSuccess: () => {
-      alert('맵이 삭제 되었습니다.');
+      alert(MESSAGE.MANAGER_MAIN.MAP_DELETED);
     },
 
     onError: (error: AxiosError<ErrorResponse>) => {
@@ -99,7 +99,7 @@ const ManagerMain = (): JSX.Element => {
 
   const handleCopyLink = () => {
     if (selectedMapId === null) {
-      alert('맵을 선택해주세요.');
+      alert(MESSAGE.MANAGER_MAIN.SELECT_MAP);
 
       return;
     }
@@ -107,10 +107,10 @@ const ManagerMain = (): JSX.Element => {
     navigator.clipboard
       .writeText(`${window.location.origin}/guest/${getSelectedSharingMapId()}`)
       .then(() => {
-        alert('맵의 공유링크가 클립보드에 복사되었습니다!');
+        alert(MESSAGE.MANAGER_MAIN.COPIED_SHARE_LINK);
       })
       .catch(() => {
-        alert('공유링크를 복사하는데 문제가 발생했습니다.');
+        alert(MESSAGE.MANAGER_MAIN.UNEXPECTED_COPY_SHARE_LINK);
       });
   };
 

--- a/frontend/src/pages/ManagerMapCreate/ManagerMapCreate.tsx
+++ b/frontend/src/pages/ManagerMapCreate/ManagerMapCreate.tsx
@@ -30,6 +30,7 @@ import MESSAGE from 'constants/message';
 import PALETTE from 'constants/palette';
 import PATH, { HREF } from 'constants/path';
 import useInput from 'hooks/useInput';
+import useListenManagerMainState from 'hooks/useListenManagerMainState';
 import useManagerMap from 'hooks/useManagerMap';
 import useManagerSpaces from 'hooks/useManagerSpaces';
 import {
@@ -58,6 +59,8 @@ const ManagerMapCreate = (): JSX.Element => {
   const params = useParams<Params>();
   const mapId = params?.mapId;
   const isEdit = !!mapId;
+
+  useListenManagerMainState({ mapId: Number(mapId) });
 
   const [mapName, onChangeMapName, setMapName] = useInput('');
 

--- a/frontend/src/pages/ManagerSpaceEdit/ManagerSpaceEdit.tsx
+++ b/frontend/src/pages/ManagerSpaceEdit/ManagerSpaceEdit.tsx
@@ -30,6 +30,7 @@ import MESSAGE from 'constants/message';
 import PALETTE from 'constants/palette';
 import PATH from 'constants/path';
 import useInput from 'hooks/useInput';
+import useListenManagerMainState from 'hooks/useListenManagerMainState';
 import useManagerMap from 'hooks/useManagerMap';
 import useManagerSpaces from 'hooks/useManagerSpaces';
 import useToggle from 'hooks/useToggle';
@@ -60,6 +61,8 @@ const ManagerSpaceEdit = (): JSX.Element => {
   const editorRef = useRef<HTMLDivElement | null>(null);
   const spaceNameRef = useRef<HTMLInputElement | null>(null);
   const { mapId } = useParams<Params>();
+
+  useListenManagerMainState({ mapId: Number(mapId) });
 
   const todayDate = formatDate(new Date());
   const initialStartTime = formatTimeWithSecond(new Date(`${todayDate}T07:00:00`));

--- a/frontend/src/utils/type.ts
+++ b/frontend/src/utils/type.ts
@@ -1,0 +1,1 @@
+export const isNullish = (value: unknown): boolean => value === null || value === undefined;


### PR DESCRIPTION
## 구현 기능
- 공간 편집, 맵 편집에서 메인 페이지로 이동 시 편집하던 맵이 자동 선택되도록 수정 구현
- 공간 관리자 메인 페이지에서 상수화되지 않은 alert message 상수화 및 적용

![zk31](https://user-images.githubusercontent.com/2542730/130738695-1a6eaeb7-f257-4c52-a954-1163d3058147.gif)

Close #424 
