### PR TITLE
feat: 공간 예약 후 랜딩 페이지 구현

### DIFF
--- a/frontend/src/constants/path.ts
+++ b/frontend/src/constants/path.ts
@@ -36,6 +36,7 @@ const PATH = {
   GUEST_MAP: '/guest/:sharingMapId',
   GUEST_RESERVATION: '/guest/:sharingMapId/reservation',
   GUEST_RESERVATION_EDIT: '/guest/:sharingMapId/reservation/edit',
+  GUEST_RESERVATION_SUCCESS: '/guest/:sharingMapId/success',
   NOT_FOUND: '/not-found',
   GITHUB_LOGIN: `https://github.com/login/oauth/authorize?client_id=${GITHUB_OAUTH_KEY}&redirect_uri=${REDIRECT_URI}/login/oauth/github`,
   GOOGLE_LOGIN:
@@ -57,6 +58,8 @@ export const HREF = {
     PATH.GUEST_MAP.replace(':sharingMapId', `${sharingMapId}`),
   GUEST_RESERVATION: (sharingMapId: string): string =>
     PATH.GUEST_RESERVATION.replace(':sharingMapId', `${sharingMapId}`),
+  GUEST_RESERVATION_SUCCESS: (sharingMapId: string): string =>
+    PATH.GUEST_RESERVATION_SUCCESS.replace(':sharingMapId', `${sharingMapId}`),
 };
 
 export default PATH;

--- a/frontend/src/constants/routes.tsx
+++ b/frontend/src/constants/routes.tsx
@@ -1,4 +1,5 @@
 import React, { ReactNode } from 'react';
+import GuestReservationSuccess from 'pages/GuestReservation/GuestReservationSuccess';
 import PATH from './path';
 
 const GuestMap = React.lazy(() => import('pages/GuestMap/GuestMap'));
@@ -59,6 +60,10 @@ export const PUBLIC_ROUTES: Route[] = [
   {
     path: PATH.GUEST_RESERVATION_EDIT,
     component: <GuestReservation />,
+  },
+  {
+    path: PATH.GUEST_RESERVATION_SUCCESS,
+    component: <GuestReservationSuccess />,
   },
 ];
 

--- a/frontend/src/pages/GuestMap/GuestMap.tsx
+++ b/frontend/src/pages/GuestMap/GuestMap.tsx
@@ -17,6 +17,7 @@ import useGuestMap from 'hooks/query/useGuestMap';
 import useGuestSpaces from 'hooks/query/useGuestSpaces';
 import useInput from 'hooks/useInput';
 import { Area, MapDrawing, MapItem, Reservation, ScrollPosition, Space } from 'types/common';
+import { GuestPageURLParams } from 'types/guest';
 import { ErrorResponse } from 'types/response';
 import { formatDate } from 'utils/datetime';
 import * as Styled from './GuestMap.styles';
@@ -28,10 +29,6 @@ export interface GuestMapState {
   scrollPosition?: ScrollPosition;
 }
 
-export interface URLParameter {
-  sharingMapId: MapItem['sharingMapId'];
-}
-
 const GuestMap = (): JSX.Element => {
   const [detailOpen, setDetailOpen] = useState(false);
   const [passwordInputModalOpen, setPasswordInputModalOpen] = useState(false);
@@ -41,7 +38,7 @@ const GuestMap = (): JSX.Element => {
 
   const history = useHistory();
   const location = useLocation<GuestMapState>();
-  const { sharingMapId } = useParams<URLParameter>();
+  const { sharingMapId } = useParams<GuestPageURLParams>();
 
   const mapRef = useRef<HTMLDivElement | null>(null);
 
@@ -167,11 +164,13 @@ const GuestMap = (): JSX.Element => {
     if (scrollPosition) {
       mapRef?.current?.scrollTo(scrollPosition.x ?? 0, scrollPosition.y ?? 0);
     }
+  }, [scrollPosition]);
 
+  useEffect(() => {
     if (targetDate) {
       setDate(new Date(targetDate));
     }
-  }, [scrollPosition, targetDate]);
+  }, [targetDate]);
 
   return (
     <>

--- a/frontend/src/pages/GuestReservation/GuestReservation.tsx
+++ b/frontend/src/pages/GuestReservation/GuestReservation.tsx
@@ -12,14 +12,11 @@ import { HREF } from 'constants/path';
 import useGuestReservations from 'hooks/query/useGuestReservations';
 import useInput from 'hooks/useInput';
 import { GuestMapState } from 'pages/GuestMap/GuestMap';
-import { MapItem, Reservation, ScrollPosition, Space } from 'types/common';
+import { Reservation, ScrollPosition, Space } from 'types/common';
+import { GuestPageURLParams } from 'types/guest';
 import { ErrorResponse } from 'types/response';
 import * as Styled from './GuestReservation.styles';
 import GuestReservationForm from './units/GuestReservationForm';
-
-interface URLParameter {
-  sharingMapId: MapItem['sharingMapId'];
-}
 
 interface GuestReservationState {
   mapId: number;
@@ -36,7 +33,7 @@ export interface EditReservationParams extends ReservationParams {
 const GuestReservation = (): JSX.Element => {
   const location = useLocation<GuestReservationState>();
   const history = useHistory<GuestMapState>();
-  const { sharingMapId } = useParams<URLParameter>();
+  const { sharingMapId } = useParams<GuestPageURLParams>();
 
   const { mapId, space, selectedDate, scrollPosition, reservation } = location.state;
 
@@ -52,7 +49,7 @@ const GuestReservation = (): JSX.Element => {
   const addReservation = useMutation(postGuestReservation, {
     onSuccess: () => {
       history.push({
-        pathname: HREF.GUEST_MAP(sharingMapId),
+        pathname: HREF.GUEST_RESERVATION_SUCCESS(sharingMapId),
         state: {
           spaceId: space.id,
           targetDate: new Date(date),

--- a/frontend/src/pages/GuestReservation/GuestReservationSuccess.styles.ts
+++ b/frontend/src/pages/GuestReservation/GuestReservationSuccess.styles.ts
@@ -1,0 +1,28 @@
+import { Link } from 'react-router-dom';
+import styled from 'styled-components';
+
+export const Container = styled.div`
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 1.5rem;
+  height: calc(100vh - 4rem);
+  padding-bottom: 6rem;
+
+  svg {
+    max-width: 200px;
+  }
+`;
+
+export const Message = styled.p`
+  font-size: 1.5rem;
+`;
+
+export const PageLink = styled(Link)`
+  color: ${({ theme }) => theme.primary[500]};
+  text-decoration: none;
+`;
+
+export const Logo = styled.img``;

--- a/frontend/src/pages/GuestReservation/GuestReservationSuccess.tsx
+++ b/frontend/src/pages/GuestReservation/GuestReservationSuccess.tsx
@@ -1,0 +1,40 @@
+import { Redirect, useLocation, useParams } from 'react-router';
+import { ReactComponent as Logo } from 'assets/svg/logo.svg';
+import Header from 'components/Header/Header';
+import Layout from 'components/Layout/Layout';
+import { HREF } from 'constants/path';
+import { GuestMapState } from 'pages/GuestMap/GuestMap';
+import { GuestPageURLParams } from 'types/guest';
+import * as Styled from './GuestReservationSuccess.styles';
+
+const GuestReservationSuccess = (): JSX.Element => {
+  const { sharingMapId } = useParams<GuestPageURLParams>();
+  const location = useLocation<GuestMapState>();
+
+  if (!location.state) return <Redirect to={HREF.GUEST_MAP(sharingMapId)} />;
+
+  return (
+    <>
+      <Header />
+      <Layout>
+        <Styled.Container>
+          <Logo />
+          <Styled.Message>예약이 완료되었습니다!</Styled.Message>
+          <Styled.PageLink
+            to={{
+              pathname: HREF.GUEST_MAP(sharingMapId),
+              state: {
+                spaceId: location.state.spaceId,
+                targetDate: location.state.targetDate,
+              },
+            }}
+          >
+            맵으로 돌아가기
+          </Styled.PageLink>
+        </Styled.Container>
+      </Layout>
+    </>
+  );
+};
+
+export default GuestReservationSuccess;

--- a/frontend/src/types/guest.ts
+++ b/frontend/src/types/guest.ts
@@ -1,0 +1,5 @@
+import { MapItem } from './common';
+
+export interface GuestPageURLParams {
+  sharingMapId: MapItem['sharingMapId'];
+}


### PR DESCRIPTION
## 구현 기능
- 공간 예약 후 예약 성공 랜딩 페이지 구현

https://user-images.githubusercontent.com/2542730/135405383-550d5aeb-3d71-4e23-ac08-87ec41415c80.mp4

- 공간 예약 후 맵으로 돌아갔을 때, 예약했던 날짜가 선택되도록 구현
- 예약자 페이지에서 공통적으로 사용하는 `URLParameter`를 `GuestPageURLParams`로 분리 적용


## 공유하고 싶은 내용
  - 애니메이션을 적용한 로고를 넣고 싶었는데, SVG 파일에 정의된 script 태그 내의 코드를 파싱하지 못하는 문제가 있어서 적용하지 못했습니다. 다른 형태로 구현한 애니메이션 로고를 추후에 넣어보겠습니다.

Close #185 

