### PR TITLE
feat: TimePicker 구현

### DIFF
--- a/frontend/src/components/TimePicker/TimePicker.stories.tsx
+++ b/frontend/src/components/TimePicker/TimePicker.stories.tsx
@@ -1,0 +1,26 @@
+import { Story } from '@storybook/react';
+import TimePicker, { Props } from './TimePicker';
+
+export default {
+  title: 'shared/TimePicker',
+  component: TimePicker,
+  argTypes: {
+    step: {
+      options: [1, 5, 10, 15, 20, 30],
+      control: { type: 'radio' },
+    },
+  },
+};
+
+const Template: Story<Props> = (args) => <TimePicker {...args} />;
+
+export const Default = Template.bind({});
+Default.args = {
+  label: '기간 선택',
+  step: 5,
+};
+
+export const WithoutLabel = Template.bind({});
+WithoutLabel.args = {
+  step: 1,
+};

--- a/frontend/src/components/TimePicker/TimePicker.stories.tsx
+++ b/frontend/src/components/TimePicker/TimePicker.stories.tsx
@@ -22,5 +22,13 @@ Default.args = {
 
 export const WithoutLabel = Template.bind({});
 WithoutLabel.args = {
-  step: 1,
+  step: 10,
+};
+
+export const HasDefaultTime = Template.bind({});
+WithoutLabel.args = {
+  label: '기본 값이 존재하는 경우',
+  step: 15,
+  defaultStartTime: new Date(),
+  defaultEndTime: new Date(),
 };

--- a/frontend/src/components/TimePicker/TimePicker.stories.tsx
+++ b/frontend/src/components/TimePicker/TimePicker.stories.tsx
@@ -1,5 +1,6 @@
 import { Story } from '@storybook/react';
-import TimePicker, { Props } from './TimePicker';
+import TimePicker from './TimePicker';
+import useTimePicker from './useTimePicker';
 
 export default {
   title: 'shared/TimePicker',
@@ -12,7 +13,18 @@ export default {
   },
 };
 
-const Template: Story<Props> = (args) => <TimePicker {...args} />;
+interface Props {
+  label?: string;
+  defaultStartTime?: Date;
+  defaultEndTime?: Date;
+  step?: 1 | 5 | 10 | 15 | 20 | 30;
+}
+
+const Template: Story<Props> = (args) => {
+  const timePicker = useTimePicker(args);
+
+  return <TimePicker {...timePicker} label={args?.label} step={args?.step} />;
+};
 
 export const Default = Template.bind({});
 Default.args = {
@@ -20,15 +32,15 @@ Default.args = {
   step: 5,
 };
 
-export const WithoutLabel = Template.bind({});
-WithoutLabel.args = {
-  step: 10,
-};
-
 export const HasDefaultTime = Template.bind({});
-WithoutLabel.args = {
+HasDefaultTime.args = {
   label: '기본 값이 존재하는 경우',
   step: 15,
   defaultStartTime: new Date(),
   defaultEndTime: new Date(),
+};
+
+export const WithoutLabel = Template.bind({});
+WithoutLabel.args = {
+  step: 10,
 };

--- a/frontend/src/components/TimePicker/TimePicker.styles.ts
+++ b/frontend/src/components/TimePicker/TimePicker.styles.ts
@@ -1,0 +1,64 @@
+import styled, { css } from 'styled-components';
+
+interface TimeContainerProps {
+  labelText?: string;
+  isOptionOpen: boolean;
+}
+
+interface TimeButtonProps {
+  selected: boolean;
+}
+
+const labelTextCSS = (labelText: string) => css`
+  margin-top: 0.375rem;
+
+  &::before {
+    content: '${labelText}';
+    display: block;
+    position: absolute;
+    top: -0.375rem;
+    left: 0.75rem;
+    padding: 0 0.25rem;
+    font-size: 0.75rem;
+    background-color: white;
+    color: ${({ theme }) => theme.gray[500]};
+  }
+`;
+
+export const Container = styled.div`
+  position: relative;
+`;
+
+export const TimeContainer = styled.div<TimeContainerProps>`
+  height: 2.875rem;
+  display: flex;
+  justify-content: space-evenly;
+  align-items: center;
+  border: 1px solid ${({ theme }) => theme.gray[500]};
+  border-radius: ${({ isOptionOpen }) => (isOptionOpen ? '0.125rem 0.125rem 0 0' : '0.125rem')};
+  position: relative;
+  box-sizing: content-box;
+
+  ${({ labelText }) => (labelText ? labelTextCSS(labelText) : '')}
+`;
+
+export const TimeButton = styled.button<TimeButtonProps>`
+  padding: 0 0.5rem;
+  display: flex;
+  align-items: center;
+  height: inherit;
+  border: 0;
+  background-color: transparent;
+  letter-spacing: 1px;
+  font-size: 1rem;
+  cursor: pointer;
+
+  ${({ selected, theme }) =>
+    selected ? `box-shadow: inset 0 -0.125rem ${theme.primary[400] as string};` : ''}
+`;
+
+export const OptionsContainer = styled.div`
+  width: 100%;
+  position: absolute;
+  top: 3rem;
+`;

--- a/frontend/src/components/TimePicker/TimePicker.tsx
+++ b/frontend/src/components/TimePicker/TimePicker.tsx
@@ -1,0 +1,141 @@
+import React, { ChangeEventHandler, MouseEventHandler, useState } from 'react';
+import * as Styled from './TimePicker.styles';
+import TimePickerOptions from './TimePickerOptions';
+
+export interface Props {
+  label?: string;
+  step?: 1 | 5 | 10 | 15 | 20 | 30;
+  minTime?: Date;
+  maxTime?: Date;
+}
+
+export interface Time {
+  midday: '오전' | '오후';
+  hour: number;
+  minute: number;
+}
+
+interface Range {
+  start: Time;
+  end: Time;
+}
+
+type SelectedTime = keyof Range | null;
+
+const now = new Date();
+
+const TimePicker = ({ label, step = 1, minTime, maxTime }: Props): JSX.Element => {
+  const [selectedTime, setSelectedTime] = useState<SelectedTime>(null);
+  const [range, setRange] = useState<Range>({
+    start: {
+      midday: now.getHours() < 12 ? '오전' : '오후',
+      hour: now.getHours() % 12,
+      minute: 0,
+    },
+    end: {
+      midday: now.getHours() + 1 < 12 ? '오전' : '오후',
+      hour: (now.getHours() % 12) + 1,
+      minute: 0,
+    },
+  });
+
+  const onClickTimeButton: MouseEventHandler<HTMLButtonElement> = ({ currentTarget }) => {
+    if (selectedTime === currentTarget.name) {
+      setSelectedTime(null);
+
+      return;
+    }
+
+    setSelectedTime(currentTarget.name as SelectedTime);
+  };
+
+  const onChangeMidday: ChangeEventHandler<HTMLInputElement> = ({ target }) => {
+    if (selectedTime === null) return;
+
+    setRange((prev) => ({
+      ...prev,
+      [selectedTime]: {
+        ...prev[selectedTime],
+        midday: target.value,
+      },
+    }));
+  };
+
+  const onChangeHour: ChangeEventHandler<HTMLInputElement> = ({ target }) => {
+    if (selectedTime === null) return;
+
+    setRange((prev) => ({
+      ...prev,
+      [selectedTime]: {
+        ...prev[selectedTime],
+        hour: Number(target.value),
+      },
+    }));
+  };
+
+  const onChangeMinute: ChangeEventHandler<HTMLInputElement> = ({ target }) => {
+    if (selectedTime === null) return;
+
+    setRange((prev) => ({
+      ...prev,
+      [selectedTime]: {
+        ...prev[selectedTime],
+        minute: Number(target.value),
+      },
+    }));
+  };
+
+  const setTime = (value: Time) => {
+    if (selectedTime === null) return;
+
+    setRange((prev) => ({
+      ...prev,
+      [selectedTime]: {
+        ...value,
+      },
+    }));
+  };
+
+  return (
+    <Styled.Container>
+      <Styled.TimeContainer labelText={label} isOptionOpen={selectedTime !== null}>
+        <Styled.TimeButton
+          type="button"
+          aria-label="시작시간"
+          name="start"
+          onClick={onClickTimeButton}
+          selected={selectedTime === 'start'}
+        >
+          {range.start.midday} {String(range.start.hour).padStart(2, '0')} :{' '}
+          {String(range.start.minute).padStart(2, '0')}
+        </Styled.TimeButton>
+        <span>~</span>
+        <Styled.TimeButton
+          type="button"
+          aria-label="종료시간"
+          name="end"
+          onClick={onClickTimeButton}
+          selected={selectedTime === 'end'}
+        >
+          {range.end.midday} {String(range.end.hour).padStart(2, '0')} :{' '}
+          {String(range.end.minute).padStart(2, '0')}
+        </Styled.TimeButton>
+      </Styled.TimeContainer>
+
+      {selectedTime !== null && (
+        <Styled.OptionsContainer>
+          <TimePickerOptions
+            time={range[selectedTime]}
+            setTime={setTime}
+            step={step}
+            onChangeMidday={onChangeMidday}
+            onChangeHour={onChangeHour}
+            onChangeMinute={onChangeMinute}
+          />
+        </Styled.OptionsContainer>
+      )}
+    </Styled.Container>
+  );
+};
+
+export default TimePicker;

--- a/frontend/src/components/TimePicker/TimePicker.tsx
+++ b/frontend/src/components/TimePicker/TimePicker.tsx
@@ -1,4 +1,4 @@
-import React, { ChangeEventHandler, MouseEventHandler, useState } from 'react';
+import React, { MouseEventHandler, useState } from 'react';
 import * as Styled from './TimePicker.styles';
 import TimePickerOptions from './TimePickerOptions';
 
@@ -49,52 +49,21 @@ const TimePicker = ({ label, step = 1, minTime, maxTime }: Props): JSX.Element =
     setSelectedTime(currentTarget.name as SelectedTime);
   };
 
-  const onChangeMidday: ChangeEventHandler<HTMLInputElement> = ({ target }) => {
-    if (selectedTime === null) return;
+  const onChange =
+    (name: string) =>
+    ({ target }: React.ChangeEvent<HTMLInputElement>) => {
+      if (selectedTime === null) return;
 
-    setRange((prev) => ({
-      ...prev,
-      [selectedTime]: {
-        ...prev[selectedTime],
-        midday: target.value,
-      },
-    }));
-  };
+      const value = name === 'midday' ? target.value : Number(target.value);
 
-  const onChangeHour: ChangeEventHandler<HTMLInputElement> = ({ target }) => {
-    if (selectedTime === null) return;
-
-    setRange((prev) => ({
-      ...prev,
-      [selectedTime]: {
-        ...prev[selectedTime],
-        hour: Number(target.value),
-      },
-    }));
-  };
-
-  const onChangeMinute: ChangeEventHandler<HTMLInputElement> = ({ target }) => {
-    if (selectedTime === null) return;
-
-    setRange((prev) => ({
-      ...prev,
-      [selectedTime]: {
-        ...prev[selectedTime],
-        minute: Number(target.value),
-      },
-    }));
-  };
-
-  const setTime = (value: Time) => {
-    if (selectedTime === null) return;
-
-    setRange((prev) => ({
-      ...prev,
-      [selectedTime]: {
-        ...value,
-      },
-    }));
-  };
+      setRange((prev) => ({
+        ...prev,
+        [selectedTime]: {
+          ...prev[selectedTime],
+          [name]: value,
+        },
+      }));
+    };
 
   return (
     <Styled.Container>
@@ -124,14 +93,7 @@ const TimePicker = ({ label, step = 1, minTime, maxTime }: Props): JSX.Element =
 
       {selectedTime !== null && (
         <Styled.OptionsContainer>
-          <TimePickerOptions
-            time={range[selectedTime]}
-            setTime={setTime}
-            step={step}
-            onChangeMidday={onChangeMidday}
-            onChangeHour={onChangeHour}
-            onChangeMinute={onChangeMinute}
-          />
+          <TimePickerOptions time={range[selectedTime]} step={step} onChange={onChange} />
         </Styled.OptionsContainer>
       )}
     </Styled.Container>

--- a/frontend/src/components/TimePicker/TimePicker.tsx
+++ b/frontend/src/components/TimePicker/TimePicker.tsx
@@ -5,8 +5,8 @@ import TimePickerOptions from './TimePickerOptions';
 export interface Props {
   label?: string;
   step?: 1 | 5 | 10 | 15 | 20 | 30;
-  minTime?: Date;
-  maxTime?: Date;
+  defaultStartTime?: Date;
+  defaultEndTime?: Date;
 }
 
 export interface Time {
@@ -15,38 +15,73 @@ export interface Time {
   minute: number;
 }
 
-interface Range {
-  start: Time;
-  end: Time;
+export interface Range {
+  start: Time | null;
+  end: Time | null;
 }
 
 type SelectedTime = keyof Range | null;
 
-const now = new Date();
+const generateTo12Hour = (hour: number) => (hour > 12 ? hour % 12 : hour);
 
-const TimePicker = ({ label, step = 1, minTime, maxTime }: Props): JSX.Element => {
+const generateDateToTime = (time: Date, step: Props['step'] = 1): Time => {
+  const minute = Math.ceil(time.getMinutes() / step) * step;
+  const hour = minute < 60 ? time.getHours() : time.getHours() + 1;
+  const midday = hour < 12 ? '오전' : '오후';
+
+  return {
+    midday,
+    hour: generateTo12Hour(hour),
+    minute: minute % 60,
+  };
+};
+
+const TimePicker = ({ label, step = 1, defaultStartTime, defaultEndTime }: Props): JSX.Element => {
   const [selectedTime, setSelectedTime] = useState<SelectedTime>(null);
   const [range, setRange] = useState<Range>({
-    start: {
-      midday: now.getHours() < 12 ? '오전' : '오후',
-      hour: now.getHours() % 12,
-      minute: 0,
-    },
-    end: {
-      midday: now.getHours() + 1 < 12 ? '오전' : '오후',
-      hour: (now.getHours() % 12) + 1,
-      minute: 0,
-    },
+    start: defaultStartTime ? generateDateToTime(defaultStartTime, step) : null,
+    end: defaultEndTime ? generateDateToTime(defaultEndTime, step) : null,
   });
 
+  const setInitialTime = (key: keyof Range) => {
+    if (key === 'start' || (key === 'end' && range.start === null)) {
+      const now = new Date();
+
+      setRange((prev) => ({
+        ...prev,
+        [key]: generateDateToTime(now, step),
+      }));
+    }
+
+    if (key === 'end' && range.start !== null) {
+      const startTime = range.start;
+
+      setRange((prev) => ({
+        ...prev,
+        end: {
+          midday:
+            startTime.hour < 11 ? startTime.midday : startTime.midday === '오전' ? '오후' : '오전',
+          hour: generateTo12Hour(startTime.hour + 1),
+          minute: startTime.minute,
+        },
+      }));
+    }
+  };
+
   const onClickTimeButton: MouseEventHandler<HTMLButtonElement> = ({ currentTarget }) => {
-    if (selectedTime === currentTarget.name) {
+    const key = currentTarget.name as keyof Range;
+
+    if (selectedTime === key) {
       setSelectedTime(null);
 
       return;
     }
 
-    setSelectedTime(currentTarget.name as SelectedTime);
+    if (range[key] === null) {
+      setInitialTime(key);
+    }
+
+    setSelectedTime(key as SelectedTime);
   };
 
   const onChange =
@@ -65,6 +100,17 @@ const TimePicker = ({ label, step = 1, minTime, maxTime }: Props): JSX.Element =
       }));
     };
 
+  const getTimeText = (key: keyof Range) => {
+    const time = range[key];
+
+    if (time === null) {
+      return key === 'start' ? '시작시간' : '종료시간';
+    }
+
+    return `${time.midday} ${String(time.hour).padStart(2, '0')} :
+    ${String(time.minute).padStart(2, '0')}`;
+  };
+
   return (
     <Styled.Container>
       <Styled.TimeContainer labelText={label} isOptionOpen={selectedTime !== null}>
@@ -75,8 +121,7 @@ const TimePicker = ({ label, step = 1, minTime, maxTime }: Props): JSX.Element =
           onClick={onClickTimeButton}
           selected={selectedTime === 'start'}
         >
-          {range.start.midday} {String(range.start.hour).padStart(2, '0')} :{' '}
-          {String(range.start.minute).padStart(2, '0')}
+          {getTimeText('start')}
         </Styled.TimeButton>
         <span>~</span>
         <Styled.TimeButton
@@ -86,8 +131,7 @@ const TimePicker = ({ label, step = 1, minTime, maxTime }: Props): JSX.Element =
           onClick={onClickTimeButton}
           selected={selectedTime === 'end'}
         >
-          {range.end.midday} {String(range.end.hour).padStart(2, '0')} :{' '}
-          {String(range.end.minute).padStart(2, '0')}
+          {getTimeText('end')}
         </Styled.TimeButton>
       </Styled.TimeContainer>
 

--- a/frontend/src/components/TimePicker/TimePicker.tsx
+++ b/frontend/src/components/TimePicker/TimePicker.tsx
@@ -1,105 +1,25 @@
-import React, { MouseEventHandler, useState } from 'react';
+import React, { MouseEventHandler } from 'react';
 import * as Styled from './TimePicker.styles';
 import TimePickerOptions from './TimePickerOptions';
+import { Range } from './useTimePicker';
 
-export interface Props {
+interface Props {
   label?: string;
   step?: 1 | 5 | 10 | 15 | 20 | 30;
-  defaultStartTime?: Date;
-  defaultEndTime?: Date;
+  range: Range;
+  onClick: MouseEventHandler<HTMLButtonElement>;
+  onChange: (name: string) => (event: React.ChangeEvent<HTMLInputElement>) => void;
+  selectedTime: keyof Range | null;
 }
 
-export interface Time {
-  midday: '오전' | '오후';
-  hour: number;
-  minute: number;
-}
-
-export interface Range {
-  start: Time | null;
-  end: Time | null;
-}
-
-type SelectedTime = keyof Range | null;
-
-const generateTo12Hour = (hour: number) => (hour > 12 ? hour % 12 : hour);
-
-const generateDateToTime = (time: Date, step: Props['step'] = 1): Time => {
-  const minute = Math.ceil(time.getMinutes() / step) * step;
-  const hour = minute < 60 ? time.getHours() : time.getHours() + 1;
-  const midday = hour < 12 ? '오전' : '오후';
-
-  return {
-    midday,
-    hour: generateTo12Hour(hour),
-    minute: minute % 60,
-  };
-};
-
-const TimePicker = ({ label, step = 1, defaultStartTime, defaultEndTime }: Props): JSX.Element => {
-  const [selectedTime, setSelectedTime] = useState<SelectedTime>(null);
-  const [range, setRange] = useState<Range>({
-    start: defaultStartTime ? generateDateToTime(defaultStartTime, step) : null,
-    end: defaultEndTime ? generateDateToTime(defaultEndTime, step) : null,
-  });
-
-  const setInitialTime = (key: keyof Range) => {
-    if (key === 'start' || (key === 'end' && range.start === null)) {
-      const now = new Date();
-
-      setRange((prev) => ({
-        ...prev,
-        [key]: generateDateToTime(now, step),
-      }));
-    }
-
-    if (key === 'end' && range.start !== null) {
-      const startTime = range.start;
-
-      setRange((prev) => ({
-        ...prev,
-        end: {
-          midday:
-            startTime.hour < 11 ? startTime.midday : startTime.midday === '오전' ? '오후' : '오전',
-          hour: generateTo12Hour(startTime.hour + 1),
-          minute: startTime.minute,
-        },
-      }));
-    }
-  };
-
-  const onClickTimeButton: MouseEventHandler<HTMLButtonElement> = ({ currentTarget }) => {
-    const key = currentTarget.name as keyof Range;
-
-    if (selectedTime === key) {
-      setSelectedTime(null);
-
-      return;
-    }
-
-    if (range[key] === null) {
-      setInitialTime(key);
-    }
-
-    setSelectedTime(key as SelectedTime);
-  };
-
-  const onChange =
-    (name: string) =>
-    ({ target }: React.ChangeEvent<HTMLInputElement>) => {
-      if (selectedTime === null) return;
-
-      const value = name === 'midday' ? target.value : Number(target.value);
-
-      setRange((prev) => ({
-        ...prev,
-        [selectedTime]: {
-          ...prev[selectedTime],
-          [name]: value,
-        },
-      }));
-    };
-
+const TimePicker = ({
+  label,
+  step = 1,
+  range,
+  selectedTime,
+  onClick,
+  onChange,
+}: Props): JSX.Element => {
   const getTimeText = (key: keyof Range) => {
     const time = range[key];
 
@@ -118,7 +38,7 @@ const TimePicker = ({ label, step = 1, defaultStartTime, defaultEndTime }: Props
           type="button"
           aria-label="시작시간"
           name="start"
-          onClick={onClickTimeButton}
+          onClick={onClick}
           selected={selectedTime === 'start'}
         >
           {getTimeText('start')}
@@ -128,7 +48,7 @@ const TimePicker = ({ label, step = 1, defaultStartTime, defaultEndTime }: Props
           type="button"
           aria-label="종료시간"
           name="end"
-          onClick={onClickTimeButton}
+          onClick={onClick}
           selected={selectedTime === 'end'}
         >
           {getTimeText('end')}

--- a/frontend/src/components/TimePicker/TimePickerOptions.styles.ts
+++ b/frontend/src/components/TimePicker/TimePickerOptions.styles.ts
@@ -1,0 +1,76 @@
+import styled from 'styled-components';
+import PALETTE from 'constants/palette';
+
+export const OptionsContainer = styled.div`
+  width: 100%;
+  border: 1px solid ${({ theme }) => theme.gray[500]};
+  border-top: 0;
+  border-radius: 0 0 0.125rem 0.125rem;
+  display: flex;
+  align-items: center;
+  height: 10rem;
+  overflow: hidden;
+  position: relative;
+
+  &::before {
+    content: '';
+    display: block;
+    width: inherit;
+    height: 2rem;
+    background-color: ${PALETTE.OPACITY_BLACK[50]};
+    position: absolute;
+    top: calc(4rem + 0.5px);
+    pointer-events: none;
+  }
+`;
+
+export const MiddayOptionContainer = styled.div`
+  width: 33.33333%;
+  height: inherit;
+  overflow-y: auto;
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+`;
+
+export const OptionContainer = styled.div`
+  width: 33.33333%;
+  height: inherit;
+  overflow-y: auto;
+  text-align: center;
+
+  &::-webkit-scrollbar {
+    display: none;
+  }
+`;
+
+export const Option = styled.label`
+  width: 100%;
+  height: 2rem;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  cursor: pointer;
+  color: ${({ theme }) => theme.gray[400]};
+
+  &:first-child {
+    margin-top: 4rem;
+  }
+
+  &:last-child {
+    margin-bottom: 4rem;
+  }
+`;
+
+export const OptionText = styled.span``;
+
+export const Radio = styled.input`
+  appearance: none;
+
+  &:checked + ${OptionText} {
+    color: ${({ theme }) => theme.gray[600]};
+    font-weight: 600;
+  }
+`;

--- a/frontend/src/components/TimePicker/TimePickerOptions.tsx
+++ b/frontend/src/components/TimePicker/TimePickerOptions.tsx
@@ -1,0 +1,100 @@
+import { ChangeEventHandler, useEffect, useRef } from 'react';
+import { Time } from './TimePicker';
+import * as Styled from './TimePickerOptions.styles';
+
+interface Props {
+  time: Time;
+  setTime: (value: Time) => void;
+  step?: 1 | 5 | 10 | 15 | 20 | 30;
+  onChangeMidday: ChangeEventHandler<HTMLInputElement>;
+  onChangeHour: ChangeEventHandler<HTMLInputElement>;
+  onChangeMinute: ChangeEventHandler<HTMLInputElement>;
+}
+
+const TimePickerOptions = ({
+  time,
+  setTime,
+  step = 1,
+  onChangeMidday,
+  onChangeHour,
+  onChangeMinute,
+}: Props): JSX.Element => {
+  const middayRef = useRef<HTMLDivElement | null>(null);
+  const hourRef = useRef<HTMLDivElement | null>(null);
+  const minuteRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (middayRef.current !== null) {
+      middayRef.current.scrollTo(0, time.midday === '오전' ? 0 : 32);
+    }
+
+    if (hourRef.current !== null) {
+      hourRef.current.scrollTo(0, (time.hour - 1) * 32);
+    }
+
+    if (minuteRef.current !== null) {
+      minuteRef.current.scrollTo(0, (time.minute / step) * 32);
+    }
+  }, [step, middayRef, hourRef, minuteRef, time]);
+
+  return (
+    <Styled.OptionsContainer>
+      <Styled.OptionContainer ref={middayRef}>
+        <Styled.Option tabIndex={0}>
+          <Styled.Radio
+            type="radio"
+            name="midday"
+            value="오전"
+            onChange={onChangeMidday}
+            checked={time.midday === '오전'}
+          />
+          <Styled.OptionText>오전</Styled.OptionText>
+        </Styled.Option>
+        <Styled.Option tabIndex={0}>
+          <Styled.Radio
+            type="radio"
+            name="midday"
+            value="오후"
+            onChange={onChangeMidday}
+            checked={time.midday === '오후'}
+          />
+          <Styled.OptionText>오후</Styled.OptionText>
+        </Styled.Option>
+      </Styled.OptionContainer>
+      <Styled.OptionContainer ref={hourRef}>
+        {Array(12)
+          .fill(undefined)
+          .map((_, index) => (
+            <Styled.Option key={`${index}-hour`} tabIndex={0}>
+              <Styled.Radio
+                type="radio"
+                name="hour"
+                value={index + 1}
+                onChange={onChangeHour}
+                checked={index + 1 === time.hour}
+              />
+              <Styled.OptionText>{String(index + 1).padStart(2, '0')} 시</Styled.OptionText>
+            </Styled.Option>
+          ))}
+      </Styled.OptionContainer>
+      <Styled.OptionContainer ref={minuteRef}>
+        {Array(60 / step)
+          .fill(undefined)
+          .map((_, index) => (
+            <Styled.Option key={`${index}-minute`} tabIndex={0}>
+              <Styled.Radio
+                type="radio"
+                name="minute"
+                value={index * step}
+                onChange={onChangeMinute}
+                checked={index * step === time.minute}
+              />
+              <Styled.OptionText>{String(index * step).padStart(2, '0')} 분</Styled.OptionText>
+            </Styled.Option>
+          ))}
+      </Styled.OptionContainer>
+    </Styled.OptionsContainer>
+  );
+};
+
+export default TimePickerOptions;

--- a/frontend/src/components/TimePicker/TimePickerOptions.tsx
+++ b/frontend/src/components/TimePicker/TimePickerOptions.tsx
@@ -1,24 +1,14 @@
-import { ChangeEventHandler, useEffect, useRef } from 'react';
+import React, { useEffect, useRef } from 'react';
 import { Time } from './TimePicker';
 import * as Styled from './TimePickerOptions.styles';
 
 interface Props {
   time: Time;
-  setTime: (value: Time) => void;
   step?: 1 | 5 | 10 | 15 | 20 | 30;
-  onChangeMidday: ChangeEventHandler<HTMLInputElement>;
-  onChangeHour: ChangeEventHandler<HTMLInputElement>;
-  onChangeMinute: ChangeEventHandler<HTMLInputElement>;
+  onChange: (name: string) => (event: React.ChangeEvent<HTMLInputElement>) => void;
 }
 
-const TimePickerOptions = ({
-  time,
-  setTime,
-  step = 1,
-  onChangeMidday,
-  onChangeHour,
-  onChangeMinute,
-}: Props): JSX.Element => {
+const TimePickerOptions = ({ time, step = 1, onChange }: Props): JSX.Element => {
   const middayRef = useRef<HTMLDivElement | null>(null);
   const hourRef = useRef<HTMLDivElement | null>(null);
   const minuteRef = useRef<HTMLDivElement | null>(null);
@@ -45,7 +35,7 @@ const TimePickerOptions = ({
             type="radio"
             name="midday"
             value="오전"
-            onChange={onChangeMidday}
+            onChange={onChange('midday')}
             checked={time.midday === '오전'}
           />
           <Styled.OptionText>오전</Styled.OptionText>
@@ -55,7 +45,7 @@ const TimePickerOptions = ({
             type="radio"
             name="midday"
             value="오후"
-            onChange={onChangeMidday}
+            onChange={onChange('midday')}
             checked={time.midday === '오후'}
           />
           <Styled.OptionText>오후</Styled.OptionText>
@@ -70,7 +60,7 @@ const TimePickerOptions = ({
                 type="radio"
                 name="hour"
                 value={index + 1}
-                onChange={onChangeHour}
+                onChange={onChange('hour')}
                 checked={index + 1 === time.hour}
               />
               <Styled.OptionText>{String(index + 1).padStart(2, '0')} 시</Styled.OptionText>
@@ -86,7 +76,7 @@ const TimePickerOptions = ({
                 type="radio"
                 name="minute"
                 value={index * step}
-                onChange={onChangeMinute}
+                onChange={onChange('minute')}
                 checked={index * step === time.minute}
               />
               <Styled.OptionText>{String(index * step).padStart(2, '0')} 분</Styled.OptionText>

--- a/frontend/src/components/TimePicker/TimePickerOptions.tsx
+++ b/frontend/src/components/TimePicker/TimePickerOptions.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef } from 'react';
-import { Time } from './TimePicker';
+import { Midday, Time } from 'types/time';
 import * as Styled from './TimePickerOptions.styles';
 
 interface Props {
@@ -17,7 +17,7 @@ const TimePickerOptions = ({ time, step = 1, onChange }: Props): JSX.Element => 
     if (time === null) return;
 
     if (middayRef.current !== null) {
-      middayRef.current.scrollTo(0, time.midday === '오전' ? 0 : 32);
+      middayRef.current.scrollTo(0, time.midday === Midday.AM ? 0 : 32);
     }
 
     if (hourRef.current !== null) {
@@ -38,7 +38,7 @@ const TimePickerOptions = ({ time, step = 1, onChange }: Props): JSX.Element => 
             name="midday"
             value="오전"
             onChange={onChange('midday')}
-            checked={time?.midday === '오전'}
+            checked={time?.midday === Midday.AM}
           />
           <Styled.OptionText>오전</Styled.OptionText>
         </Styled.Option>
@@ -48,7 +48,7 @@ const TimePickerOptions = ({ time, step = 1, onChange }: Props): JSX.Element => 
             name="midday"
             value="오후"
             onChange={onChange('midday')}
-            checked={time?.midday === '오후'}
+            checked={time?.midday === Midday.PM}
           />
           <Styled.OptionText>오후</Styled.OptionText>
         </Styled.Option>

--- a/frontend/src/components/TimePicker/TimePickerOptions.tsx
+++ b/frontend/src/components/TimePicker/TimePickerOptions.tsx
@@ -3,7 +3,7 @@ import { Time } from './TimePicker';
 import * as Styled from './TimePickerOptions.styles';
 
 interface Props {
-  time: Time;
+  time: Time | null;
   step?: 1 | 5 | 10 | 15 | 20 | 30;
   onChange: (name: string) => (event: React.ChangeEvent<HTMLInputElement>) => void;
 }
@@ -14,6 +14,8 @@ const TimePickerOptions = ({ time, step = 1, onChange }: Props): JSX.Element => 
   const minuteRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
+    if (time === null) return;
+
     if (middayRef.current !== null) {
       middayRef.current.scrollTo(0, time.midday === '오전' ? 0 : 32);
     }
@@ -36,7 +38,7 @@ const TimePickerOptions = ({ time, step = 1, onChange }: Props): JSX.Element => 
             name="midday"
             value="오전"
             onChange={onChange('midday')}
-            checked={time.midday === '오전'}
+            checked={time?.midday === '오전'}
           />
           <Styled.OptionText>오전</Styled.OptionText>
         </Styled.Option>
@@ -46,7 +48,7 @@ const TimePickerOptions = ({ time, step = 1, onChange }: Props): JSX.Element => 
             name="midday"
             value="오후"
             onChange={onChange('midday')}
-            checked={time.midday === '오후'}
+            checked={time?.midday === '오후'}
           />
           <Styled.OptionText>오후</Styled.OptionText>
         </Styled.Option>
@@ -61,7 +63,7 @@ const TimePickerOptions = ({ time, step = 1, onChange }: Props): JSX.Element => 
                 name="hour"
                 value={index + 1}
                 onChange={onChange('hour')}
-                checked={index + 1 === time.hour}
+                checked={index + 1 === time?.hour}
               />
               <Styled.OptionText>{String(index + 1).padStart(2, '0')} 시</Styled.OptionText>
             </Styled.Option>
@@ -77,7 +79,7 @@ const TimePickerOptions = ({ time, step = 1, onChange }: Props): JSX.Element => 
                 name="minute"
                 value={index * step}
                 onChange={onChange('minute')}
-                checked={index * step === time.minute}
+                checked={index * step === time?.minute}
               />
               <Styled.OptionText>{String(index * step).padStart(2, '0')} 분</Styled.OptionText>
             </Styled.Option>

--- a/frontend/src/components/TimePicker/useTimePicker.ts
+++ b/frontend/src/components/TimePicker/useTimePicker.ts
@@ -1,0 +1,111 @@
+import { MouseEventHandler, useState } from 'react';
+import { Midday, Time } from 'types/time';
+
+type SelectedTime = keyof Range | null;
+
+export interface Range {
+  start: Time | null;
+  end: Time | null;
+}
+
+interface Props {
+  defaultStartTime?: Date;
+  defaultEndTime?: Date;
+  step?: 1 | 5 | 10 | 15 | 20 | 30;
+}
+
+const generateTo12Hour = (hour: number) => (hour > 12 ? hour % 12 : hour);
+
+const generateDateToTime = (time: Date, step: Props['step'] = 1): Time => {
+  const minute = Math.ceil(time.getMinutes() / step) * step;
+  const hour = minute < 60 ? time.getHours() : time.getHours() + 1;
+  const midday = hour < 12 ? Midday.AM : Midday.PM;
+
+  return {
+    midday,
+    hour: generateTo12Hour(hour),
+    minute: minute % 60,
+  };
+};
+
+const useTimePicker = ({
+  defaultStartTime,
+  defaultEndTime,
+  step = 1,
+}: Props): {
+  range: Range;
+  selectedTime: SelectedTime;
+  onClick: MouseEventHandler<HTMLButtonElement>;
+  onChange: (name: string) => (event: React.ChangeEvent<HTMLInputElement>) => void;
+} => {
+  const [selectedTime, setSelectedTime] = useState<SelectedTime>(null);
+  const [range, setRange] = useState<Range>({
+    start: defaultStartTime ? generateDateToTime(defaultStartTime, step) : null,
+    end: defaultEndTime ? generateDateToTime(defaultEndTime, step) : null,
+  });
+
+  const setInitialTime = (key: keyof Range) => {
+    if (key === 'start' || (key === 'end' && range.start === null)) {
+      const now = new Date();
+
+      setRange((prev) => ({
+        ...prev,
+        [key]: generateDateToTime(now, step),
+      }));
+    }
+
+    if (key === 'end' && range.start !== null) {
+      const startTime = range.start;
+
+      setRange((prev) => ({
+        ...prev,
+        end: {
+          midday:
+            startTime.hour < 11
+              ? startTime.midday
+              : startTime.midday === Midday.AM
+              ? Midday.PM
+              : Midday.AM,
+          hour: generateTo12Hour(startTime.hour + 1),
+          minute: startTime.minute,
+        },
+      }));
+    }
+  };
+
+  const onClickTimeButton: MouseEventHandler<HTMLButtonElement> = ({ currentTarget }) => {
+    const key = currentTarget.name as keyof Range;
+
+    if (selectedTime === key) {
+      setSelectedTime(null);
+
+      return;
+    }
+
+    if (range[key] === null) {
+      setInitialTime(key);
+    }
+
+    setSelectedTime(key as SelectedTime);
+  };
+
+  const onChange =
+    (name: string) =>
+    ({ target }: React.ChangeEvent<HTMLInputElement>) => {
+      if (selectedTime === null) return;
+
+      const value = name === 'midday' ? target.value : Number(target.value);
+
+      setRange((prev) => ({
+        ...prev,
+        [selectedTime]: {
+          ...prev[selectedTime],
+          [name]: value,
+        },
+      }));
+    };
+
+  return { range, selectedTime, onClick: onClickTimeButton, onChange };
+};
+
+export default useTimePicker;

--- a/frontend/src/constants/editor.ts
+++ b/frontend/src/constants/editor.ts
@@ -24,6 +24,7 @@ export const KEY = {
   DELETE: 'Delete',
   BACK_SPACE: 'Backspace',
   SPACE: ' ',
+  ENTER: 'Enter',
 };
 
 export const EDITOR = {

--- a/frontend/src/constants/palette.ts
+++ b/frontend/src/constants/palette.ts
@@ -95,6 +95,7 @@ const PALETTE = {
 
   OPACITY_GRAY: 'rgba(212, 212, 216, 0.3)',
   OPACITY_BLACK: {
+    50: 'rgba(0, 0, 0, 0.05)',
     100: 'rgba(0, 0, 0, 0.1)',
     200: 'rgba(0, 0, 0, 0.2)',
     300: 'rgba(0, 0, 0, 0.3)',

--- a/frontend/src/pages/GuestMap/GuestMap.tsx
+++ b/frontend/src/pages/GuestMap/GuestMap.tsx
@@ -165,7 +165,7 @@ const GuestMap = (): JSX.Element => {
 
   useEffect(() => {
     if (scrollPosition) {
-      mapRef?.current?.scrollTo(scrollPosition.x ?? 0, scrollPosition.y ?? 0);
+      mapRef.current?.scrollTo(scrollPosition.x ?? 0, scrollPosition.y ?? 0);
     }
 
     if (targetDate) {

--- a/frontend/src/types/time.ts
+++ b/frontend/src/types/time.ts
@@ -1,0 +1,9 @@
+export enum Midday {
+  AM = '오전',
+  PM = '오후',
+}
+export interface Time {
+  midday: Midday;
+  hour: number;
+  minute: number;
+}


### PR DESCRIPTION
## 구현 기능
### 기본값이 없는 경우
- 기본 UI
![image](https://user-images.githubusercontent.com/45230497/136149603-6a24a5e6-109c-436d-b236-ea776561daf9.png)
- 시작시간 선택 시 -> 현재와 가장 가까운 선택 가능 시간으로 설정(현재시간: 3시 9분, step: 5)
![image](https://user-images.githubusercontent.com/45230497/136149694-ba70be82-497d-4bab-bc1e-f69b54247abd.png)
- 종료시간 선택 시 -> 설정된 시작시간에서 1시간 이후로 기본 설정
![image](https://user-images.githubusercontent.com/45230497/136149849-638cded1-3bf4-40e0-96a2-4979f4f05ca9.png)
- 시작시간이 설정되지 않은 상태에서 종료 시간을 먼저 선택하는 경우 종료시간은 현재 시간에서 가장 가까운 선택 가능 시간으로 설정됨

### 기본값이 있는 경우
- 기본 값에서 가장 가까운 선택 가능시간으로 설정
  - 예. 시작시간 기본값이 9시 3분이고, step이 10(분) -> 9시 10분으로 기본값 설정
![image](https://user-images.githubusercontent.com/45230497/136150078-16524b3f-8442-4b6c-b337-97f676c66d0a.png)

## 공유하고 싶은 내용
- `useTimePicker`와 `TimePicker`를 함께 하용하시면 됩니다.
- `useTimePicker`에서 반환되는 `range`의 타입은 아래와 같습니다.
```typescript
enum Midday {
  AM = '오전',
  PM = '오후',
}

interface Time {
  midday: Midday;
  hour: number;
  minute: number;
}

interface Range {
  start: Time | null;
  end: Time | null;
}
```


## 기타
- 사용해보시고 기본값이나, 기능에 추가하거나 변경하면 좋을 부분 의견주세요!

Close #207 

