### PR TITLE
fix: RequestRejectedException 핸들링 코드 추가

### DIFF
--- a/backend/src/main/java/com/woowacourse/zzimkkong/controller/ControllerAdvice.java
+++ b/backend/src/main/java/com/woowacourse/zzimkkong/controller/ControllerAdvice.java
@@ -13,21 +13,26 @@ import org.slf4j.MDC;
 import org.springframework.dao.DataAccessException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.security.web.firewall.RequestRejectedException;
+import org.springframework.security.web.firewall.RequestRejectedHandler;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 import javax.validation.ConstraintViolationException;
+import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 
-import static com.woowacourse.zzimkkong.dto.ValidatorMessage.FORMAT_MESSAGE;
-import static com.woowacourse.zzimkkong.dto.ValidatorMessage.SERVER_ERROR_MESSAGE;
+import static com.woowacourse.zzimkkong.dto.ValidatorMessage.*;
 import static net.logstash.logback.argument.StructuredArguments.value;
 
 @Slf4j
 @RestControllerAdvice
-public class ControllerAdvice {
+public class ControllerAdvice implements RequestRejectedHandler {
     private static final String MESSAGE_FORMAT = "{} (traceId: {})";
     private static final String TRACE_ID_KEY = "traceId";
 
@@ -116,4 +121,8 @@ public class ControllerAdvice {
         return MDC.get(TRACE_ID_KEY);
     }
 
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response, RequestRejectedException requestRejectedException) throws IOException, ServletException {
+        response.sendError(HttpServletResponse.SC_BAD_REQUEST);
+    }
 }


### PR DESCRIPTION
## 구현 기능
- 그놈의 malicious String 때문에 DEV, PROD 가리지 않고 잉잉 우는 사이렌을 잠재우기 위해 해당 예외 잡아서 400으로 내리는 핸들링 코드를 추가했습니다.
<img width="600" alt="image" src="https://user-images.githubusercontent.com/56033755/152138171-1813ed69-0070-4577-82a6-6f439801d43c.png">

### before
<img width="500" alt="스크린샷 2022-02-02 오후 7 47 36" src="https://user-images.githubusercontent.com/56033755/152140003-7300bc29-ff7f-40f4-8543-573fb823ad12.png">


### after
<img width="500" alt="requestrejectedexception3" src="https://user-images.githubusercontent.com/56033755/152139389-713fea90-e961-441b-8bc9-da225751a016.png">

## 공유하고 싶은 내용
- 자세한 내용은 [블로그](https://xrabcde.github.io/requestrejectedexception)에 정리했으니 참고하세요 '-'

Close #786 

