### PR TITLE
feat: 운영 환경의 로깅 레벨을 INFO로 하향

### DIFF
--- a/backend/src/main/resources/logback-spring.xml
+++ b/backend/src/main/resources/logback-spring.xml
@@ -47,7 +47,7 @@
         <include resource="appenders/file-appender-error.xml"/>
         <include resource="appenders/file-appender-warn.xml"/>
 
-        <root level="WARN">
+        <root level="INFO">
             <appender-ref ref="CONSOLE_APPENDER"/>
             <appender-ref ref="KAFKA_APPENDER_PROD"/>
 


### PR DESCRIPTION
## 구현 기능
- 운영 환경의 로그 레벨을 INFO로 내립니다.
- 단, File로 저장하는 레벨은 여전히 WARN으로 유지합니다.
- INFO 로그를 ELK를 통해 수집하는 데에 목적을 둡니다.

Close #638 

