### PR TITLE
chore: DEPLOY_ENV 추가

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -22,9 +22,11 @@
     }
   ],
   "scripts": {
-    "prod": "cross-env NODE_ENV=production webpack serve",
-    "start": "cross-env NODE_ENV=development webpack serve",
-    "build": "cross-env NODE_ENV=production webpack",
+    "prod": "cross-env NODE_ENV=production DEPLOY_ENV=production webpack serve",
+    "prod:dev": "cross-env NODE_ENV=production DEPLOY_ENV=development webpack serve",
+    "start": "cross-env NODE_ENV=development DEPLOY_ENV=development webpack serve",
+    "build": "cross-env NODE_ENV=production DEPLOY_ENV=production webpack",
+    "build:dev": "cross-env NODE_ENV=production DEPLOY_ENV=development webpack",
     "storybook": "start-storybook -s ./src/assets -p 6006",
     "build-storybook": "build-storybook -s ./src/assets",
     "test": "jest --watch --passWithNoTests",

--- a/frontend/src/api/api.ts
+++ b/frontend/src/api/api.ts
@@ -7,7 +7,7 @@ import { ErrorResponse } from 'types/response';
 import { getLocalStorageItem } from 'utils/localStorage';
 
 const api = axios.create({
-  baseURL: process.env.NODE_ENV !== 'production' ? BASE_URL.DEV : BASE_URL.PROD,
+  baseURL: process.env.DEPLOY_ENV !== 'production' ? BASE_URL.DEV : BASE_URL.PROD,
   headers: {
     'Content-type': 'application/json',
   },

--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -2,6 +2,7 @@ const path = require('path');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const FaviconsWebpackPlugin = require('favicons-webpack-plugin');
 const TsconfigPathsPlugin = require('tsconfig-paths-webpack-plugin');
+const webpack = require('webpack');
 
 module.exports = () => {
   const isDevelopment = process.env.NODE_ENV !== 'production';
@@ -68,6 +69,10 @@ module.exports = () => {
         logo: 'src/assets/images/logo.png',
         publicPath: '/',
         manifest: 'public/manifest.json',
+      }),
+      new webpack.DefinePlugin({
+        'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV),
+        'process.env.DEPLOY_ENV': JSON.stringify(process.env.DEPLOY_ENV),
       }),
     ],
   };


### PR DESCRIPTION
## 구현 기능
- `process.env`에 `DEPLOY_ENV`를 추가했습니다.
  - DEPLOY_ENV : 배포 환경을 설정합니다. (개발용 배포 환경 : `development` / 라이브 배포 환경 : `production`)
  - 기존의 NODE_ENV는 Webpack mode를 설정하는 용도입니다.

## 기타
- 배포 환경이 개발용 배포 환경인 `dev.zzimkkong.com`과 라이브 배포 환경인 `zzimkkong.com`으로 나눠짐에 따라 API baseURL도 이에 맞추어 변경할 수 있도록 `DEPLOY_ENV`를 추가하였습니다.
- 이에 맞추어 package.json에 script도 추가해두었습니다.
- dev branch에서 젠킨스 빌드 시 `yarn build:dev`로 동작하도록 설정을 변경해두었습니다.

## 논의하고 싶은 내용
- 현재 PR에서 젠킨스 빌드 테스트 시 무조건 `yarn build`로 동작하는데, `dev` 브랜치로 머지하는 PR과 `main` 브랜치로 머지하는 PR이 구별되었으면 좋겠습니다. PR에서는 테스트만 하기 때문에 `yarn build`와 `yarn build:dev` 간에 큰 차이는 없습니다.

Close #470

