### PR TITLE
refactor: 관리자 메인 페이지에서 썸네일을 png대신 svg로 보여주도록 수정

### DIFF
--- a/frontend/src/__mocks__/mockData.ts
+++ b/frontend/src/__mocks__/mockData.ts
@@ -30,7 +30,7 @@ export const guestMaps: GuestMaps = {
     mapName: 'GUEST_TEST_MAP',
     mapDrawing:
       '{"width":800,"height":600,"mapElements":[{"id":2,"type":"rect","stroke":"#333333","points":["210,90","650,230"]},{"id":3,"type":"rect","stroke":"#333333","width":440,"height":140,"x":210,"y":90,"points":["210, 90","650, 230"]}]}',
-    mapImageUrl: '',
+    thumbnail: '',
     sharingMapId: 'JMTGR',
   },
 };

--- a/frontend/src/api/managerMap.ts
+++ b/frontend/src/api/managerMap.ts
@@ -14,14 +14,14 @@ export interface QueryManagerMapParams {
 interface PostMapParams {
   mapName: string;
   mapDrawing: string;
-  mapImageSvg: string;
+  thumbnail: string;
 }
 
 interface PutMapParams {
   mapId: number;
   mapName: string;
   mapDrawing: string;
-  mapImageSvg: string;
+  thumbnail: string;
 }
 
 interface DeleteMapParams {
@@ -53,17 +53,17 @@ export const queryManagerMap: QueryFunction<
 export const postMap = ({
   mapName,
   mapDrawing,
-  mapImageSvg,
+  thumbnail,
 }: PostMapParams): Promise<AxiosResponse<never>> =>
-  api.post('/managers/maps', { mapName, mapDrawing, mapImageSvg });
+  api.post('/managers/maps', { mapName, mapDrawing, thumbnail });
 
 export const putMap = ({
   mapId,
   mapName,
   mapDrawing,
-  mapImageSvg,
+  thumbnail,
 }: PutMapParams): Promise<AxiosResponse<never>> =>
-  api.put(`/managers/maps/${mapId}`, { mapName, mapDrawing, mapImageSvg });
+  api.put(`/managers/maps/${mapId}`, { mapName, mapDrawing, thumbnail });
 
 export const deleteMap = ({ mapId }: DeleteMapParams): Promise<AxiosResponse<never>> =>
   api.delete(`/managers/maps/${mapId}`);

--- a/frontend/src/api/managerSpace.ts
+++ b/frontend/src/api/managerSpace.ts
@@ -21,7 +21,7 @@ export interface PostManagerSpaceParams {
     description: string;
     area: string;
     settingsRequest: ReservationSettings;
-    mapImageSvg: string;
+    thumbnail: string;
   };
 }
 
@@ -32,7 +32,7 @@ export interface PutManagerSpaceParams extends PostManagerSpaceParams {
 export interface DeleteManagerSpaceParams {
   mapId: number;
   spaceId: number;
-  mapImageSvg: string;
+  thumbnail: string;
 }
 
 export const queryManagerSpaces: QueryFunction<
@@ -71,6 +71,6 @@ export const putManagerSpace = ({
 export const deleteManagerSpace = ({
   mapId,
   spaceId,
-  mapImageSvg,
+  thumbnail,
 }: DeleteManagerSpaceParams): Promise<AxiosResponse<never>> =>
-  api.delete(`/managers/maps/${mapId}/spaces/${spaceId}`, { data: { mapImageSvg } });
+  api.delete(`/managers/maps/${mapId}/spaces/${spaceId}`, { data: { thumbnail } });

--- a/frontend/src/components/MapListItem/MapListItem.stories.tsx
+++ b/frontend/src/components/MapListItem/MapListItem.stories.tsx
@@ -10,10 +10,7 @@ export default {
 
 const Template: Story<Props> = (args) => <MapListItem {...args} />;
 
-const thumbnail = {
-  src: './images/luther.png',
-  alt: '루터회관 14F 공간',
-};
+const thumbnail = `<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="800px" height="600px" viewBox="0 0 800 600"> <rect x="260" y="180" width="130" height="210" stroke="#333333" fill="none" strokewidth="3"></rect> </svg>`;
 
 export const Default = Template.bind({});
 Default.args = {

--- a/frontend/src/components/MapListItem/MapListItem.styles.ts
+++ b/frontend/src/components/MapListItem/MapListItem.styles.ts
@@ -28,6 +28,10 @@ export const ImageInner = styled.div`
   display: flex;
   justify-content: center;
   align-items: center;
+
+  svg {
+    z-index: -1;
+  }
 `;
 
 export const TitleWrapper = styled.div`

--- a/frontend/src/components/MapListItem/MapListItem.styles.ts
+++ b/frontend/src/components/MapListItem/MapListItem.styles.ts
@@ -30,11 +30,6 @@ export const ImageInner = styled.div`
   align-items: center;
 `;
 
-export const Image = styled.img`
-  max-width: 100%;
-  max-height: 100%;
-`;
-
 export const TitleWrapper = styled.div`
   display: flex;
   gap: 0.25rem;

--- a/frontend/src/components/MapListItem/MapListItem.tsx
+++ b/frontend/src/components/MapListItem/MapListItem.tsx
@@ -19,7 +19,7 @@ const MapListItem = ({
   return (
     <Styled.Container role="listitem" selected={selected}>
       <Styled.ImageWrapper onClick={onClick}>
-        <Styled.ImageInner dangerouslySetInnerHTML={{ __html: thumbnail }} />
+        <Styled.ImageInner dangerouslySetInnerHTML={{ __html: `${thumbnail}` }} />
       </Styled.ImageWrapper>
       <Styled.TitleWrapper>
         <Styled.Title>{title}</Styled.Title>

--- a/frontend/src/components/MapListItem/MapListItem.tsx
+++ b/frontend/src/components/MapListItem/MapListItem.tsx
@@ -1,12 +1,8 @@
-import { ReactNode, useState } from 'react';
-import MapDefault from 'assets/images/map-default.jpg';
+import { ReactNode } from 'react';
 import * as Styled from './MapListItem.styles';
 
 export interface Props {
-  thumbnail: {
-    src: string;
-    alt: string;
-  };
+  thumbnail: string;
   title: string;
   control?: ReactNode;
   selected?: boolean;
@@ -20,23 +16,10 @@ const MapListItem = ({
   selected = false,
   onClick = () => null,
 }: Props): JSX.Element => {
-  const [thumbnailSrc, setThumbnailSrc] = useState(thumbnail.src);
-
-  const onImgError = () => {
-    setThumbnailSrc(MapDefault);
-  };
-
   return (
     <Styled.Container role="listitem" selected={selected}>
       <Styled.ImageWrapper onClick={onClick}>
-        <Styled.ImageInner>
-          <Styled.Image
-            src={thumbnailSrc}
-            alt={thumbnail.alt}
-            onError={onImgError}
-            loading="lazy"
-          />
-        </Styled.ImageInner>
+        <Styled.ImageInner dangerouslySetInnerHTML={{ __html: thumbnail }} />
       </Styled.ImageWrapper>
       <Styled.TitleWrapper>
         <Styled.Title>{title}</Styled.Title>

--- a/frontend/src/pages/ManagerMain/units/MapDrawer.tsx
+++ b/frontend/src/pages/ManagerMain/units/MapDrawer.tsx
@@ -32,11 +32,11 @@ const MapDrawer = ({
           <Drawer.HeaderText>{organization}</Drawer.HeaderText>
           <Drawer.CloseButton />
         </Drawer.Header>
-        {maps.map(({ mapId, mapName, mapImageUrl }) => (
+        {maps.map(({ mapId, mapName, thumbnail }) => (
           <Styled.SpaceWrapper key={`map-${mapId}`}>
             <MapListItem
               onClick={() => onSelectMap(mapId, mapName)}
-              thumbnail={{ src: mapImageUrl, alt: mapName }}
+              thumbnail={thumbnail}
               title={mapName}
               selected={mapId === selectedMapId}
               control={

--- a/frontend/src/pages/ManagerMapEditor/ManagerMapEditor.tsx
+++ b/frontend/src/pages/ManagerMapEditor/ManagerMapEditor.tsx
@@ -129,7 +129,7 @@ const ManagerMapEditor = (): JSX.Element => {
       mapElements: mapElements.map(({ ref, ...props }) => props),
     });
 
-    const mapImageSvg = createMapImageSvg({
+    const thumbnail = createMapImageSvg({
       mapElements,
       spaces,
       width,
@@ -137,12 +137,12 @@ const ManagerMapEditor = (): JSX.Element => {
     });
 
     if (isEdit) {
-      updateMap.mutate({ mapId: Number(mapId), mapName: name, mapDrawing, mapImageSvg });
+      updateMap.mutate({ mapId: Number(mapId), mapName: name, mapDrawing, thumbnail });
 
       return;
     }
 
-    createMap.mutate({ mapName: name, mapDrawing, mapImageSvg });
+    createMap.mutate({ mapName: name, mapDrawing, thumbnail });
   };
 
   useListenManagerMainState({ mapId: Number(mapId) }, { enabled: isEdit });

--- a/frontend/src/pages/ManagerSpaceEditor/units/Form.tsx
+++ b/frontend/src/pages/ManagerSpaceEditor/units/Form.tsx
@@ -67,13 +67,13 @@ const Form = ({
   const handleSubmit: FormEventHandler<HTMLFormElement> = (event) => {
     event.preventDefault();
 
-    const mapImageSvg = generateSvg({ ...mapData, spaces: getSpacesForSvg() });
+    const thumbnail = generateSvg({ ...mapData, spaces: getSpacesForSvg() });
     const valuesForRequest = getRequestValues();
 
     if (selectedSpaceId === null) {
       onCreateSpace({
         space: {
-          mapImageSvg,
+          thumbnail,
           ...valuesForRequest.space,
           settingsRequest: { ...valuesForRequest.space.settings },
         },
@@ -85,7 +85,7 @@ const Form = ({
     onUpdateSpace({
       spaceId: selectedSpaceId,
       space: {
-        mapImageSvg,
+        thumbnail,
         ...valuesForRequest.space,
         settingsRequest: { ...valuesForRequest.space.settings },
       },
@@ -97,11 +97,11 @@ const Form = ({
     if (!window.confirm(MESSAGE.MANAGER_SPACE.DELETE_SPACE_CONFIRM)) return;
 
     const filteredSpaces = spaces.filter(({ id }) => id !== selectedSpaceId);
-    const mapImageSvg = generateSvg({ ...mapData, spaces: filteredSpaces });
+    const thumbnail = generateSvg({ ...mapData, spaces: filteredSpaces });
 
     onDeleteSpace({
       spaceId: selectedSpaceId,
-      mapImageSvg,
+      thumbnail,
     });
 
     resetForm();

--- a/frontend/src/types/common.ts
+++ b/frontend/src/types/common.ts
@@ -40,7 +40,7 @@ export interface MapItem {
   mapId: number;
   mapName: string;
   mapDrawing: MapDrawing;
-  mapImageUrl: string;
+  thumbnail: string;
   sharingMapId: string;
 }
 


### PR DESCRIPTION
## 구현 기능
- [x] 관리자 메인 페이지에서 썸네일 이미지를 png 대신 svg로 보여준다.

## 공유하고 싶은 내용
- API 명세가 변경 됨에 따라 type명 변경이 있었습니다.
   - `mapImageSvg` ->  `thumbnail`
- `Drawer` -> `MapListItem` 컴포넌트에서 `dangerouslySetInnerHTML`을 사용 했습니다. 
   - 체프와 썬의 아이디어를 반영해보려 했으나 시간 관계상 이번 PR에는 적용하기 힘들거 같습니다ㅠㅠ 추후 리팩토링 진행하도록 하겠습니다 
   - 이 부분이 마음에 걸리는데 혹시 안전하게 처리할 수 있는 방법이 있다면 코멘트로 남겨주심 감사하겠습니다



Close #763 

