### PR TITLE
fix: oauth 버그를 해결한다.

### DIFF
--- a/backend/src/main/java/com/woowacourse/zzimkkong/DataLoader.java
+++ b/backend/src/main/java/com/woowacourse/zzimkkong/DataLoader.java
@@ -53,11 +53,11 @@ public class DataLoader implements CommandLineRunner {
         );
 
         Setting defaultSetting = Setting.builder()
-                .availableStartTime(LocalTime.of(0, 0))
-                .availableEndTime(LocalTime.of(23, 59))
+                .availableStartTime(LocalTime.of(9, 0))
+                .availableEndTime(LocalTime.of(22, 00))
                 .reservationTimeUnit(10)
                 .reservationMinimumTimeUnit(10)
-                .reservationMaximumTimeUnit(1440)
+                .reservationMaximumTimeUnit(700)
                 .reservationEnable(true)
                 .enabledDayOfWeek("monday,tuesday,wednesday,thursday,friday,saturday,sunday")
                 .build();

--- a/backend/src/main/java/com/woowacourse/zzimkkong/infrastructure/oauth/GithubRequester.java
+++ b/backend/src/main/java/com/woowacourse/zzimkkong/infrastructure/oauth/GithubRequester.java
@@ -3,13 +3,12 @@ package com.woowacourse.zzimkkong.infrastructure.oauth;
 import com.woowacourse.zzimkkong.domain.OauthProvider;
 import com.woowacourse.zzimkkong.domain.oauth.GithubUserInfo;
 import com.woowacourse.zzimkkong.domain.oauth.OauthUserInfo;
+import com.woowacourse.zzimkkong.exception.infrastructure.oauth.ErrorResponseToGetGithubAccessTokenException;
 import com.woowacourse.zzimkkong.exception.infrastructure.oauth.UnableToGetTokenResponseFromGithubException;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.PropertySource;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
-import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
 
 import java.util.Map;
@@ -57,8 +56,14 @@ public class GithubRequester implements OauthAPIRequester {
                 })
                 .blockOptional()
                 .orElseThrow(UnableToGetTokenResponseFromGithubException::new);
-
+        validateResponseBody(responseBody);
         return responseBody.get("access_token").toString();
+    }
+
+    private void validateResponseBody(Map<String, Object> responseBody) {
+        if (!responseBody.containsKey("access_token")) {
+            throw new ErrorResponseToGetGithubAccessTokenException(responseBody.get("error_description").toString());
+        }
     }
 
     private OauthUserInfo getUserInfo(final String token) {

--- a/backend/src/main/resources/application-dev.properties
+++ b/backend/src/main/resources/application-dev.properties
@@ -29,3 +29,6 @@ converter.temp.location=/home/ubuntu/zzimkkong/tmp/
 
 # cors (delimiter == ',')
 cors.allow-origin.urls=*
+
+# oauth
+google.uri.redirect=https://dev.zzimkkong.com/login/oauth/google

--- a/backend/src/main/resources/application-local.properties
+++ b/backend/src/main/resources/application-local.properties
@@ -34,3 +34,7 @@ converter.temp.location=src/main/resources/tmp/
 
 # cors (delimiter == ',')
 cors.allow-origin.urls=*
+
+# oauth
+google.uri.redirect=http://localhost:3000/login/oauth/google
+

--- a/backend/src/main/resources/application-test.properties
+++ b/backend/src/main/resources/application-test.properties
@@ -26,3 +26,6 @@ converter.temp.location=src/main/resources/tmp/
 
 # cors (delimiter == ',')
 cors.allow-origin.urls=*
+
+# oauth
+google.uri.redirect=http://localhost:3000/login/oauth/google


### PR DESCRIPTION
## 구현 기능
- google은 redirect uri가 환경마다 달라야 해서 발생하는 문제였고, application-local과 application-prod에 수정하면서 해결했습니다.
- github은 제 생각엔 프론트에 client id가 잘못 전달된 것 같고, 500은 안터지게 예외 처리 로직을 추가했습니다.
- 두개 다 포스트맨 확인을 마쳤으니 이제 잘 것이라 추정하는 바입니다.

동작 확인하고 이슈 닫겠슴니다...
Close 

