### PR TITLE
feat: 공간목록 오름차순, 내림차순 정렬

### DIFF
--- a/frontend/src/components/Panel/Panel.styles.ts
+++ b/frontend/src/components/Panel/Panel.styles.ts
@@ -6,6 +6,14 @@ interface PanelProps {
 
 export const Panel = styled.div<PanelProps>`
   margin: ${({ expanded }) => (expanded ? '1.5rem 0' : '0')};
+
+  &:first-of-type {
+    margin-top: 0;
+  }
+
+  &:last-of-type {
+    margin-bottom: 0;
+  }
 `;
 
 export const Title = styled.p`

--- a/frontend/src/components/Panel/Panel.tsx
+++ b/frontend/src/components/Panel/Panel.tsx
@@ -1,10 +1,10 @@
-import { PropsWithChildren, useState } from 'react';
+import { HTMLAttributes, PropsWithChildren, useState } from 'react';
 import * as Styled from './Panel.styles';
 import PanelContent from './PanelContent';
 import PanelContext from './PanelContext';
 import PanelHeader from './PanelHeader';
 
-export interface Props {
+export interface Props extends HTMLAttributes<HTMLDivElement> {
   expandable?: boolean;
   initialExpanded?: boolean;
 }

--- a/frontend/src/pages/GuestMap/GuestMap.tsx
+++ b/frontend/src/pages/GuestMap/GuestMap.tsx
@@ -200,6 +200,7 @@ const GuestMap = (): JSX.Element => {
                         points={element.points.join(' ')}
                         stroke={element.stroke}
                         strokeWidth={EDITOR.STROKE_WIDTH}
+                        strokeLinecap="round"
                       />
                     ) : (
                       <rect

--- a/frontend/src/pages/ManagerMain/ManagerMain.styles.ts
+++ b/frontend/src/pages/ManagerMain/ManagerMain.styles.ts
@@ -65,6 +65,11 @@ export const ReservationsContainer = styled.div`
 export const SpacesOrderButton = styled(Button)`
   display: block;
   margin-left: auto;
+  color: ${({ theme }) => theme.gray[400]};
+
+  &:hover {
+    color: ${({ theme }) => theme.gray[500]};
+  }
 `;
 
 export const SpaceList = styled.ul``;

--- a/frontend/src/pages/ManagerMain/ManagerMain.styles.ts
+++ b/frontend/src/pages/ManagerMain/ManagerMain.styles.ts
@@ -2,6 +2,7 @@ import { Link } from 'react-router-dom';
 import styled from 'styled-components';
 import { ReactComponent as LinkIcon } from 'assets/svg/link.svg';
 import { ReactComponent as Plus } from 'assets/svg/plus.svg';
+import Button from 'components/Button/Button';
 import IconButton from 'components/IconButton/IconButton';
 
 export const PrimaryLinkIcon = styled(LinkIcon)`
@@ -57,11 +58,16 @@ export const PanelMessage = styled.p`
   color: ${({ theme }) => theme.gray[500]};
 `;
 
-export const SpaceList = styled.ul`
-  margin: 3rem 0;
+export const ReservationsContainer = styled.div`
+  margin: 2rem 0 5rem;
 `;
 
-export const SpaceReservationWrapper = styled.div``;
+export const SpacesOrderButton = styled(Button)`
+  display: block;
+  margin-left: auto;
+`;
+
+export const SpaceList = styled.ul``;
 
 export const SpaceWrapper = styled.div`
   margin: 2.5rem 0;

--- a/frontend/src/pages/ManagerMain/ManagerMain.tsx
+++ b/frontend/src/pages/ManagerMain/ManagerMain.tsx
@@ -9,7 +9,6 @@ import { ReactComponent as EditIcon } from 'assets/svg/edit.svg';
 import { ReactComponent as MapEditorIcon } from 'assets/svg/map-editor.svg';
 import { ReactComponent as MenuIcon } from 'assets/svg/menu.svg';
 import { ReactComponent as SpaceEditorIcon } from 'assets/svg/space-editor.svg';
-import Button from 'components/Button/Button';
 import DateInput from 'components/DateInput/DateInput';
 import Drawer from 'components/Drawer/Drawer';
 import Header from 'components/Header/Header';
@@ -23,7 +22,7 @@ import MESSAGE from 'constants/message';
 import PATH, { HREF } from 'constants/path';
 import useManagerMaps from 'hooks/useManagerMaps';
 import useManagerReservations from 'hooks/useManagerReservations';
-import { Reservation } from 'types/common';
+import { Order, Reservation } from 'types/common';
 import { ErrorResponse, MapItemResponse } from 'types/response';
 import { formatDate } from 'utils/datetime';
 import { isNullish } from 'utils/type';
@@ -32,8 +31,6 @@ import * as Styled from './ManagerMain.styles';
 interface LocationState {
   mapId?: number;
 }
-
-type SpacesOrder = 'ascending' | 'descending';
 
 const ManagerMain = (): JSX.Element => {
   const history = useHistory();
@@ -44,7 +41,7 @@ const ManagerMain = (): JSX.Element => {
 
   const [selectedMapId, setSelectedMapId] = useState<number | null>(location.state?.mapId ?? null);
   const [selectedMapName, setSelectedMapName] = useState('');
-  const [spacesOrder, setSpacesOrder] = useState<SpacesOrder>('ascending');
+  const [spacesOrder, setSpacesOrder] = useState<Order>('ascending');
 
   const onRequestError = (error: AxiosError<ErrorResponse>) => {
     alert(error.response?.data?.message ?? MESSAGE.MANAGER_MAIN.UNEXPECTED_GET_DATA_ERROR);

--- a/frontend/src/types/common.ts
+++ b/frontend/src/types/common.ts
@@ -2,6 +2,8 @@ import { DrawingAreaShape } from 'constants/editor';
 
 export type Color = string;
 
+export type Order = 'ascending' | 'descending';
+
 export interface Coordinate {
   x: number;
   y: number;


### PR DESCRIPTION
## 구현 기능
- 공간관리자 공간목록 정렬
  - 색상으로 우선 정렬
  - 공간 이름 오름차순/내림차순(기본값: 오름차순)
- 예약 페이지 맵의 선 요소 끝을 둥글게 변경

![image](https://user-images.githubusercontent.com/45230497/131443744-7889039f-4732-4976-9dcb-c48ba06ece61.png)

![image](https://user-images.githubusercontent.com/45230497/131443758-01b719b3-82ae-43b2-84f4-0814faf5eba3.png)


Close #468 
Close #474
