### PR TITLE
feat: `useInputs` 커스텀 훅 구현

### DIFF
--- a/frontend/src/hooks/useInputs.ts
+++ b/frontend/src/hooks/useInputs.ts
@@ -1,0 +1,22 @@
+import React, { useState } from 'react';
+
+const useInputs = <T = Record<string, string>>(
+  initialValues: T
+): [
+  T,
+  (event: React.ChangeEvent<HTMLInputElement>) => void,
+  React.Dispatch<React.SetStateAction<T>>
+] => {
+  const [values, setValues] = useState<T>(initialValues);
+
+  const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setValues((prevValues) => ({
+      ...prevValues,
+      [event.target.name]: event.target.value,
+    }));
+  };
+
+  return [values, handleChange, setValues];
+};
+
+export default useInputs;


### PR DESCRIPTION
## 구현 기능
- 하나의 객체에서 `input` 요소의 value를 관리하는 `useInputs` 커스텀 훅 구현

## 사용 방법
- input value들을 관리할 객체의 interface를 정의하고 Generic으로 넣어주세요.

```ts
interface Form {
  email: string;
  password: string;
}

const [{ email, password }, onChangeForm] = useInputs<Form>({ email: '', password: '' });
```

Close #513 
