### PR TITLE
fix: OAuth 로그인 시 요청 URL이 잘못되어 있는 문제

### DIFF
--- a/frontend/src/api/join.ts
+++ b/frontend/src/api/join.ts
@@ -36,7 +36,7 @@ export const postSocialJoin = ({
   organization,
   oauthProvider,
 }: SocialJoinParams): Promise<AxiosResponse> =>
-  api.post(`/api/managers/oauth`, {
+  api.post(`/managers/oauth`, {
     email,
     organization,
     oauthProvider,

--- a/frontend/src/api/login.ts
+++ b/frontend/src/api/login.ts
@@ -31,5 +31,5 @@ export const queryGoogleLogin: QueryFunction<
 > = ({ queryKey }) => {
   const [, { code }] = queryKey;
 
-  return api.get(`/api/managers/google/login/token?code=${code}`);
+  return api.get(`/managers/google/login/token?code=${code}`);
 };


### PR DESCRIPTION
## 구현 기능
- OAuth 로그인 시 요청 URL이 잘못되어 있는 문제를 수정했습니다.
  - URL 주소에 /api이라는 문자열이 두 번 포함되어 있는 상태였으며, 한 번만 포함되도록 수정했습니다.

Close #569

