### PR TITLE
feat: 프리셋 전체조회 시 id값 같이 반환

### DIFF
--- a/backend/src/main/java/com/woowacourse/zzimkkong/controller/MemberController.java
+++ b/backend/src/main/java/com/woowacourse/zzimkkong/controller/MemberController.java
@@ -27,7 +27,6 @@ public class MemberController {
     public MemberController(final MemberService memberService, final PresetService presetService) {
         this.memberService = memberService;
         this.presetService = presetService;
-
     }
 
     @PostMapping

--- a/backend/src/main/java/com/woowacourse/zzimkkong/dto/member/PresetFindResponse.java
+++ b/backend/src/main/java/com/woowacourse/zzimkkong/dto/member/PresetFindResponse.java
@@ -11,9 +11,11 @@ import java.time.LocalTime;
 @Getter
 @NoArgsConstructor
 public class PresetFindResponse extends SettingResponse {
+    private Long id;
     private String name;
 
     private PresetFindResponse(
+            final Long id,
             final LocalTime availableStartTime,
             final LocalTime availableEndTime,
             final Integer reservationTimeUnit,
@@ -23,6 +25,7 @@ public class PresetFindResponse extends SettingResponse {
             final String enabledDayOfWeek,
             final String name) {
         super(availableStartTime, availableEndTime, reservationTimeUnit, reservationMinimumTimeUnit, reservationMaximumTimeUnit, reservationEnable, enabledDayOfWeek);
+        this.id = id;
         this.name = name;
     }
 
@@ -30,6 +33,7 @@ public class PresetFindResponse extends SettingResponse {
         Setting setting = preset.getSetting();
 
         return new PresetFindResponse(
+                preset.getId(),
                 setting.getAvailableStartTime(),
                 setting.getAvailableEndTime(),
                 setting.getReservationTimeUnit(),

--- a/backend/src/test/java/com/woowacourse/zzimkkong/controller/MemberControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/zzimkkong/controller/MemberControllerTest.java
@@ -114,7 +114,7 @@ class MemberControllerTest extends AcceptanceTest {
 
         //then
         assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
-        assertThat(actual).usingRecursiveComparison().isEqualTo(expected);
+        assertThat(actual).usingRecursiveComparison().ignoringExpectedNullFields().isEqualTo(expected);
     }
 
     @Test


### PR DESCRIPTION
## 구현 기능
- 프리셋 전체조회 시 preset 의 id 값 같이 반환하도록 응답에 추가했습니다.

![image](https://user-images.githubusercontent.com/56033755/131777722-acab5d33-348d-438d-bddd-18ef0f830631.png)

Close #479 

