### PR TITLE
fix: 로그아웃 후 다른 아이디로 로그인 시, 로그아웃 되던 오류

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -12,7 +12,7 @@ import NotFound from './pages/NotFound/NotFound';
 
 export const history = createBrowserHistory();
 
-const queryClient = new QueryClient();
+export const queryClient = new QueryClient();
 
 const App = (): JSX.Element => {
   return (

--- a/frontend/src/components/Header/Header.tsx
+++ b/frontend/src/components/Header/Header.tsx
@@ -1,5 +1,6 @@
 import { useHistory, useParams } from 'react-router-dom';
 import { useRecoilState } from 'recoil';
+import { queryClient } from 'App';
 import { ReactComponent as LogoIcon } from 'assets/svg/logo.svg';
 import PATH, { HREF } from 'constants/path';
 import { LOCAL_STORAGE_KEY } from 'constants/storage';
@@ -29,6 +30,7 @@ const Header = (): JSX.Element => {
 
   const handleLogout = () => {
     setAccessToken('');
+    queryClient.clear();
     localStorage.removeItem(LOCAL_STORAGE_KEY.ACCESS_TOKEN);
 
     history.push(PATH.MANAGER_LOGIN);

--- a/frontend/src/pages/ManagerMain/ManagerMain.tsx
+++ b/frontend/src/pages/ManagerMain/ManagerMain.tsx
@@ -60,7 +60,7 @@ const ManagerMain = (): JSX.Element => {
       date: formatDate(date),
     },
     {
-      enabled: !(selectedMapId === null),
+      enabled: !isNullish(selectedMapId),
       onError: onRequestError,
     }
   );


### PR DESCRIPTION
## 공유하고 싶은 내용
### 기존 오류 상황

- 아래 스크린샷을 보면 최초 로그인시 불러온 `maps`가 로그아웃 시 clear되지 않았고, 이에 따라 메인화면에 진입할 때 기존에 가지고 있는 맵 목록의 첫 번째 맵의 id를 `selectedMapId`로 설정하고 있었습니다.
- 새롭게 로그인 된 아이디에서는 해당 맵의 `reservation`에 대한 접근권한이 없었고, 그렇기 때문에 로그아웃 되면서 다시 메인 화면으로 돌아가는 증상을 확인할 수 있었습니다.

<img width="835" alt="스크린샷 2021-09-03 오후 10 01 02" src="https://user-images.githubusercontent.com/61097373/132010376-4b0b8411-6c6b-4d67-9f76-71e4719f981d.png">

### 해결 방법

- `App.tsx` 파일을 보면 `QueryClientProvider`로 전체 `App`을 감쌀 때 `client={queryClient}`라는 옵션을 준 것을 확인할 수 있습니다.
```tsx
const queryClient = new QueryClient();

const App = (): JSX.Element => {
  return (
    <QueryClientProvider client={queryClient}>
       // ... 생략
    </QueryClientProvider>
  );
};
```

- 해당 queryClient를 export하여 로그아웃 시 queryCache를 초기화하는 로직을 추가하였습니다.

```tsx
  const handleLogout = () => {
    setAccessToken('');
    queryClient.clear();  // <--- 새로 추가된 로직
    localStorage.removeItem(LOCAL_STORAGE_KEY.ACCESS_TOKEN);

    history.push(PATH.MANAGER_LOGIN);
  };
```

### 현재 동작

![Sep-03-2021 22-09-03](https://user-images.githubusercontent.com/61097373/132010846-820046a9-f128-40b0-bb4c-59593834db0e.gif)

## 기타

- history와 관련된 문제인줄 알고 열심히 삽질을 하고 있을 때 체프가 준 인사이트 덕분에 문제를 빠르게 해결할 수 있었습니다.
- 함께 고민해준 체프와 썬 감사합니다람쥐~~ 😆😆😆
- QueryCache 관련 참고 자료(공식 문서)
   - https://react-query.tanstack.com/reference/QueryCache 

Close #425 



