### PR TITLE
fix: 맵 생성이 진행되지 않는 문제 수정

### DIFF
--- a/frontend/src/pages/ManagerMapEditor/ManagerMapEditor.tsx
+++ b/frontend/src/pages/ManagerMapEditor/ManagerMapEditor.tsx
@@ -121,7 +121,12 @@ const ManagerMapEditor = (): JSX.Element => {
 
     if (createMap.isLoading || updateMap.isLoading) return;
 
-    const mapDrawing = JSON.stringify({ width, height, mapElements });
+    const mapDrawing = JSON.stringify({
+      width,
+      height,
+      mapElements: mapElements.map(({ ref, ...props }) => props),
+    });
+
     const mapImageSvg = createMapImageSvg({
       mapElements,
       spaces,

--- a/frontend/src/types/common.ts
+++ b/frontend/src/types/common.ts
@@ -121,10 +121,11 @@ export interface DrawingStatus {
   start?: Coordinate;
   end?: Coordinate;
 }
+
 export interface MapDrawing {
   width: number;
   height: number;
-  mapElements: MapElement[];
+  mapElements: Omit<MapElement[], 'ref'>;
 }
 
 export interface GripPoint {


### PR DESCRIPTION
## 수정 사항
- [x] `MapElement` 객체 내부에 `ref` 속성으로 인해, `JSON.stringify` 실행 시 ref 객체까지 stringify되다가 에러가 발생하는 문제를 수정했습니다
- [x] 맵 요소 배열을 `JSON.parse`할 때의 타입 지정을 더욱 명확하게 했습니다.

Close #603 

