### PR TITLE
feat: 공간 예약 조건 프리셋 기능 구현

### DIFF
--- a/frontend/src/api/presets.ts
+++ b/frontend/src/api/presets.ts
@@ -1,0 +1,19 @@
+import { AxiosResponse } from 'axios';
+import { QueryFunction, QueryKey } from 'react-query';
+import { ReservationSettings } from 'types/common';
+import { QueryPresetsSuccess } from 'types/response';
+import api from './api';
+
+export interface PostPresetParams {
+  name: string;
+  settingsRequest: ReservationSettings;
+}
+
+export const queryPresets: QueryFunction<AxiosResponse<QueryPresetsSuccess>, [QueryKey]> = () =>
+  api.get(`/members/presets`);
+
+export const postPreset = ({
+  name,
+  settingsRequest,
+}: PostPresetParams): Promise<AxiosResponse<never>> =>
+  api.post(`/members/presets`, { name, settingsRequest });

--- a/frontend/src/api/presets.ts
+++ b/frontend/src/api/presets.ts
@@ -9,11 +9,18 @@ export interface PostPresetParams {
   settingsRequest: ReservationSettings;
 }
 
+export interface DeletePresetParams {
+  id: number;
+}
+
 export const queryPresets: QueryFunction<AxiosResponse<QueryPresetsSuccess>, [QueryKey]> = () =>
-  api.get(`/members/presets`);
+  api.get('/members/presets');
 
 export const postPreset = ({
   name,
   settingsRequest,
 }: PostPresetParams): Promise<AxiosResponse<never>> =>
-  api.post(`/members/presets`, { name, settingsRequest });
+  api.post('/members/presets', { name, settingsRequest });
+
+export const deletePreset = ({ id }: DeletePresetParams): Promise<AxiosResponse<never>> =>
+  api.delete(`/members/presets/${id}`);

