### PR TITLE
fix: SlackUrl이 dev, local 프로파일에서 제대로 Configuration이 되지 않는 문제 해결

### DIFF
--- a/backend/src/main/java/com/woowacourse/zzimkkong/config/SlackConfig.java
+++ b/backend/src/main/java/com/woowacourse/zzimkkong/config/SlackConfig.java
@@ -19,7 +19,7 @@ public class SlackConfig implements WebMvcConfigurer {
     }
 
     @Bean
-    @Profile({"{local", "dev"})
+    @Profile({"local", "dev"})
     public SlackUrl slackUrlDev(
             @Value("${slack.webhook.local}") final String devUrl) {
         return new SlackUrl(devUrl);


### PR DESCRIPTION
## 버그 해결 사항
- Configuration에서 프로파일 문법에 실수가 있어 dev, local 프로파일에서 서버가 실행되지 않는 문제를 해결합니다.

Close #641 

