### PR TITLE
feat: Github, Google OAuth 공간 관리자 로그인 기능 구현

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -2,3 +2,4 @@
 node_modules
 dist
 .eslintcache
+.env

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -67,6 +67,7 @@
     "babel-eslint": "^10.0.0",
     "babel-loader": "^8.2.2",
     "cross-env": "^7.0.3",
+    "dotenv-webpack": "^7.0.3",
     "eslint": "^7.5.0",
     "eslint-config-prettier": "^8.3.0",
     "eslint-config-react-app": "^6.0.0",

--- a/frontend/src/PrivateRoute.tsx
+++ b/frontend/src/PrivateRoute.tsx
@@ -1,7 +1,7 @@
 import { PropsWithChildren } from 'react';
 import { Redirect, Route, RouteProps } from 'react-router-dom';
-import { useRecoilValue } from 'recoil';
-import accessTokenState from 'state/accessTokenState';
+import { LOCAL_STORAGE_KEY } from 'constants/storage';
+import { getLocalStorageItem } from 'utils/localStorage';
 
 interface Props extends RouteProps {
   redirectPath: string;
@@ -12,7 +12,10 @@ const PrivateRoute = ({
   children,
   ...props
 }: PropsWithChildren<Props>): JSX.Element => {
-  const token = useRecoilValue(accessTokenState);
+  const token = getLocalStorageItem({
+    key: LOCAL_STORAGE_KEY.ACCESS_TOKEN,
+    defaultValue: '',
+  });
 
   return <Route {...props}>{token ? children : <Redirect to={redirectPath} />}</Route>;
 };

--- a/frontend/src/api/join.ts
+++ b/frontend/src/api/join.ts
@@ -8,12 +8,33 @@ interface JoinParams {
   organization: string;
 }
 
+interface SocialJoinParams {
+  email: string;
+  organization: string;
+  oauthProvider: 'GITHUB' | 'GOOGLE';
+}
+
+export interface QueryEmailParams {
+  code: string;
+}
+
 export const queryValidateEmail: QueryFunction = ({ queryKey }) => {
   const [, email] = queryKey;
 
-  return api.get(`/managers/?email=${email as string}`);
+  return api.get(`/managers?email=${email as string}`);
 };
 
 export const postJoin = ({ email, password, organization }: JoinParams): Promise<AxiosResponse> => {
   return api.post('/managers', { email, password, organization });
 };
+
+export const postSocialJoin = ({
+  email,
+  organization,
+  oauthProvider,
+}: SocialJoinParams): Promise<AxiosResponse> =>
+  api.post(`/api/managers/oauth`, {
+    email,
+    organization,
+    oauthProvider,
+  });

--- a/frontend/src/api/login.ts
+++ b/frontend/src/api/login.ts
@@ -1,4 +1,6 @@
 import { AxiosResponse } from 'axios';
+import { QueryFunction, QueryKey } from 'react-query';
+import { LoginSuccess } from 'types/response';
 import api from './api';
 
 interface LoginParams {
@@ -6,6 +8,28 @@ interface LoginParams {
   password: string;
 }
 
+export interface SocialLoginParams {
+  code: string;
+}
+
 export const postLogin = (loginData: LoginParams): Promise<AxiosResponse> => {
-  return api.post('/login/token', loginData);
+  return api.post('/managers/login/token', loginData);
+};
+
+export const queryGithubLogin: QueryFunction<
+  AxiosResponse<LoginSuccess>,
+  [QueryKey, SocialLoginParams]
+> = ({ queryKey }) => {
+  const [, { code }] = queryKey;
+
+  return api.get(`/managers/github/login/token?code=${code}`);
+};
+
+export const queryGoogleLogin: QueryFunction<
+  AxiosResponse<LoginSuccess>,
+  [QueryKey, SocialLoginParams]
+> = ({ queryKey }) => {
+  const [, { code }] = queryKey;
+
+  return api.get(`/api/managers/google/login/token?code=${code}`);
 };

--- a/frontend/src/components/Input/Input.styles.ts
+++ b/frontend/src/components/Input/Input.styles.ts
@@ -68,6 +68,10 @@ export const Input = styled.input<InputProps>`
     border-color: ${({ theme }) => theme.primary[400]};
     box-shadow: inset 0px 0px 0px 1px ${({ theme }) => theme.primary[400]};
   }
+
+  &:disabled {
+    color: ${({ theme }) => theme.gray[400]};
+  }
 `;
 
 export const Message = styled.p<MessageProps>`

--- a/frontend/src/components/SocialAuthButton/SociaLoginButton.stories.tsx
+++ b/frontend/src/components/SocialAuthButton/SociaLoginButton.stories.tsx
@@ -7,7 +7,7 @@ export default {
   component: SocialLoginButton,
   argTypes: {
     provider: {
-      options: ['github', 'google'],
+      options: ['GITHUB', 'GOOGLE'],
       control: { type: 'radio' },
     },
   },
@@ -15,12 +15,22 @@ export default {
 
 const Template: Story<PropsWithChildren<Props>> = (args) => <SocialLoginButton {...args} />;
 
-export const Github = Template.bind({});
-Github.args = {
-  provider: 'github',
+export const GithubLogin = Template.bind({});
+GithubLogin.args = {
+  provider: 'GITHUB',
 };
 
-export const Google = Template.bind({});
-Google.args = {
-  provider: 'google',
+export const GoogleLogin = Template.bind({});
+GoogleLogin.args = {
+  provider: 'GOOGLE',
+};
+
+export const GithubJoin = Template.bind({});
+GithubJoin.args = {
+  provider: 'GITHUB',
+};
+
+export const GoogleJoin = Template.bind({});
+GoogleJoin.args = {
+  provider: 'GOOGLE',
 };

--- a/frontend/src/components/SocialAuthButton/SocialAuthButton.styles.ts
+++ b/frontend/src/components/SocialAuthButton/SocialAuthButton.styles.ts
@@ -1,22 +1,22 @@
 import styled, { css } from 'styled-components';
 import PALETTE from 'constants/palette';
-import { Props } from './SocialLoginButton';
+import { Props as JoinButtonProps } from './SocialJoinButton';
+import { Props as LoginButtonProps } from './SocialLoginButton';
 
 const providerCSS = {
-  github: css`
+  GITHUB: css`
     background-color: ${PALETTE.GITHUB};
     color: ${PALETTE.WHITE};
     border: none;
   `,
-  google: css`
+  GOOGLE: css`
     background-color: ${PALETTE.WHITE};
     color: ${PALETTE.BLACK[700]};
     border: 1px solid ${PALETTE.BLACK[700]};
   `,
 };
 
-export const SocialLoginButton = styled.a<Props>`
-  ${({ provider }) => providerCSS[provider]};
+const buttonCSS = css`
   display: flex;
   justify-content: center;
   align-items: center;
@@ -24,6 +24,19 @@ export const SocialLoginButton = styled.a<Props>`
   text-decoration: none;
   padding: 0.75rem 1rem;
   font-size: 1.25rem;
+  border-radius: 0.125rem;
+`;
+
+export const SocialLoginButton = styled.a<LoginButtonProps>`
+  ${({ provider }) => providerCSS[provider]}
+  ${buttonCSS};
+`;
+
+export const SocialJoinButton = styled.button<JoinButtonProps>`
+  ${({ provider }) => providerCSS[provider]}
+  ${buttonCSS};
+  width: 100%;
+  cursor: pointer;
 `;
 
 export const Icon = styled.div`

--- a/frontend/src/components/SocialAuthButton/SocialJoinButton.stories.tsx
+++ b/frontend/src/components/SocialAuthButton/SocialJoinButton.stories.tsx
@@ -1,0 +1,26 @@
+import { Story } from '@storybook/react';
+import { PropsWithChildren } from 'react';
+import SocialJoinButton, { Props } from './SocialJoinButton';
+
+export default {
+  title: 'shared/SocialJoinButton',
+  component: SocialJoinButton,
+  argTypes: {
+    provider: {
+      options: ['GITHUB', 'GOOGLE'],
+      control: { type: 'radio' },
+    },
+  },
+};
+
+const Template: Story<PropsWithChildren<Props>> = (args) => <SocialJoinButton {...args} />;
+
+export const GithubJoin = Template.bind({});
+GithubJoin.args = {
+  provider: 'GITHUB',
+};
+
+export const GoogleJoin = Template.bind({});
+GoogleJoin.args = {
+  provider: 'GOOGLE',
+};

--- a/frontend/src/components/SocialAuthButton/SocialJoinButton.tsx
+++ b/frontend/src/components/SocialAuthButton/SocialJoinButton.tsx
@@ -1,0 +1,30 @@
+import { ButtonHTMLAttributes } from 'react';
+import { ReactComponent as GithubIcon } from 'assets/svg/github-logo.svg';
+import { ReactComponent as GoogleIcon } from 'assets/svg/google-logo.svg';
+import * as Styled from './SocialAuthButton.styles';
+
+export interface Props extends ButtonHTMLAttributes<HTMLButtonElement> {
+  provider: 'GITHUB' | 'GOOGLE';
+}
+
+const social = {
+  GITHUB: {
+    icon: <GithubIcon />,
+    text: 'Github로 시작하기',
+  },
+  GOOGLE: {
+    icon: <GoogleIcon />,
+    text: 'Google로 시작하기',
+  },
+};
+
+const SocialJoinButton = ({ provider, ...props }: Props): JSX.Element => {
+  return (
+    <Styled.SocialJoinButton provider={provider} {...props}>
+      <Styled.Icon>{social[provider].icon}</Styled.Icon>
+      <Styled.Text>{social[provider].text}</Styled.Text>
+    </Styled.SocialJoinButton>
+  );
+};
+
+export default SocialJoinButton;

--- a/frontend/src/components/SocialAuthButton/SocialLoginButton.tsx
+++ b/frontend/src/components/SocialAuthButton/SocialLoginButton.tsx
@@ -1,18 +1,18 @@
 import { AnchorHTMLAttributes } from 'react';
 import { ReactComponent as GithubIcon } from 'assets/svg/github-logo.svg';
 import { ReactComponent as GoogleIcon } from 'assets/svg/google-logo.svg';
-import * as Styled from './SocialLoginButton.styles';
+import * as Styled from './SocialAuthButton.styles';
 
 export interface Props extends AnchorHTMLAttributes<HTMLAnchorElement> {
-  provider: 'github' | 'google';
+  provider: 'GITHUB' | 'GOOGLE';
 }
 
 const social = {
-  github: {
+  GITHUB: {
     icon: <GithubIcon />,
     text: 'Github로 로그인',
   },
-  google: {
+  GOOGLE: {
     icon: <GoogleIcon />,
     text: 'Google로 로그인',
   },

--- a/frontend/src/constants/path.ts
+++ b/frontend/src/constants/path.ts
@@ -1,7 +1,28 @@
+const GITHUB_OAUTH_KEY = (() => {
+  if (process.env.NODE_ENV === 'development' && process.env.DEPLOY_ENV === 'development') {
+    return process.env.GITHUB_OAUTH_KEY_LOCAL ?? '';
+  }
+
+  if (process.env.NODE_ENV === 'production' && process.env.DEPLOY_ENV === 'development') {
+    return process.env.GITHUB_OAUTH_KEY_DEV ?? '';
+  }
+
+  if (process.env.NODE_ENV === 'production' && process.env.DEPLOY_ENV === 'production') {
+    return process.env.GITHUB_OAUTH_KEY_PROD ?? '';
+  }
+
+  return '';
+})();
+
+const GOOGLE_OAUTH_KEY = process.env.GOOGLE_OAUTH_KEY ?? '';
+
 const PATH = {
   MAIN: '/',
   MANAGER_LOGIN: '/login',
   MANAGER_JOIN: '/join',
+  MANAGER_SOCIAL_JOIN: '/join/social',
+  MANAGER_GITHUB_OAUTH_REDIRECT: '/login/oauth/github',
+  MANAGER_GOOGLE_OAUTH_REDIRECT: '/login/oauth/google',
   MANAGER_MAIN: '/map',
   MANAGER_RESERVATION_EDIT: '/reservation/edit',
   MANAGER_MAP_CREATE: '/map/create',
@@ -11,6 +32,16 @@ const PATH = {
   GUEST_RESERVATION: '/guest/:sharingMapId/reservation',
   GUEST_RESERVATION_EDIT: '/guest/:sharingMapId/reservation/edit',
   NOT_FOUND: ['*', '/not-found'],
+  GITHUB_LOGIN: `https://github.com/login/oauth/authorize?client_id=${GITHUB_OAUTH_KEY}&redirect_uri=http://localhost:3000/login/oauth/github`,
+  GOOGLE_LOGIN:
+    'https://accounts.google.com/o/oauth2/v2/auth?' +
+    'scope=https://www.googleapis.com/auth/userinfo.email&' +
+    'access_type=offline&' +
+    'include_granted_scopes=true&' +
+    'response_type=code&' +
+    'state=state_parameter_passthrough_value&' +
+    'redirect_uri=http://localhost:3000/login/oauth/google&' +
+    `client_id=${GOOGLE_OAUTH_KEY}`,
 };
 
 export const HREF = {

--- a/frontend/src/constants/routes.tsx
+++ b/frontend/src/constants/routes.tsx
@@ -7,7 +7,10 @@ import ManagerLogin from 'pages/ManagerLogin/ManagerLogin';
 import ManagerMain from 'pages/ManagerMain/ManagerMain';
 import ManagerMapEditor from 'pages/ManagerMapEditor/ManagerMapEditor';
 import ManagerReservationEdit from 'pages/ManagerReservationEdit/ManagerReservationEdit';
+import ManagerSocialJoin from 'pages/ManagerSocialJoin/ManagerSocialJoin';
 import ManagerSpaceEditor from 'pages/ManagerSpaceEditor/ManagerSpaceEditor';
+import GithubOAuthRedirect from 'pages/OAuthRedirect/GithubOAuthRedirect';
+import GoogleOAuthRedirect from 'pages/OAuthRedirect/GoogleOAuthRedirect';
 import PATH from './path';
 
 interface Route {
@@ -31,6 +34,18 @@ export const PUBLIC_ROUTES: Route[] = [
   {
     path: PATH.MANAGER_JOIN,
     component: <ManagerJoin />,
+  },
+  {
+    path: PATH.MANAGER_SOCIAL_JOIN,
+    component: <ManagerSocialJoin />,
+  },
+  {
+    path: PATH.MANAGER_GITHUB_OAUTH_REDIRECT,
+    component: <GithubOAuthRedirect />,
+  },
+  {
+    path: PATH.MANAGER_GOOGLE_OAUTH_REDIRECT,
+    component: <GoogleOAuthRedirect />,
   },
   {
     path: PATH.GUEST_MAP,

--- a/frontend/src/hooks/query/useGithubLogin.ts
+++ b/frontend/src/hooks/query/useGithubLogin.ts
@@ -1,0 +1,21 @@
+import { AxiosError, AxiosResponse } from 'axios';
+import { QueryKey, useQuery, UseQueryOptions, UseQueryResult } from 'react-query';
+import { queryGithubLogin, SocialLoginParams } from 'api/login';
+import { LoginSuccess, SocialLoginFailure } from 'types/response';
+
+const useGithubLogin = <TData = AxiosResponse<LoginSuccess>>(
+  { code }: SocialLoginParams,
+  options?: UseQueryOptions<
+    AxiosResponse<LoginSuccess>,
+    AxiosError<SocialLoginFailure>,
+    TData,
+    [QueryKey, SocialLoginParams]
+  >
+): UseQueryResult<TData, AxiosError<SocialLoginFailure>> =>
+  useQuery(['getGithubLogin', { code }], queryGithubLogin, {
+    ...options,
+    retry: false,
+    refetchOnWindowFocus: false,
+  });
+
+export default useGithubLogin;

--- a/frontend/src/hooks/query/useGoogleLogin.ts
+++ b/frontend/src/hooks/query/useGoogleLogin.ts
@@ -1,0 +1,21 @@
+import { AxiosError, AxiosResponse } from 'axios';
+import { QueryKey, useQuery, UseQueryOptions, UseQueryResult } from 'react-query';
+import { queryGoogleLogin, SocialLoginParams } from 'api/login';
+import { SocialLoginFailure, LoginSuccess } from 'types/response';
+
+const useGoogleLogin = <TData = AxiosResponse<LoginSuccess>>(
+  { code }: SocialLoginParams,
+  options?: UseQueryOptions<
+    AxiosResponse<LoginSuccess>,
+    AxiosError<SocialLoginFailure>,
+    TData,
+    [QueryKey, SocialLoginParams]
+  >
+): UseQueryResult<TData, AxiosError<SocialLoginFailure>> =>
+  useQuery(['getGoogleLogin', { code }], queryGoogleLogin, {
+    ...options,
+    retry: false,
+    refetchOnWindowFocus: false,
+  });
+
+export default useGoogleLogin;

--- a/frontend/src/hooks/useQueryString.ts
+++ b/frontend/src/hooks/useQueryString.ts
@@ -1,0 +1,5 @@
+import { useLocation } from 'react-router-dom';
+
+const useQueryString = (): URLSearchParams => new URLSearchParams(useLocation().search);
+
+export default useQueryString;

--- a/frontend/src/pages/ManagerLogin/ManagerLogin.tsx
+++ b/frontend/src/pages/ManagerLogin/ManagerLogin.tsx
@@ -7,7 +7,7 @@ import { useSetRecoilState } from 'recoil';
 import { postLogin } from 'api/login';
 import Header from 'components/Header/Header';
 import Layout from 'components/Layout/Layout';
-import SocialLoginButton from 'components/SocialLoginButton/SocialLoginButton';
+import SocialLoginButton from 'components/SocialAuthButton/SocialLoginButton';
 import MESSAGE from 'constants/message';
 import PATH from 'constants/path';
 import { LOCAL_STORAGE_KEY } from 'constants/storage';
@@ -74,8 +74,8 @@ const ManagerLogin = (): JSX.Element => {
           <LoginForm errorMessage={errorMessage} onSubmit={handleSubmit} />
           <Styled.HorizontalLine />
           <Styled.SocialLogin>
-            <SocialLoginButton provider="github" />
-            <SocialLoginButton provider="google" />
+            <SocialLoginButton provider="GITHUB" href={PATH.GITHUB_LOGIN} />
+            <SocialLoginButton provider="GOOGLE" href={PATH.GOOGLE_LOGIN} />
           </Styled.SocialLogin>
           <Styled.JoinLinkMessage>
             아직 회원이 아니신가요?

--- a/frontend/src/pages/ManagerSocialJoin/ManagerSocialJoin.styles.ts
+++ b/frontend/src/pages/ManagerSocialJoin/ManagerSocialJoin.styles.ts
@@ -1,0 +1,14 @@
+import styled from 'styled-components';
+
+export const Container = styled.div`
+  width: 100%;
+  max-width: 660px;
+  margin: 0 auto;
+`;
+
+export const PageTitle = styled.h2`
+  font-size: 1.5rem;
+  font-weight: 400;
+  text-align: center;
+  margin: 2.125rem auto;
+`;

--- a/frontend/src/pages/ManagerSocialJoin/ManagerSocialJoin.tsx
+++ b/frontend/src/pages/ManagerSocialJoin/ManagerSocialJoin.tsx
@@ -1,0 +1,63 @@
+import { AxiosError } from 'axios';
+import { useMutation } from 'react-query';
+import { useHistory, useLocation } from 'react-router-dom';
+import { postSocialJoin } from 'api/join';
+import Header from 'components/Header/Header';
+import Layout from 'components/Layout/Layout';
+import MESSAGE from 'constants/message';
+import PATH from 'constants/path';
+import { ErrorResponse } from 'types/response';
+import * as Styled from './ManagerSocialJoin.styles';
+import SocialJoinForm from './units/SocialJoinForm';
+
+export interface SocialJoinParams {
+  email: string;
+  organization: string;
+}
+
+interface SocialJoinState {
+  email: string;
+  oauthProvider: 'GITHUB' | 'GOOGLE';
+}
+
+const ManagerSocialJoin = (): JSX.Element => {
+  const history = useHistory();
+  const location = useLocation<SocialJoinState>();
+
+  const email = location.state?.email;
+  const oauthProvider = location.state?.oauthProvider;
+
+  const socialJoin = useMutation(postSocialJoin, {
+    onSuccess: () => {
+      history.replace(PATH.MANAGER_LOGIN);
+    },
+
+    onError: (error: AxiosError<ErrorResponse>) => {
+      alert(error?.response?.data.message ?? MESSAGE.JOIN.FAILURE);
+    },
+  });
+
+  const handleSubmit = ({ email, organization }: SocialJoinParams) => {
+    if (!email || !organization || !oauthProvider || socialJoin.isLoading) return;
+
+    socialJoin.mutate({ email, organization, oauthProvider });
+  };
+
+  if (!email || !oauthProvider) {
+    history.replace(PATH.MANAGER_LOGIN);
+  }
+
+  return (
+    <>
+      <Header />
+      <Layout>
+        <Styled.Container>
+          <Styled.PageTitle>추가 정보 입력</Styled.PageTitle>
+          <SocialJoinForm email={email} oauthProvider={oauthProvider} onSubmit={handleSubmit} />
+        </Styled.Container>
+      </Layout>
+    </>
+  );
+};
+
+export default ManagerSocialJoin;

--- a/frontend/src/pages/ManagerSocialJoin/units/SocialJoinForm.styles.ts
+++ b/frontend/src/pages/ManagerSocialJoin/units/SocialJoinForm.styles.ts
@@ -1,0 +1,9 @@
+import styled from 'styled-components';
+
+export const Form = styled.form`
+  margin: 3.75rem 0 1rem;
+
+  label {
+    margin-bottom: 3rem;
+  }
+`;

--- a/frontend/src/pages/ManagerSocialJoin/units/SocialJoinForm.tsx
+++ b/frontend/src/pages/ManagerSocialJoin/units/SocialJoinForm.tsx
@@ -1,0 +1,70 @@
+import { FormEventHandler, useEffect, useState } from 'react';
+import Input from 'components/Input/Input';
+import SocialJoinButton from 'components/SocialAuthButton/SocialJoinButton';
+import MANAGER from 'constants/manager';
+import MESSAGE from 'constants/message';
+import REGEXP from 'constants/regexp';
+import useInput from 'hooks/useInput';
+import { SocialJoinParams } from '../ManagerSocialJoin';
+import * as Styled from './SocialJoinForm.styles';
+
+interface Props {
+  email: string;
+  oauthProvider: 'GITHUB' | 'GOOGLE';
+  onSubmit: ({ email, organization }: SocialJoinParams) => void;
+}
+
+const SocialJoinForm = ({ email, oauthProvider, onSubmit }: Props): JSX.Element => {
+  const [organization, onChangeForm] = useInput('');
+
+  const [organizationMessage, setOrganizationMessage] = useState('');
+
+  const isValidOrganization = REGEXP.ORGANIZATION.test(organization);
+
+  const handleSubmit: FormEventHandler<HTMLFormElement> = (event) => {
+    event.preventDefault();
+
+    onSubmit({ email, organization });
+  };
+
+  useEffect(() => {
+    if (!organization) {
+      setOrganizationMessage('');
+
+      return;
+    }
+
+    setOrganizationMessage(
+      isValidOrganization ? MESSAGE.JOIN.VALID_ORGANIZATION : MESSAGE.JOIN.INVALID_ORGANIZATION
+    );
+  }, [organization, isValidOrganization]);
+
+  return (
+    <Styled.Form onSubmit={handleSubmit}>
+      <Input
+        type="email"
+        label="이메일"
+        name="email"
+        value={email}
+        onChange={onChangeForm}
+        required
+        disabled
+      />
+      <Input
+        type="text"
+        label="조직명"
+        name="organization"
+        minLength={MANAGER.ORGANIZATION.MIN_LENGTH}
+        value={organization}
+        onChange={onChangeForm}
+        message={organizationMessage}
+        status={isValidOrganization ? 'success' : 'error'}
+        required
+        autoFocus
+      />
+      <SocialJoinButton provider={oauthProvider} />
+    </Styled.Form>
+  );
+};
+
+export default SocialJoinForm;

--- a/frontend/src/pages/OAuthRedirect/GithubOAuthRedirect.tsx
+++ b/frontend/src/pages/OAuthRedirect/GithubOAuthRedirect.tsx
@@ -1,0 +1,55 @@
+import { AxiosError, AxiosResponse } from 'axios';
+import { useHistory } from 'react-router';
+import { useSetRecoilState } from 'recoil';
+import MESSAGE from 'constants/message';
+import PATH from 'constants/path';
+import { LOCAL_STORAGE_KEY } from 'constants/storage';
+import useGithubLogin from 'hooks/query/useGithubLogin';
+import useQueryString from 'hooks/useQueryString';
+import accessTokenState from 'state/accessTokenState';
+import { LoginSuccess, SocialLoginFailure } from 'types/response';
+import { setLocalStorageItem } from 'utils/localStorage';
+
+const GithubOAuthRedirect = (): JSX.Element => {
+  const history = useHistory();
+  const setAccessToken = useSetRecoilState(accessTokenState);
+
+  const query = useQueryString();
+  const code = query.get('code') ?? '';
+
+  useGithubLogin(
+    { code },
+    {
+      onSuccess: (response: AxiosResponse<LoginSuccess>) => {
+        const { accessToken } = response.data;
+
+        setAccessToken(accessToken);
+        setLocalStorageItem({ key: LOCAL_STORAGE_KEY.ACCESS_TOKEN, item: accessToken });
+
+        history.replace(PATH.MANAGER_MAIN);
+      },
+
+      onError: (error: AxiosError<SocialLoginFailure>) => {
+        if (error.response?.status === 404) {
+          history.push({
+            pathname: PATH.MANAGER_SOCIAL_JOIN,
+            state: {
+              oauthProvider: 'GITHUB',
+              email: error.response?.data?.email,
+            },
+          });
+
+          return;
+        }
+
+        alert(error.response?.data.message ?? MESSAGE.LOGIN.UNEXPECTED_ERROR);
+
+        history.replace(PATH.MANAGER_LOGIN);
+      },
+    }
+  );
+
+  return <div />;
+};
+
+export default GithubOAuthRedirect;

--- a/frontend/src/pages/OAuthRedirect/GoogleOAuthRedirect.tsx
+++ b/frontend/src/pages/OAuthRedirect/GoogleOAuthRedirect.tsx
@@ -1,0 +1,55 @@
+import { AxiosError, AxiosResponse } from 'axios';
+import { useHistory } from 'react-router';
+import { useSetRecoilState } from 'recoil';
+import MESSAGE from 'constants/message';
+import PATH from 'constants/path';
+import { LOCAL_STORAGE_KEY } from 'constants/storage';
+import useGoogleLogin from 'hooks/query/useGoogleLogin';
+import useQueryString from 'hooks/useQueryString';
+import accessTokenState from 'state/accessTokenState';
+import { SocialLoginFailure, LoginSuccess } from 'types/response';
+import { setLocalStorageItem } from 'utils/localStorage';
+
+const GoogleOAuthRedirect = (): JSX.Element => {
+  const history = useHistory();
+  const setAccessToken = useSetRecoilState(accessTokenState);
+
+  const query = useQueryString();
+  const code = query.get('code') ?? '';
+
+  useGoogleLogin(
+    { code },
+    {
+      onSuccess: (response: AxiosResponse<LoginSuccess>) => {
+        const { accessToken } = response.data;
+
+        setAccessToken(accessToken);
+        setLocalStorageItem({ key: LOCAL_STORAGE_KEY.ACCESS_TOKEN, item: accessToken });
+
+        history.replace(PATH.MANAGER_MAIN);
+      },
+
+      onError: (error: AxiosError<SocialLoginFailure>) => {
+        if (error.response?.status === 404) {
+          history.push({
+            pathname: PATH.MANAGER_SOCIAL_JOIN,
+            state: {
+              oauthProvider: 'GOOGLE',
+              email: error.response?.data?.email,
+            },
+          });
+
+          return;
+        }
+
+        alert(error.response?.data.message ?? MESSAGE.LOGIN.UNEXPECTED_ERROR);
+
+        history.replace(PATH.MANAGER_LOGIN);
+      },
+    }
+  );
+
+  return <div />;
+};
+
+export default GoogleOAuthRedirect;

--- a/frontend/src/types/response.ts
+++ b/frontend/src/types/response.ts
@@ -17,6 +17,16 @@ export interface LoginSuccess {
   accessToken: string;
 }
 
+export interface SocialLoginFailure {
+  message?: string;
+  email?: string;
+}
+
+export interface QuerySocialEmailSuccess {
+  email: string;
+  oauthProvider: 'GITHUB' | 'GOOGLE';
+}
+
 export type QueryGuestMapSuccess = MapItemResponse;
 
 export type QueryManagerMapSuccess = MapItemResponse;

--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -3,6 +3,7 @@ const HtmlWebpackPlugin = require('html-webpack-plugin');
 const FaviconsWebpackPlugin = require('favicons-webpack-plugin');
 const TsconfigPathsPlugin = require('tsconfig-paths-webpack-plugin');
 const webpack = require('webpack');
+const Dotenv = require('dotenv-webpack');
 
 module.exports = () => {
   const isDevelopment = process.env.NODE_ENV !== 'production';
@@ -74,6 +75,7 @@ module.exports = () => {
         'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV),
         'process.env.DEPLOY_ENV': JSON.stringify(process.env.DEPLOY_ENV),
       }),
+      new Dotenv(),
     ],
   };
 };

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -6289,6 +6289,13 @@ dotenv-defaults@^1.0.2:
   dependencies:
     dotenv "^6.2.0"
 
+dotenv-defaults@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/dotenv-defaults/-/dotenv-defaults-2.0.2.tgz#6b3ec2e4319aafb70940abda72d3856770ee77ac"
+  integrity sha512-iOIzovWfsUHU91L5i8bJce3NYK5JXeAwH50Jh6+ARUdLiiGlYWfGw6UkzsYqaXZH/hjE/eCd/PlfM/qqyK0AMg==
+  dependencies:
+    dotenv "^8.2.0"
+
 dotenv-expand@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/dotenv-expand/-/dotenv-expand-5.1.0.tgz#3fbaf020bfd794884072ea26b1e9791d45a629f0"
@@ -6301,12 +6308,19 @@ dotenv-webpack@^1.8.0:
   dependencies:
     dotenv-defaults "^1.0.2"
 
+dotenv-webpack@^7.0.3:
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/dotenv-webpack/-/dotenv-webpack-7.0.3.tgz#f50ec3c7083a69ec6076e110566720003b7b107b"
+  integrity sha512-O0O9pOEwrk+n1zzR3T2uuXRlw64QxHSPeNN1GaiNBloQFNaCUL9V8jxSVz4jlXXFP/CIqK8YecWf8BAvsSgMjw==
+  dependencies:
+    dotenv-defaults "^2.0.2"
+
 dotenv@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-6.2.0.tgz#941c0410535d942c8becf28d3f357dbd9d476064"
   integrity sha512-HygQCKUBSFl8wKQZBSemMywRWcEDNidvNbjGVyZu3nbZ8qq9ubiPoGLMdRDpfSrpkkm9BXYFkpKxxFX38o/76w==
 
-dotenv@^8.0.0:
+dotenv@^8.0.0, dotenv@^8.2.0:
   version "8.6.0"
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-8.6.0.tgz#061af664d19f7f4d8fc6e4ff9b584ce237adcb8b"
   integrity sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==


### PR DESCRIPTION
## 구현 기능
- Github, Google OAuth 공간 관리자 로그인 구현
- `SocialJoinButton` 컴포넌트 구현 (`Github로 시작하기`, `Google로 시작하기` 버튼)
- `Input` 컴포넌트에 disabled 스타일 적용
- `.env` 파일 및 설정 추가

## 수정 사항
- `PrivateRoute`에서 `token`을 Recoil이 아닌 `localStorage`에서 가져오도록 수정
  - OAuth 로그인 시, Recoil에서 `token` 값이 바로 반영되지 않는 문제가 있어 `localStorage`에서 `token`을 가져오도록 수정 구현했습니다.
- 이메일 중복 체크, 공간 관리자 로그인 API URL을 올바르게 수정했습니다.
- 처음 로그인했을 때, 회원가입 이후 한 번 더 로그인을 시도해야 로그인됩니다. 이후, 소셜 회원가입하고 바로 로그인되어 메인 페이지로 넘어가도록 구현할 예정입니다.

## 공유하고 싶은 내용
- 공유드린 `.env` 파일을 root에 놓아주세요.
- `dotenv-webpack` 플러그인을 추가했으니 `yarn install`을 한 번 실행해주세요.
- PR 머지 후 실제로 잘 동작하는지 확인이 필요합니다. PR 머지하고 소셜 로그인 시도 후 문제가 생긴다면 바로 이슈 올리겠습니다.

Close #465


