### PR TITLE
fix: 맵 추가 페이지에서 메인으로 돌아왔을 때 예약 목록이 로드되지 않는 문제 수정

### DIFF
--- a/frontend/src/hooks/useListenManagerMainState.ts
+++ b/frontend/src/hooks/useListenManagerMainState.ts
@@ -1,23 +1,27 @@
 import { useEffect } from 'react';
 import { useHistory } from 'react-router-dom';
 import PATH from 'constants/path';
+import { isNullish } from 'utils/type';
 
 interface Props {
-  mapId?: number | null;
+  mapId?: number;
 }
 
-const useListenManagerMainState = ({ mapId }: Props): void => {
-  const history = useHistory();
+const useListenManagerMainState = (
+  { mapId }: Props,
+  { enabled }: { enabled: boolean } = { enabled: true }
+): void => {
+  const history = useHistory<Props>();
 
-  useEffect(
-    () =>
-      history.listen((location) => {
-        if (location.pathname === PATH.MANAGER_MAIN) {
-          location.state = { mapId };
-        }
-      }),
-    [history, mapId]
-  );
+  useEffect(() => {
+    if (!enabled || isNullish(mapId)) return;
+
+    history.listen((location) => {
+      if (location.pathname === PATH.MANAGER_MAIN) {
+        location.state = { mapId };
+      }
+    });
+  }, [history, mapId, enabled]);
 };
 
 export default useListenManagerMainState;

--- a/frontend/src/pages/ManagerMapCreate/ManagerMapCreate.tsx
+++ b/frontend/src/pages/ManagerMapCreate/ManagerMapCreate.tsx
@@ -60,7 +60,7 @@ const ManagerMapCreate = (): JSX.Element => {
   const mapId = params?.mapId;
   const isEdit = !!mapId;
 
-  useListenManagerMainState({ mapId: Number(mapId) });
+  useListenManagerMainState({ mapId: Number(mapId) }, { enabled: isEdit });
 
   const [mapName, onChangeMapName, setMapName] = useInput('');
 


### PR DESCRIPTION
## 구현 기능
- 맵 추가 페이지에서 메인으로 돌아왔을 때 예약 목록이 로드되지 않는 문제 수정

Close #492 

