### PR TITLE
test: 예약 완료 랜딩 페이지 테스트 추가

### DIFF
--- a/frontend/jest.config.js
+++ b/frontend/jest.config.js
@@ -9,4 +9,5 @@ module.exports = {
       '<rootDir>/src/__mocks__/fileMock.ts',
   },
   setupFilesAfterEnv: ['./src/__mocks__/setupTest.ts', '@testing-library/jest-dom/extend-expect'],
+  setupFiles: ['@testing-library/react/dont-cleanup-after-each'],
 };

--- a/frontend/src/__mocks__/mockData.ts
+++ b/frontend/src/__mocks__/mockData.ts
@@ -27,7 +27,7 @@ interface Reservations {
 export const guestMaps: GuestMaps = {
   JMTGR: {
     mapId: 1,
-    mapName: 'guestMap-1',
+    mapName: 'GUEST_TEST_MAP',
     mapDrawing:
       '{"width":800,"height":600,"mapElements":[{"id":2,"type":"rect","stroke":"#333333","points":["210,90","650,230"]},{"id":3,"type":"rect","stroke":"#333333","width":440,"height":140,"x":210,"y":90,"points":["210, 90","650, 230"]}]}',
     mapImageUrl: '',

--- a/frontend/src/__tests__/reservation.test.tsx
+++ b/frontend/src/__tests__/reservation.test.tsx
@@ -6,8 +6,13 @@ import { PUBLIC_ROUTES } from 'constants/routes';
 import { render, screen, waitFor, within } from 'test-utils';
 import { formatDate } from 'utils/datetime';
 
-describe('예약 페이지 조회', () => {
-  beforeEach(() => {
+describe('예약 페이지', () => {
+  const date = '2021-07-01';
+  const nowDate = new Date();
+  const spaceId = 1;
+  const reservationId = 2;
+
+  beforeAll(() => {
     const sharingMapId = 'JMTGR';
 
     render(
@@ -24,60 +29,35 @@ describe('예약 페이지 조회', () => {
   });
 
   it('예약 목록을 조회할 수 있다.', async () => {
-    const date = '2021-07-01';
-    const spaceId = 1;
-
-    const $targetSpace = await waitFor(() => screen.getByTestId(spaceId));
+    const $targetSpace = await screen.findByTestId(spaceId);
     const $targetDateInput = screen.getByDisplayValue(formatDate(new Date()));
 
     userEvent.type($targetDateInput, date);
     userEvent.click($targetSpace);
 
-    const reservations = await waitFor(() => screen.getAllByRole('listitem'));
+    const reservations = await screen.findAllByRole('listitem');
 
     expect(reservations).toHaveLength(2);
   });
-});
 
-describe('예약 추가', () => {
-  beforeAll(() => {
-    const sharingMapId = 'JMTGR';
+  it('예약을 추가할 수 있다.', async () => {
+    const targetDate = formatDate(nowDate);
 
-    render(
-      <MemoryRouter initialEntries={[HREF.GUEST_MAP(sharingMapId)]}>
-        <Switch>
-          {PUBLIC_ROUTES.map(({ path, component }) => (
-            <Route exact path={path} key={path}>
-              {component}
-            </Route>
-          ))}
-        </Switch>
-      </MemoryRouter>
-    );
-  });
-
-  it('예약페이지에 진입할 수 있다.', async () => {
-    const date = new Date();
-    date.setDate(date.getDate() + 1);
-    const targetDate = formatDate(date);
-    const spaceId = 1;
-
-    const $targetSpace = await waitFor(() => screen.getByTestId(spaceId));
-    const $targetDateInput = screen.getByDisplayValue(formatDate(new Date()));
+    const $targetSpace = await screen.findByTestId(spaceId);
+    const $targetDateInput = screen.getByDisplayValue('2021-07-01');
 
     userEvent.type($targetDateInput, targetDate);
     userEvent.click($targetSpace);
 
-    const $reservationButton = await waitFor(() =>
-      screen.getByRole('button', { name: /예약하기/i })
-    );
+    const $reservationButton = await screen.findByRole('button', { name: /예약하기/i });
+
     userEvent.click($reservationButton);
 
-    const $pageTitle = await waitFor(() => screen.getByTestId(/spaceName/i));
+    const $pageTitle = await screen.findByTestId(/spaceName/i);
 
     expect($pageTitle).toHaveTextContent('testSpace');
 
-    const $nameInput = await waitFor(() => screen.getByRole('textbox', { name: /이름/i }));
+    const $nameInput = await screen.findByRole('textbox', { name: /이름/i });
     const $descriptionInput = screen.getByRole('textbox', { name: /사용 목적/i });
     const $startTimeInput = screen.getByLabelText(/시작 시간/i);
     const $endTimeInput = screen.getByLabelText(/종료 시간/i);
@@ -91,42 +71,22 @@ describe('예약 추가', () => {
     userEvent.type($passwordInput, '1117');
     userEvent.click($submitButton);
 
-    // TODO 예약 완료 랜딩 페이지 작성 후 추가 테스트 작성
-  });
-});
+    const $link = await screen.findByRole('link', { name: /맵으로 돌아가기/i });
 
-describe('예약 삭제', () => {
-  beforeAll(() => {
-    const sharingMapId = 'JMTGR';
+    userEvent.click($link);
 
-    render(
-      <MemoryRouter initialEntries={[HREF.GUEST_MAP(sharingMapId)]}>
-        <Switch>
-          {PUBLIC_ROUTES.map(({ path, component }) => (
-            <Route exact path={path} key={path}>
-              {component}
-            </Route>
-          ))}
-        </Switch>
-      </MemoryRouter>
-    );
+    const $heading = await screen.findByRole('heading', { name: /GUEST_TEST_MAP/i });
+    expect($heading).toBeTruthy();
   });
 
-  it('특정 예약을 삭제할 수 있다.', async () => {
-    const date = '2021-07-01';
-    const spaceId = 1;
-    const reservationId = 2;
-
-    const $targetSpace = await waitFor(() => screen.getByTestId(spaceId));
-    const $targetDateInput = screen.getByDisplayValue(formatDate(new Date()));
+  it('예약을 삭제할 수 있다.', async () => {
+    const $targetSpace = await screen.findByTestId(spaceId);
+    const $targetDateInput = screen.getByDisplayValue(formatDate(nowDate));
 
     userEvent.type($targetDateInput, date);
     userEvent.click($targetSpace);
 
-    const $targetReservation = await waitFor(() =>
-      screen.getByTestId(`reservation-${reservationId}`)
-    );
-
+    const $targetReservation = screen.getByTestId(`reservation-${reservationId}`);
     const $deleteButton = within($targetReservation).getByRole('button', { name: /삭제/i });
 
     userEvent.click($deleteButton);


### PR DESCRIPTION
## 구현 기능
- [x] 예약 완료 랜딩페이지 테스트 추가

## 공유하고 싶은 내용

### jest config 추가

- 이전에 테스트를 작성하다 cleanup 되면서 `describe`을 여러개 작성했는데 해당 부분을 아래 옵션을 통해 cleanup이 이뤄지지 않게 하면서 하나의 `describe`으로 통합하였습니다.

```js
/** @type {import('@ts-jest/dist/types').InitialOptionsTsJest} */
module.exports = {
  ...

  setupFiles: ['@testing-library/react/dont-cleanup-after-each'], 
};

```

- 그러나 현재 적용된 설정대로라면 이후 작성하는 테스트 파일에도 cleanup이 되지 않는 옵션이 그대로 적용됩니다.
- 폴더 단위로(ex - componets/__test__ , pages/__test__) `jest.config.js`를 별도로 작성하는 방법이 존재하는데 이 부분을 어떻게 적용하고 관리할지 얘기해보면 좋을거 같습니다.
- 참고자료
   - [Skipping Auto Cleanup / RTL 공홈](https://testing-library.com/docs/react-testing-library/setup/#skipping-auto-cleanup)
   - [cleanup API / RTL 공홈](https://testing-library.com/docs/react-testing-library/api/#cleanup)


Close #624 

