### PR TITLE
fix: 예약 시간이 12시인 경우 예약을 완료할 수 없는 문제

### DIFF
--- a/frontend/src/utils/datetime.ts
+++ b/frontend/src/utils/datetime.ts
@@ -30,7 +30,10 @@ export const formatTime = (time: Date | Time): string => {
     return `${hour < 10 ? `0${hour}` : `${hour}`}:${minute < 10 ? `0${minute}` : `${minute}`}`;
   }
 
-  const hour = time.midday === Midday.AM ? `${time.hour}`.padStart(2, '0') : `${time.hour + 12}`;
+  const hour =
+    time.midday === Midday.AM || time.hour === 12
+      ? `${time.hour}`.padStart(2, '0')
+      : `${time.hour + 12}`;
   const minute = `${time.minute}`.padStart(2, '0');
 
   return `${hour}:${minute}`;

--- a/frontend/src/utils/datetime.ts
+++ b/frontend/src/utils/datetime.ts
@@ -21,7 +21,7 @@ export const formatDateWithDay = (value: Date): string => {
   return `${year}/${month}/${date} (${DAY[day]})`;
 };
 
-// Note: HH:MM 형태로 변환함
+// Note: HH:MM (24시간 기준) 형태로 변환함
 export const formatTime = (time: Date | Time): string => {
   if (time instanceof Date) {
     const hour = time.getHours();
@@ -30,11 +30,13 @@ export const formatTime = (time: Date | Time): string => {
     return `${hour < 10 ? `0${hour}` : `${hour}`}:${minute < 10 ? `0${minute}` : `${minute}`}`;
   }
 
-  const hour =
-    time.midday === Midday.AM || time.hour === 12
-      ? `${time.hour}`.padStart(2, '0')
-      : `${time.hour + 12}`;
   const minute = `${time.minute}`.padStart(2, '0');
+
+  if (time.hour === 12) {
+    return `${time.midday === Midday.AM ? '00' : '12'}:${minute}`;
+  }
+
+  const hour = time.midday === Midday.AM ? `${time.hour}`.padStart(2, '0') : `${time.hour + 12}`;
 
   return `${hour}:${minute}`;
 };


### PR DESCRIPTION
## 버그 원인
- 예약 form 제출 시 입력받은 시간을 `formatTime`을 이용하여 Date타입으로 변환합니다.
- `formatTime`에서 입력받은 시간이 오후인 경우 시간에 12를 더하고 있었습니다.
- 오후 12시 30분의 경우 24시 30분이 되면서 유효하지 않은 시간으로 변환되어 모든 값을 입력하라는 오류가 나타났습니다.
- 오전 12시 30분의 경우 오후 12시 30분으로 변환되면서 의도치 않은 오류가 발생했습니다.
- (요약) 오전 12시는 00시가 아닌 12시, 오후 12시는 12시가 아닌 24시로 변환되어 오류남

## 해결 방법
- 입력받은 시간이 12인 경우, 오전이면 '00' 오후면 '12'로 시간을 반환하도록 변경

Close #791