--- a/frontend/src/components/Modal/Modal.tsx
+++ b/frontend/src/components/Modal/Modal.tsx
@@ -16,14 +16,14 @@ const Modal = ({
   onClose,
   children,
 }: PropsWithChildren<Props>): JSX.Element => {
-  const handleDimmedClick: MouseEventHandler<HTMLDivElement> = ({ target, currentTarget }) => {
+  const handleMouseDownOverlay: MouseEventHandler<HTMLDivElement> = ({ target, currentTarget }) => {
     if (isClosableDimmer && target === currentTarget) {
       onClose();
     }
   };
 
   return (
-    <Styled.Overlay open={open} onClick={handleDimmedClick}>
+    <Styled.Overlay open={open} onMouseDown={handleMouseDownOverlay}>
       <Styled.Modal>
         {open && showCloseButton && (
           <Styled.CloseButton onClick={onClose}>

--- a/frontend/src/components/Select/Select.styles.ts
+++ b/frontend/src/components/Select/Select.styles.ts
@@ -44,6 +44,10 @@ export const ListBoxButton = styled.button`
   }
 `;
 
+export const ListBoxLabel = styled.span`
+  color: ${({ theme }) => theme.gray[400]};
+`;
+
 export const OptionChildrenWrapper = styled.div`
   flex: 1;
 `;

--- a/frontend/src/components/Select/Select.tsx
+++ b/frontend/src/components/Select/Select.tsx
@@ -1,4 +1,4 @@
-import { useState, ReactNode } from 'react';
+import { useState, ReactNode, useEffect } from 'react';
 import { ReactComponent as CaretDownIcon } from 'assets/svg/caret-down.svg';
 import PALETTE from 'constants/palette';
 import * as Styled from './Select.styles';
@@ -40,6 +40,10 @@ const Select = ({
     setOpen(false);
     onChange(selectedValue);
   };
+
+  useEffect(() => {
+    if (options.length === 0) setOpen(false);
+  }, [options.length]);
 
   return (
     <Styled.Select>

--- a/frontend/src/components/Select/Select.tsx
+++ b/frontend/src/components/Select/Select.tsx
@@ -1,16 +1,18 @@
-import { useState, PropsWithChildren } from 'react';
+import { useState, ReactNode } from 'react';
 import { ReactComponent as CaretDownIcon } from 'assets/svg/caret-down.svg';
 import PALETTE from 'constants/palette';
 import * as Styled from './Select.styles';
 
 interface Option {
   value: string;
+  title?: string;
+  children: ReactNode;
 }
 
 export interface Props {
   name: string;
   label: string;
-  options: PropsWithChildren<Option>[];
+  options: Option[];
   maxheight?: string | number;
   disabled?: boolean;
   value: string;
@@ -53,7 +55,7 @@ const Select = ({
       >
         <Styled.OptionChildrenWrapper>
           {value === '' && <Styled.ListBoxLabel>{label}</Styled.ListBoxLabel>}
-          {selectedOption?.children}
+          {selectedOption?.title ? selectedOption?.title : selectedOption?.children}
         </Styled.OptionChildrenWrapper>
         <Styled.CaretDownIconWrapper open={open}>
           <CaretDownIcon fill={PALETTE.GRAY[400]} />
@@ -71,7 +73,6 @@ const Select = ({
             <Styled.Option
               key={option.value}
               role="option"
-              id={option.value}
               value={option.value}
               aria-selected={option.value === value}
               onClick={() => selectOption(option.value)}

--- a/frontend/src/components/Select/Select.tsx
+++ b/frontend/src/components/Select/Select.tsx
@@ -23,7 +23,7 @@ const Select = ({
   options,
   maxheight,
   disabled = false,
-  value,
+  value = '',
   onChange = () => null,
 }: Props): JSX.Element => {
   const [open, setOpen] = useState(false);
@@ -51,7 +51,10 @@ const Select = ({
         disabled={options.length === 0 || disabled}
         onClick={handleToggle}
       >
-        <Styled.OptionChildrenWrapper>{selectedOption?.children}</Styled.OptionChildrenWrapper>
+        <Styled.OptionChildrenWrapper>
+          {value === '' && <Styled.ListBoxLabel>{label}</Styled.ListBoxLabel>}
+          {selectedOption?.children}
+        </Styled.OptionChildrenWrapper>
         <Styled.CaretDownIconWrapper open={open}>
           <CaretDownIcon fill={PALETTE.GRAY[400]} />
         </Styled.CaretDownIconWrapper>

--- a/frontend/src/constants/api.ts
+++ b/frontend/src/constants/api.ts
@@ -1,4 +1,4 @@
 export const BASE_URL = {
-  DEV: 'http://52.78.60.9:8080/api',
+  DEV: 'https://dev.zzimkkong-proxy.o-r.kr/api',
   PROD: 'https://zzimkkong-proxy.o-r.kr/api',
 };

--- a/frontend/src/constants/message.ts
+++ b/frontend/src/constants/message.ts
@@ -52,6 +52,7 @@ const MESSAGE = {
     SPACE_DELETED: '공간이 생성되었습니다.',
     PRESET_CREATED: '프리셋이 추가되었습니다.',
     PRESET_DELETED: '프리셋이 삭제되었습니다.',
+    DELETE_PRESET_CONFIRM: '이 프리셋을 삭제하시겠어요?',
   },
   MANAGER_MAP: {
     CREATE_SUCCESS_CONFIRM: '맵 생성 완료! 공간을 편집하러 가시겠어요?',

--- a/frontend/src/constants/message.ts
+++ b/frontend/src/constants/message.ts
@@ -43,6 +43,10 @@ const MESSAGE = {
       '공간을 삭제하는 중에 문제가 발생했습니다. 잠시 후에 다시 시도해주세요.',
     CANCEL_ADD_SPACE_CONFIRM: '입력한 공간 설정은 저장되지 않습니다. 공간 추가를 취소하시겠습니까?',
     DELETE_SPACE_CONFIRM: '공간을 삭제하시겠습니까?',
+    ADD_PRESET_UNEXPECTED_ERROR:
+      '프리셋을 추가하는 중에 문제가 발생했습니다. 잠시 후에 다시 시도해주세요.',
+    DELETE_PRESET_UNEXPECTED_ERROR:
+      '프리셋을 삭제하는 중에 문제가 발생했습니다. 잠시 후에 다시 시도해주세요.',
   },
   MANAGER_MAP: {
     CREATE_SUCCESS_CONFIRM: '맵 생성 완료! 공간을 편집하러 가시겠어요?',

--- a/frontend/src/constants/message.ts
+++ b/frontend/src/constants/message.ts
@@ -50,6 +50,7 @@ const MESSAGE = {
     SPACE_CREATED: '공간이 생성되었습니다.',
     SPACE_SETTING_UPDATED: '공간 설정이 수정되었습니다.',
     SPACE_DELETED: '공간이 생성되었습니다.',
+    PRESET_CREATED: '프리셋이 추가되었습니다.',
     PRESET_DELETED: '프리셋이 삭제되었습니다.',
   },
   MANAGER_MAP: {

--- a/frontend/src/constants/message.ts
+++ b/frontend/src/constants/message.ts
@@ -50,6 +50,7 @@ const MESSAGE = {
     SPACE_CREATED: '공간이 생성되었습니다.',
     SPACE_SETTING_UPDATED: '공간 설정이 수정되었습니다.',
     SPACE_DELETED: '공간이 생성되었습니다.',
+    PRESET_DELETED: '프리셋이 삭제되었습니다.',
   },
   MANAGER_MAP: {
     CREATE_SUCCESS_CONFIRM: '맵 생성 완료! 공간을 편집하러 가시겠어요?',

--- a/frontend/src/constants/message.ts
+++ b/frontend/src/constants/message.ts
@@ -47,6 +47,9 @@ const MESSAGE = {
       '프리셋을 추가하는 중에 문제가 발생했습니다. 잠시 후에 다시 시도해주세요.',
     DELETE_PRESET_UNEXPECTED_ERROR:
       '프리셋을 삭제하는 중에 문제가 발생했습니다. 잠시 후에 다시 시도해주세요.',
+    SPACE_CREATED: '공간이 생성되었습니다.',
+    SPACE_SETTING_UPDATED: '공간 설정이 수정되었습니다.',
+    SPACE_DELETED: '공간이 생성되었습니다.',
   },
   MANAGER_MAP: {
     CREATE_SUCCESS_CONFIRM: '맵 생성 완료! 공간을 편집하러 가시겠어요?',

--- a/frontend/src/constants/space.ts
+++ b/frontend/src/constants/space.ts
@@ -1,0 +1,7 @@
+const SPACE = {
+  PRESET_NAME: {
+    MAX_LENGTH: 20,
+  },
+};
+
+export default SPACE;

--- a/frontend/src/hooks/usePreset.ts
+++ b/frontend/src/hooks/usePreset.ts
@@ -1,0 +1,16 @@
+import { AxiosError, AxiosResponse } from 'axios';
+import { QueryKey, useQuery, UseQueryOptions, UseQueryResult } from 'react-query';
+import { queryPresets } from 'api/presets';
+import { ErrorResponse, QueryPresetsSuccess } from 'types/response';
+
+const usePresets = <TData = AxiosResponse<QueryPresetsSuccess>>(
+  options?: UseQueryOptions<
+    AxiosResponse<QueryPresetsSuccess>,
+    AxiosError<ErrorResponse>,
+    TData,
+    [QueryKey]
+  >
+): UseQueryResult<TData, AxiosError<ErrorResponse>> =>
+  useQuery(['getPresets'], queryPresets, options);
+
+export default usePresets;

--- a/frontend/src/pages/ManagerSpaceEdit/ManagerSpaceEdit.styles.ts
+++ b/frontend/src/pages/ManagerSpaceEdit/ManagerSpaceEdit.styles.ts
@@ -183,6 +183,17 @@ export const PresetOption = styled.div`
   align-items: center;
 `;
 
+export const PresetName = styled.span`
+  display: block;
+  flex: 1;
+`;
+
+export const PresetNameFormControl = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 1rem;
+`;
+
 export const InputWrapper = styled.div`
   display: flex;
   gap: 1rem;
@@ -367,10 +378,4 @@ export const SpaceAreaText = styled.text`
   font-size: 1rem;
   pointer-events: none;
   user-select: none;
-`;
-
-export const PresetNameFormControl = styled.div`
-  display: flex;
-  justify-content: flex-end;
-  margin-top: 1rem;
 `;

--- a/frontend/src/pages/ManagerSpaceEdit/ManagerSpaceEdit.styles.ts
+++ b/frontend/src/pages/ManagerSpaceEdit/ManagerSpaceEdit.styles.ts
@@ -177,6 +177,12 @@ export const PresetSelectWrapper = styled.div`
   flex: 1;
 `;
 
+export const PresetOption = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+`;
+
 export const InputWrapper = styled.div`
   display: flex;
   gap: 1rem;
@@ -361,4 +367,10 @@ export const SpaceAreaText = styled.text`
   font-size: 1rem;
   pointer-events: none;
   user-select: none;
+`;
+
+export const PresetNameFormControl = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 1rem;
 `;

--- a/frontend/src/pages/ManagerSpaceEdit/ManagerSpaceEdit.tsx
+++ b/frontend/src/pages/ManagerSpaceEdit/ManagerSpaceEdit.tsx
@@ -13,6 +13,7 @@ import {
 import { useMutation } from 'react-query';
 import { Link, Redirect, useParams } from 'react-router-dom';
 import { deleteManagerSpace, postManagerSpace, putManagerSpace } from 'api/managerSpace';
+import { postPreset } from 'api/presets';
 import { ReactComponent as CloseIcon } from 'assets/svg/close.svg';
 import { ReactComponent as DeleteIcon } from 'assets/svg/delete.svg';
 import { ReactComponent as PaletteIcon } from 'assets/svg/palette.svg';
@@ -23,16 +24,19 @@ import Button from 'components/Button/Button';
 import Header from 'components/Header/Header';
 import Input from 'components/Input/Input';
 import Layout from 'components/Layout/Layout';
+import Modal from 'components/Modal/Modal';
 import Select from 'components/Select/Select';
 import Toggle from 'components/Toggle/Toggle';
 import { DrawingAreaShape, EDITOR, KEY } from 'constants/editor';
 import MESSAGE from 'constants/message';
 import PALETTE from 'constants/palette';
 import PATH from 'constants/path';
+import SPACE from 'constants/space';
 import useInput from 'hooks/useInput';
 import useListenManagerMainState from 'hooks/useListenManagerMainState';
 import useManagerMap from 'hooks/useManagerMap';
 import useManagerSpaces from 'hooks/useManagerSpaces';
+import usePresets from 'hooks/usePreset';
 import useToggle from 'hooks/useToggle';
 import { Coordinate, DrawingStatus, ManagerSpace, MapDrawing, SpaceArea } from 'types/common';
 import { ErrorResponse } from 'types/response';
@@ -90,7 +94,6 @@ const ManagerSpaceEdit = (): JSX.Element => {
       })) ?? [],
     [managerSpaces.data?.data.spaces]
   );
-
   const spaceOptions = spaces.map(({ id, name, color }) => ({
     value: `${id}`,
     children: (
@@ -100,6 +103,23 @@ const ManagerSpaceEdit = (): JSX.Element => {
       </Styled.SpaceOption>
     ),
   }));
+
+  const getPresets = usePresets();
+  const presets = useMemo(() => getPresets.data?.data?.presets ?? [], []);
+  const presetOptions = presets.map(({ name }) => ({
+    value: name,
+    children: <Styled.PresetOption>{name}</Styled.PresetOption>,
+  }));
+
+  const createPreset = useMutation(postPreset, {
+    onSuccess: () => {
+      setPresetFormOpen(false);
+      managerSpaces.refetch();
+    },
+    onError: (error: AxiosError<ErrorResponse>) => {
+      console.error(error);
+    },
+  });
 
   const createSpace = useMutation(postManagerSpace, {
     onSuccess: (response) => {
@@ -141,12 +161,16 @@ const ManagerSpaceEdit = (): JSX.Element => {
     },
   });
 
+  const [isPresetFormOpen, setPresetFormOpen] = useState(false);
+  const [presetName, onChangePresetName] = useInput('');
+
   const [isDragging, setDragging] = useState(false);
   const [isDraggable, setDraggable] = useState(false);
   const [dragOffsetX, setDragOffsetX] = useState(0);
   const [dragOffsetY, setDragOffsetY] = useState(0);
 
   const [selectedSpaceId, setSelectedSpaceId] = useState<number | null>(null);
+  const [selectedPresetName, setSelectedPresetName] = useState<string | null>(null);
 
   const [isDrawingArea, setDrawingArea] = useState(false);
   const [isAddingSpace, setAddingSpace] = useState(false);
@@ -343,8 +367,85 @@ const ManagerSpaceEdit = (): JSX.Element => {
     setSpaceColor,
   ]);
 
+  const handleChangeReservationForm = (
+    event: React.ChangeEvent<HTMLInputElement>,
+    callback: ChangeEventHandler<HTMLInputElement>
+  ) => {
+    if (selectedPresetName) selectPreset(null);
+
+    callback(event);
+  };
+
+  const handleSubmitPreset: FormEventHandler<HTMLFormElement> = (event) => {
+    event.preventDefault();
+
+    const availableTime = {
+      start: formatTimeWithSecond(new Date(`${todayDate}T${availableStartTime}`)),
+      end: formatTimeWithSecond(new Date(`${todayDate}T${availableEndTime}`)),
+    };
+
+    const settingsRequest = {
+      availableStartTime: availableTime.start,
+      availableEndTime: availableTime.end,
+      reservationTimeUnit: Number(reservationTimeUnit),
+      reservationMinimumTimeUnit: Number(reservationMinimumTimeUnit),
+      reservationMaximumTimeUnit: Number(reservationMaximumTimeUnit),
+      reservationEnable,
+      enabledDayOfWeek,
+    };
+
+    createPreset.mutate({ name: presetName, settingsRequest });
+  };
+
+  const handleClickAddPreset = () => {
+    setPresetFormOpen(true);
+  };
+
+  const selectPreset = useCallback(
+    (name: string | null) => {
+      setSelectedPresetName(name);
+
+      if (name === null) return;
+
+      const {
+        availableStartTime,
+        availableEndTime,
+        reservationTimeUnit,
+        reservationMinimumTimeUnit,
+        reservationMaximumTimeUnit,
+        enabledDayOfWeek,
+      } = presets.find((preset) => preset.name === name) ?? presets[0];
+
+      const enableWeekdays = enabledDayOfWeek?.toLowerCase()?.split(',') ?? [];
+
+      setAvailableStartTime(availableStartTime);
+      setAvailableEndTime(availableEndTime);
+      setReservationTimeUnit(`${reservationTimeUnit}`);
+      setReservationMinimumTimeUnit(`${reservationMinimumTimeUnit}`);
+      setReservationMaximumTimeUnit(`${reservationMaximumTimeUnit}`);
+      setEnabledWeekdays({
+        monday: enableWeekdays.includes('monday'),
+        tuesday: enableWeekdays.includes('tuesday'),
+        wednesday: enableWeekdays.includes('wednesday'),
+        thursday: enableWeekdays.includes('thursday'),
+        friday: enableWeekdays.includes('friday'),
+        saturday: enableWeekdays.includes('saturday'),
+        sunday: enableWeekdays.includes('sunday'),
+      });
+    },
+    [
+      presets,
+      setAvailableEndTime,
+      setAvailableStartTime,
+      setReservationMaximumTimeUnit,
+      setReservationMinimumTimeUnit,
+      setReservationTimeUnit,
+    ]
+  );
+
   const selectSpace = useCallback(
     (id: number | null) => {
+      selectPreset(null);
       setSelectedSpaceId(id);
 
       if (id === null) return;
@@ -385,6 +486,7 @@ const ManagerSpaceEdit = (): JSX.Element => {
       });
     },
     [
+      selectPreset,
       setAvailableEndTime,
       setAvailableStartTime,
       setReservationEnable,
@@ -1060,33 +1162,41 @@ const ManagerSpaceEdit = (): JSX.Element => {
                   </Styled.FormRow>
                   <Styled.FormHeader>예약 조건</Styled.FormHeader>
                   {/* Note: 프리셋 기능을 구현할 때 이 UI를 활성화하면 됩니다 */}
-                  {/* <Styled.FormRow>
-                  <Styled.PresetSelect>
-                    <Styled.PresetSelectWrapper>
-                      <Select
-                        label="공간 선택"
-                        options={spaceOptions}
-                        value={selectedSpaceId}
-                        setValue={setSelectedSpaceId}
-                      />
-                    </Styled.PresetSelectWrapper>
-                    <Button type="button">프리셋 저장</Button>
-                  </Styled.PresetSelect>
-                </Styled.FormRow> */}
+                  <Styled.FormRow>
+                    <Styled.PresetSelect>
+                      <Styled.PresetSelectWrapper>
+                        <Select
+                          name="preset"
+                          label="프리셋 선택"
+                          options={presetOptions}
+                          value={`${selectedPresetName ?? ''}`}
+                          onChange={(name) => selectPreset(name)}
+                        />
+                      </Styled.PresetSelectWrapper>
+                      <Button type="button" onClick={handleClickAddPreset}>
+                        추가
+                      </Button>
+                      <Button type="button">삭제</Button>
+                    </Styled.PresetSelect>
+                  </Styled.FormRow>
                   <Styled.FormRow>
                     <Styled.InputWrapper>
                       <Input
                         type="time"
                         label="예약이 열릴 시간"
                         value={availableStartTime}
-                        onChange={onChangeAvailableStartTime}
+                        onChange={(event) =>
+                          handleChangeReservationForm(event, onChangeAvailableStartTime)
+                        }
                         required
                       />
                       <Input
                         type="time"
                         label="예약이 닫힐 시간"
                         value={availableEndTime}
-                        onChange={onChangeAvailableEndTime}
+                        onChange={(event) =>
+                          handleChangeReservationForm(event, onChangeAvailableEndTime)
+                        }
                         required
                       />
                     </Styled.InputWrapper>
@@ -1104,7 +1214,9 @@ const ManagerSpaceEdit = (): JSX.Element => {
                             type="radio"
                             checked={reservationTimeUnit === '5'}
                             value="5"
-                            onChange={onChangeReservationTimeUnit}
+                            onChange={(event) =>
+                              handleChangeReservationForm(event, onChangeReservationTimeUnit)
+                            }
                             name="time-unit"
                             required
                           />
@@ -1115,7 +1227,9 @@ const ManagerSpaceEdit = (): JSX.Element => {
                             type="radio"
                             checked={reservationTimeUnit === '10'}
                             value="10"
-                            onChange={onChangeReservationTimeUnit}
+                            onChange={(event) =>
+                              handleChangeReservationForm(event, onChangeReservationTimeUnit)
+                            }
                             name="time-unit"
                           />
                           <Styled.RadioLabelText>10분</Styled.RadioLabelText>
@@ -1125,7 +1239,9 @@ const ManagerSpaceEdit = (): JSX.Element => {
                             type="radio"
                             checked={reservationTimeUnit === '30'}
                             value="30"
-                            onChange={onChangeReservationTimeUnit}
+                            onChange={(event) =>
+                              handleChangeReservationForm(event, onChangeReservationTimeUnit)
+                            }
                             name="time-unit"
                           />
                           <Styled.RadioLabelText>30분</Styled.RadioLabelText>
@@ -1135,7 +1251,9 @@ const ManagerSpaceEdit = (): JSX.Element => {
                             type="radio"
                             checked={reservationTimeUnit === '60'}
                             value="60"
-                            onChange={onChangeReservationTimeUnit}
+                            onChange={(event) =>
+                              handleChangeReservationForm(event, onChangeReservationTimeUnit)
+                            }
                             name="time-unit"
                           />
                           <Styled.RadioLabelText>1시간</Styled.RadioLabelText>
@@ -1156,7 +1274,9 @@ const ManagerSpaceEdit = (): JSX.Element => {
                         step={reservationTimeUnit}
                         label="최소 예약 가능 시간 (분)"
                         value={reservationMinimumTimeUnit}
-                        onChange={onChangeReservationMinimumTimeUnit}
+                        onChange={(event) =>
+                          handleChangeReservationForm(event, onChangeReservationMinimumTimeUnit)
+                        }
                         required
                       />
                       <Input
@@ -1166,7 +1286,9 @@ const ManagerSpaceEdit = (): JSX.Element => {
                         step={reservationTimeUnit}
                         label="최대 예약 가능 시간 (분)"
                         value={reservationMaximumTimeUnit}
-                        onChange={onChangeReservationMaximumTimeUnit}
+                        onChange={(event) =>
+                          handleChangeReservationForm(event, onChangeReservationMaximumTimeUnit)
+                        }
                         required
                       />
                     </Styled.InputWrapper>
@@ -1185,7 +1307,9 @@ const ManagerSpaceEdit = (): JSX.Element => {
                             type="checkbox"
                             checked={monday}
                             name="monday"
-                            onChange={handleChangeEnabledDayOfWeek}
+                            onChange={(event) =>
+                              handleChangeReservationForm(event, handleChangeEnabledDayOfWeek)
+                            }
                           />
                         </Styled.WeekdayLabel>
                         <Styled.WeekdayLabel>
@@ -1194,7 +1318,9 @@ const ManagerSpaceEdit = (): JSX.Element => {
                             type="checkbox"
                             checked={tuesday}
                             name="tuesday"
-                            onChange={handleChangeEnabledDayOfWeek}
+                            onChange={(event) =>
+                              handleChangeReservationForm(event, handleChangeEnabledDayOfWeek)
+                            }
                           />
                         </Styled.WeekdayLabel>
                         <Styled.WeekdayLabel>
@@ -1203,7 +1329,9 @@ const ManagerSpaceEdit = (): JSX.Element => {
                             type="checkbox"
                             checked={wednesday}
                             name="wednesday"
-                            onChange={handleChangeEnabledDayOfWeek}
+                            onChange={(event) =>
+                              handleChangeReservationForm(event, handleChangeEnabledDayOfWeek)
+                            }
                           />
                         </Styled.WeekdayLabel>
                         <Styled.WeekdayLabel>
@@ -1212,7 +1340,9 @@ const ManagerSpaceEdit = (): JSX.Element => {
                             type="checkbox"
                             checked={thursday}
                             name="thursday"
-                            onChange={handleChangeEnabledDayOfWeek}
+                            onChange={(event) =>
+                              handleChangeReservationForm(event, handleChangeEnabledDayOfWeek)
+                            }
                           />
                         </Styled.WeekdayLabel>
                         <Styled.WeekdayLabel>
@@ -1221,7 +1351,9 @@ const ManagerSpaceEdit = (): JSX.Element => {
                             type="checkbox"
                             checked={friday}
                             name="friday"
-                            onChange={handleChangeEnabledDayOfWeek}
+                            onChange={(event) =>
+                              handleChangeReservationForm(event, handleChangeEnabledDayOfWeek)
+                            }
                           />
                         </Styled.WeekdayLabel>
                         <Styled.WeekdayLabel>
@@ -1230,7 +1362,9 @@ const ManagerSpaceEdit = (): JSX.Element => {
                             type="checkbox"
                             checked={saturday}
                             name="saturday"
-                            onChange={handleChangeEnabledDayOfWeek}
+                            onChange={(event) =>
+                              handleChangeReservationForm(event, handleChangeEnabledDayOfWeek)
+                            }
                           />
                         </Styled.WeekdayLabel>
                         <Styled.WeekdayLabel>
@@ -1239,7 +1373,9 @@ const ManagerSpaceEdit = (): JSX.Element => {
                             type="checkbox"
                             checked={sunday}
                             name="sunday"
-                            onChange={handleChangeEnabledDayOfWeek}
+                            onChange={(event) =>
+                              handleChangeReservationForm(event, handleChangeEnabledDayOfWeek)
+                            }
                           />
                         </Styled.WeekdayLabel>
                       </Styled.WeekdaySelect>
@@ -1275,6 +1411,30 @@ const ManagerSpaceEdit = (): JSX.Element => {
           </Styled.EditorContainer>
         </Styled.Page>
       </Layout>
+      <Modal
+        open={isPresetFormOpen}
+        isClosableDimmer
+        showCloseButton
+        onClose={() => setPresetFormOpen(false)}
+      >
+        <Modal.Header>추가할 프리셋의 이름을 입력해주세요</Modal.Header>
+        <Modal.Inner>
+          <form onSubmit={handleSubmitPreset}>
+            <Input
+              type="text"
+              maxLength={SPACE.PRESET_NAME.MAX_LENGTH}
+              value={presetName}
+              onChange={onChangePresetName}
+              message={createPreset.error?.response?.data.message ?? ''}
+              status={!!createPreset.error?.response?.data.message ? 'error' : 'default'}
+              autoFocus
+            />
+            <Styled.PresetNameFormControl>
+              <Button variant="text">저장</Button>
+            </Styled.PresetNameFormControl>
+          </form>
+        </Modal.Inner>
+      </Modal>
     </>
   );
 };

--- a/frontend/src/pages/ManagerSpaceEdit/ManagerSpaceEdit.tsx
+++ b/frontend/src/pages/ManagerSpaceEdit/ManagerSpaceEdit.tsx
@@ -1079,6 +1079,7 @@ const ManagerSpaceEdit = (): JSX.Element => {
                             stroke={element.stroke}
                             strokeWidth={EDITOR.STROKE_WIDTH}
                             strokeLinecap="round"
+                            pointerEvents="none"
                           />
                         ) : (
                           <rect

--- a/frontend/src/pages/ManagerSpaceEdit/ManagerSpaceEdit.tsx
+++ b/frontend/src/pages/ManagerSpaceEdit/ManagerSpaceEdit.tsx
@@ -167,7 +167,6 @@ const ManagerSpaceEdit = (): JSX.Element => {
       setPresetName('');
 
       getPresets.refetch();
-      alert(MESSAGE.MANAGER_SPACE.PRESET_CREATED);
     },
     onError: (error: AxiosError<ErrorResponse>) => {
       alert(error.response?.data.message ?? MESSAGE.MANAGER_SPACE.ADD_PRESET_UNEXPECTED_ERROR);
@@ -175,9 +174,6 @@ const ManagerSpaceEdit = (): JSX.Element => {
   });
 
   const removePreset = useMutation(deletePreset, {
-    onSuccess: () => {
-      alert(MESSAGE.MANAGER_SPACE.PRESET_DELETED);
-    },
     onError: (error: AxiosError<ErrorResponse>) => {
       alert(error.response?.data.message ?? MESSAGE.MANAGER_SPACE.DELETE_PRESET_UNEXPECTED_ERROR);
     },

--- a/frontend/src/pages/ManagerSpaceEdit/ManagerSpaceEdit.tsx
+++ b/frontend/src/pages/ManagerSpaceEdit/ManagerSpaceEdit.tsx
@@ -1,4 +1,4 @@
-import { AxiosError } from 'axios';
+import { AxiosError, AxiosResponse } from 'axios';
 import {
   ChangeEventHandler,
   FormEventHandler,
@@ -158,9 +158,15 @@ const ManagerSpaceEdit = (): JSX.Element => {
   );
 
   const createPreset = useMutation(postPreset, {
-    onSuccess: () => {
+    onSuccess: (response) => {
+      const { location } = response.headers as CreateResponseHeaders;
+      const newPresetId = Number(location.split('/').pop() ?? '');
+
+      setSelectedPresetId(newPresetId);
       setPresetFormOpen(false);
+
       getPresets.refetch();
+      alert(MESSAGE.MANAGER_SPACE.PRESET_CREATED);
     },
     onError: (error: AxiosError<ErrorResponse>) => {
       alert(error.response?.data.message ?? MESSAGE.MANAGER_SPACE.ADD_PRESET_UNEXPECTED_ERROR);

--- a/frontend/src/pages/ManagerSpaceEdit/ManagerSpaceEdit.tsx
+++ b/frontend/src/pages/ManagerSpaceEdit/ManagerSpaceEdit.tsx
@@ -164,6 +164,7 @@ const ManagerSpaceEdit = (): JSX.Element => {
 
       setSelectedPresetId(newPresetId);
       setPresetFormOpen(false);
+      setPresetName('');
 
       getPresets.refetch();
       alert(MESSAGE.MANAGER_SPACE.PRESET_CREATED);
@@ -183,7 +184,7 @@ const ManagerSpaceEdit = (): JSX.Element => {
   });
 
   const [isPresetFormOpen, setPresetFormOpen] = useState(false);
-  const [presetName, onChangePresetName] = useInput('');
+  const [presetName, onChangePresetName, setPresetName] = useInput('');
 
   const [isDragging, setDragging] = useState(false);
   const [isDraggable, setDraggable] = useState(false);

--- a/frontend/src/pages/ManagerSpaceEdit/ManagerSpaceEdit.tsx
+++ b/frontend/src/pages/ManagerSpaceEdit/ManagerSpaceEdit.tsx
@@ -1,4 +1,4 @@
-import { AxiosError, AxiosResponse } from 'axios';
+import { AxiosError } from 'axios';
 import {
   ChangeEventHandler,
   FormEventHandler,
@@ -424,7 +424,7 @@ const ManagerSpaceEdit = (): JSX.Element => {
 
   const handleDeletePreset = (event: React.MouseEvent<HTMLButtonElement>, id: Preset['id']) => {
     event.stopPropagation();
-    if (!window.confirm('이 프리셋을 삭제하시겠어요?')) return;
+    if (!window.confirm(MESSAGE.MANAGER_SPACE.DELETE_PRESET_CONFIRM)) return;
 
     removePreset.mutate({ id });
   };
@@ -880,7 +880,7 @@ const ManagerSpaceEdit = (): JSX.Element => {
     children: (
       <Styled.PresetOption>
         <Styled.PresetName>{name}</Styled.PresetName>
-        <IconButton type="button" onClickCapture={(event) => handleDeletePreset(event, id)}>
+        <IconButton type="button" onClick={(event) => handleDeletePreset(event, id)}>
           <DeleteIcon />
         </IconButton>
       </Styled.PresetOption>

--- a/frontend/src/pages/ManagerSpaceEdit/ManagerSpaceEdit.tsx
+++ b/frontend/src/pages/ManagerSpaceEdit/ManagerSpaceEdit.tsx
@@ -105,7 +105,10 @@ const ManagerSpaceEdit = (): JSX.Element => {
   }));
 
   const getPresets = usePresets();
-  const presets = useMemo(() => getPresets.data?.data?.presets ?? [], []);
+  const presets = useMemo(
+    () => getPresets.data?.data?.presets ?? [],
+    [getPresets.data?.data?.presets]
+  );
   const presetOptions = presets.map(({ name }) => ({
     value: name,
     children: <Styled.PresetOption>{name}</Styled.PresetOption>,
@@ -131,7 +134,7 @@ const ManagerSpaceEdit = (): JSX.Element => {
       setSelectedSpaceId(newSpaceId);
 
       managerSpaces.refetch();
-      alert('공간이 생성되었습니다');
+      alert(MESSAGE.MANAGER_SPACE.SPACE_CREATED);
     },
     onError: (error: AxiosError<ErrorResponse>) => {
       alert(error.response?.data.message ?? MESSAGE.MANAGER_SPACE.ADD_UNEXPECTED_ERROR);
@@ -141,7 +144,7 @@ const ManagerSpaceEdit = (): JSX.Element => {
   const updateSpace = useMutation(putManagerSpace, {
     onSuccess: () => {
       managerSpaces.refetch();
-      alert('공간 설정이 수정되었습니다');
+      alert(MESSAGE.MANAGER_SPACE.SPACE_SETTING_UPDATED);
     },
     onError: (error: AxiosError<ErrorResponse>) => {
       alert(error.response?.data.message ?? MESSAGE.MANAGER_SPACE.EDIT_UNEXPECTED_ERROR);
@@ -154,7 +157,7 @@ const ManagerSpaceEdit = (): JSX.Element => {
       setArea(null);
 
       managerSpaces.refetch();
-      alert('공간이 삭제되었습니다.');
+      alert(MESSAGE.MANAGER_SPACE.SPACE_DELETED);
     },
     onError: (error: AxiosError<ErrorResponse>) => {
       alert(error.response?.data.message ?? MESSAGE.MANAGER_SPACE.DELETE_UNEXPECTED_ERROR);

--- a/frontend/src/types/common.ts
+++ b/frontend/src/types/common.ts
@@ -85,6 +85,7 @@ export interface ReservationSettings {
 }
 
 export interface Preset extends ReservationSettings {
+  id: number;
   name: string;
 }
 

--- a/frontend/src/types/common.ts
+++ b/frontend/src/types/common.ts
@@ -84,6 +84,10 @@ export interface ReservationSettings {
   enabledDayOfWeek: string | null;
 }
 
+export interface Preset extends ReservationSettings {
+  name: string;
+}
+
 export interface ManagerSpace {
   id: number;
   name: string;

--- a/frontend/src/types/response.ts
+++ b/frontend/src/types/response.ts
@@ -1,4 +1,4 @@
-import { MapItem, Reservation, Space, SpaceReservation, ManagerSpaceAPI } from './common';
+import { MapItem, Reservation, Space, SpaceReservation, ManagerSpaceAPI, Preset } from './common';
 
 export interface MapItemResponse extends Omit<MapItem, 'mapDrawing'> {
   mapDrawing: string;
@@ -44,4 +44,8 @@ export interface QueryManagerSpaceSuccess {
 
 export interface QueryManagerSpacesSuccess {
   spaces: ManagerSpaceAPI[];
+}
+
+export interface QueryPresetsSuccess {
+  presets: Preset[];
 }


### PR DESCRIPTION
## 구현 기능
- 공간 예약 조건 프리셋 기능 구현 (추가, 조회 및 설정, 삭제)

https://user-images.githubusercontent.com/2542730/131951761-a5fa0bdf-1113-475e-82f5-44b7e7a24157.mp4


- 프리셋 선택 후, 예약 조건을 수정하면 프리셋 선택이 자동으로 해제됩니다.


https://user-images.githubusercontent.com/2542730/131951768-3c03b14e-b0da-490f-ae8d-bc84eb82a126.mp4



## 기타 수정한 문제
- 공간 편집 페이지에서 영역 드래그 시 커서가 선에 닿았을 때 올바르게 동작하지 않는 문제 수정
- 상수화되지 않은 alert message 상수화
- `Select` 컴포넌트에 `title` prop 추가

## 공유하고 싶은 내용
- 로컬에서 한번 사용해보시면서 기능 동작을 한 번 확인 부탁드리고 이와 관련된 피드백도 부탁드립니다!

Close #179 
Close #181 
Close #515 
