### PR TITLE
fix: 회원가입 실패 시 서버에서 오는 메시지를 보여주지 않는 문제 및 기타 버그 수정

### DIFF
--- a/frontend/src/pages/ManagerJoin/ManagerJoin.tsx
+++ b/frontend/src/pages/ManagerJoin/ManagerJoin.tsx
@@ -68,6 +68,7 @@ const ManagerJoin = (): JSX.Element => {
 
     if (password !== passwordConfirm) {
       alert(MESSAGE.JOIN.INVALID_PASSWORD_CONFIRM);
+
       return;
     }
 


### PR DESCRIPTION
## 수정 사항
- 회원가입 실패 시 서버에서 오는 메시지를 보여주지 않는 문제를 수정했습니다.
- 회원가입에서 비밀번호와 비밀번호 확인이 서로 달라도 회원가입이 진행되는 문제를 수정했습니다.

Close #431

