### PR TITLE
refactor: 타임존 관리 방식 변경으로 인한 API 대응 및 타임존 고정

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -35,6 +35,7 @@
   },
   "dependencies": {
     "axios": "^0.21.1",
+    "dayjs": "^1.10.7",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-query": "^3.18.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -29,8 +29,8 @@
     "build:dev": "cross-env NODE_ENV=production DEPLOY_ENV=development webpack",
     "storybook": "start-storybook -s ./src/assets -p 6006",
     "build-storybook": "build-storybook -s ./src/assets",
-    "test": "TZ=UTC+9 jest --watch --passWithNoTests",
-    "test:ci": "TZ=UTC+9 jest --passWithNoTests",
+    "test": "TZ=Asia/Seoul jest --watch --passWithNoTests",
+    "test:ci": "TZ=Asia/Seoul jest --passWithNoTests",
     "prepare": "cd .. && husky install frontend/.husky && cd frontend"
   },
   "dependencies": {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,3 +1,6 @@
+import dayjs from 'dayjs';
+import timezone from 'dayjs/plugin/timezone';
+import utc from 'dayjs/plugin/utc';
 import { createBrowserHistory } from 'history';
 import { Suspense } from 'react';
 import { QueryClient, QueryClientProvider } from 'react-query';
@@ -11,6 +14,10 @@ import { PRIVATE_ROUTES, PUBLIC_ROUTES } from 'constants/routes';
 import AccessTokenProvider from 'providers/AccessTokenProvider';
 import { GlobalStyle, theme } from './App.styles';
 import NotFound from './pages/NotFound/NotFound';
+
+dayjs.extend(utc);
+dayjs.extend(timezone);
+dayjs.tz.setDefault('Asia/Seoul');
 
 export const history = createBrowserHistory();
 export const queryClient = new QueryClient();

--- a/frontend/src/api/guestReservation.ts
+++ b/frontend/src/api/guestReservation.ts
@@ -15,8 +15,8 @@ export interface QuerySpaceReservationsParams extends QueryMapReservationsParams
 
 export interface ReservationParams {
   reservation: {
-    startDateTime: Date;
-    endDateTime: Date;
+    startDateTime: string;
+    endDateTime: string;
     password: string;
     name: string;
     description: string;

--- a/frontend/src/api/managerReservation.ts
+++ b/frontend/src/api/managerReservation.ts
@@ -19,8 +19,8 @@ export interface PostReservationParams {
   mapId: number;
   spaceId: number;
   reservation: {
-    startDateTime: Date;
-    endDateTime: Date;
+    startDateTime: string;
+    endDateTime: string;
     name: string;
     description: string;
     password: string;
@@ -32,8 +32,8 @@ export interface PutReservationParams {
   spaceId: number;
   reservationId: number;
   reservation: {
-    startDateTime: Date;
-    endDateTime: Date;
+    startDateTime: string;
+    endDateTime: string;
     name: string;
     description: string;
   };

--- a/frontend/src/components/DateInput/DateInput.stories.tsx
+++ b/frontend/src/components/DateInput/DateInput.stories.tsx
@@ -1,4 +1,5 @@
 import { Story } from '@storybook/react';
+import dayjs from 'dayjs';
 import DateInput, { Props } from './DateInput';
 
 export default {
@@ -10,5 +11,5 @@ const Template: Story<Props> = (args) => <DateInput {...args} />;
 
 export const Default = Template.bind({});
 Default.args = {
-  date: new Date(),
+  date: dayjs().tz(),
 };

--- a/frontend/src/components/DateInput/DateInput.tsx
+++ b/frontend/src/components/DateInput/DateInput.tsx
@@ -1,24 +1,25 @@
+import dayjs, { Dayjs } from 'dayjs';
 import { ChangeEventHandler, Dispatch, InputHTMLAttributes, SetStateAction } from 'react';
 import IconButton from 'components/IconButton/IconButton';
 import { formatDate, formatDateWithDay } from 'utils/datetime';
 import * as Styled from './DateInput.styles';
 
 export interface Props extends Omit<InputHTMLAttributes<HTMLInputElement>, 'type' | 'value'> {
-  date: Date;
-  setDate: Dispatch<SetStateAction<Date>>;
+  date: Dayjs;
+  setDate: Dispatch<SetStateAction<Dayjs>>;
 }
 
 const DateInput = ({ date, setDate, ...props }: Props): JSX.Element => {
   const onChange: ChangeEventHandler<HTMLInputElement> = (event) => {
-    setDate(new Date(event.target.value));
+    setDate(dayjs(event.target.value).tz());
   };
 
   const onClickPrev = () => {
-    setDate(new Date(date.setDate(date.getDate() - 1)));
+    setDate(dayjs(date).subtract(1, 'day'));
   };
 
   const onClickNext = () => {
-    setDate(new Date(date.setDate(date.getDate() + 1)));
+    setDate(dayjs(date).add(1, 'day'));
   };
 
   return (

--- a/frontend/src/components/ReservationListItem/ReservationListItem.tsx
+++ b/frontend/src/components/ReservationListItem/ReservationListItem.tsx
@@ -1,3 +1,4 @@
+import dayjs from 'dayjs';
 import { ReactNode } from 'react';
 import { Reservation, ReservationStatus } from 'types/common';
 import { formatTime } from 'utils/datetime';
@@ -12,8 +13,8 @@ export interface Props {
 const ReservationListItem = ({ reservation, control, status, ...props }: Props): JSX.Element => {
   const { name, description, startDateTime, endDateTime } = reservation;
 
-  const start = formatTime(new Date(startDateTime));
-  const end = formatTime(new Date(endDateTime));
+  const start = formatTime(dayjs(startDateTime).tz());
+  const end = formatTime(dayjs(endDateTime).tz());
 
   return (
     <Styled.Item role="listitem" {...props}>

--- a/frontend/src/constants/date.ts
+++ b/frontend/src/constants/date.ts
@@ -3,6 +3,7 @@ const DATE = {
   MIN_DATE_STRING: '2000-01-01',
   MAX_DATE: new Date('2100-12-31'),
   MAX_DATE_STRING: '2100-12-31',
+  TIMEZONE_OFFSET: '+09:00',
 };
 
 export default DATE;

--- a/frontend/src/hooks/useTimePicker.ts
+++ b/frontend/src/hooks/useTimePicker.ts
@@ -21,13 +21,15 @@ const generateDateToTime = (time: Date | Dayjs, step: Props['step'] = 1): Time =
   const minute = isDayjs(time)
     ? Math.ceil(time.minute() / step) * step
     : Math.ceil(time.getMinutes() / step) * step;
-  const hour = isDayjs(time)
-    ? minute < 60
-      ? time.hour()
-      : time.hour() + 1
-    : minute < 60
-    ? time.getHours()
-    : time.getHours() + 1;
+
+  const hour = (() => {
+    if (isDayjs(time)) {
+      return minute < 60 ? time.hour() : time.hour() + 1;
+    }
+
+    return minute < 60 ? time.getHours() : time.getHours() + 1;
+  })();
+
   const midday = hour < 12 ? Midday.AM : Midday.PM;
 
   return {

--- a/frontend/src/hooks/useTimePicker.ts
+++ b/frontend/src/hooks/useTimePicker.ts
@@ -1,3 +1,4 @@
+import dayjs, { Dayjs, isDayjs } from 'dayjs';
 import { MouseEventHandler, useState } from 'react';
 import { Step } from 'components/TimePicker/TimePicker';
 import { Midday, Range, Time } from 'types/time';
@@ -16,9 +17,17 @@ const generateTo12Hour = (hour: number) => {
   return result === 0 ? 12 : result;
 };
 
-const generateDateToTime = (time: Date, step: Props['step'] = 1): Time => {
-  const minute = Math.ceil(time.getMinutes() / step) * step;
-  const hour = minute < 60 ? time.getHours() : time.getHours() + 1;
+const generateDateToTime = (time: Date | Dayjs, step: Props['step'] = 1): Time => {
+  const minute = isDayjs(time)
+    ? Math.ceil(time.minute() / step) * step
+    : Math.ceil(time.getMinutes() / step) * step;
+  const hour = isDayjs(time)
+    ? minute < 60
+      ? time.hour()
+      : time.hour() + 1
+    : minute < 60
+    ? time.getHours()
+    : time.getHours() + 1;
   const midday = hour < 12 ? Midday.AM : Midday.PM;
 
   return {
@@ -41,13 +50,13 @@ const useTimePicker = ({
 } => {
   const [selectedTime, setSelectedTime] = useState<SelectedTime>(null);
   const [range, setRange] = useState<Range>({
-    start: initialStartTime ? generateDateToTime(initialStartTime, step) : null,
-    end: initialEndTime ? generateDateToTime(initialEndTime, step) : null,
+    start: initialStartTime ? generateDateToTime(dayjs(initialStartTime).tz(), step) : null,
+    end: initialEndTime ? generateDateToTime(dayjs(initialEndTime).tz(), step) : null,
   });
 
   const setInitialTime = (key: keyof Range) => {
     if (key === 'start' || (key === 'end' && range.start === null)) {
-      const now = new Date();
+      const now = dayjs().tz();
 
       setRange((prev) => ({
         ...prev,

--- a/frontend/src/pages/GuestMap/GuestMap.tsx
+++ b/frontend/src/pages/GuestMap/GuestMap.tsx
@@ -1,4 +1,5 @@
 import { AxiosError } from 'axios';
+import dayjs, { Dayjs } from 'dayjs';
 import { FormEventHandler, useEffect, useMemo, useRef, useState } from 'react';
 import { useMutation } from 'react-query';
 import { useHistory, useLocation, useParams } from 'react-router-dom';
@@ -29,7 +30,7 @@ import ReservationDrawer from './units/ReservationDrawer';
 
 export interface GuestMapState {
   spaceId?: Space['id'];
-  targetDate?: Date;
+  targetDate?: Dayjs;
   scrollPosition?: ScrollPosition;
 }
 
@@ -76,7 +77,7 @@ const GuestMap = (): JSX.Element => {
 
   const [spaceList, setSpaceList] = useState<Space[]>([]);
   const [selectedSpaceId, setSelectedSpaceId] = useState<Space['id'] | null>(spaceId ?? null);
-  const [date, setDate] = useState(targetDate ? new Date(targetDate) : new Date());
+  const [date, setDate] = useState(targetDate ? dayjs(targetDate).tz() : dayjs().tz());
 
   const spaces = useMemo(() => {
     const result: { [key: string]: Space } = {};
@@ -186,7 +187,7 @@ const GuestMap = (): JSX.Element => {
 
   useEffect(() => {
     if (targetDate) {
-      setDate(new Date(targetDate));
+      setDate(dayjs(targetDate).tz());
     }
   }, [targetDate]);
 

--- a/frontend/src/pages/GuestMap/units/ReservationDrawer.tsx
+++ b/frontend/src/pages/GuestMap/units/ReservationDrawer.tsx
@@ -1,3 +1,4 @@
+import { Dayjs } from 'dayjs';
 import { ReactComponent as DeleteIcon } from 'assets/svg/delete.svg';
 import { ReactComponent as EditIcon } from 'assets/svg/edit.svg';
 import Drawer from 'components/Drawer/Drawer';
@@ -11,7 +12,7 @@ import * as Styled from './ReservationDrawer.styles';
 interface Props {
   reservations: Reservation[];
   space: Space;
-  date: Date;
+  date: Dayjs;
   open: boolean;
   isSuccess: boolean;
   isLoadingError: boolean;

--- a/frontend/src/pages/GuestReservation/GuestReservation.tsx
+++ b/frontend/src/pages/GuestReservation/GuestReservation.tsx
@@ -1,4 +1,5 @@
 import { AxiosError } from 'axios';
+import dayjs from 'dayjs';
 import React, { useEffect } from 'react';
 import { useMutation } from 'react-query';
 import { useHistory, useLocation, useParams } from 'react-router-dom';
@@ -51,7 +52,7 @@ const GuestReservation = (): JSX.Element => {
   const getReservations = useGuestReservations(
     { mapId, spaceId: space.id, date },
     {
-      enabled: !isPastDate(new Date(date), DATE.MIN_DATE) && !!date,
+      enabled: !isPastDate(dayjs(date).tz(), DATE.MIN_DATE) && !!date,
     }
   );
   const reservations = getReservations.data?.data?.reservations ?? [];
@@ -70,7 +71,7 @@ const GuestReservation = (): JSX.Element => {
             name,
             description,
           },
-          targetDate: new Date(date),
+          targetDate: dayjs(date).tz(),
         },
       });
     },
@@ -85,7 +86,7 @@ const GuestReservation = (): JSX.Element => {
         pathname: HREF.GUEST_MAP(sharingMapId),
         state: {
           spaceId: space.id,
-          targetDate: new Date(date),
+          targetDate: dayjs(date).tz(),
         },
       });
     },
@@ -121,12 +122,12 @@ const GuestReservation = (): JSX.Element => {
       target: { value },
     } = event;
 
-    if (isPastDate(new Date(date), DATE.MIN_DATE)) {
+    if (isPastDate(dayjs(date).tz(), DATE.MIN_DATE)) {
       setDate(DATE.MIN_DATE_STRING);
       return;
     }
 
-    if (isFutureDate(new Date(date), DATE.MAX_DATE)) {
+    if (isFutureDate(dayjs(date).tz(), DATE.MAX_DATE)) {
       setDate(DATE.MAX_DATE_STRING);
       return;
     }
@@ -153,7 +154,7 @@ const GuestReservation = (): JSX.Element => {
       ) {
         location.state = {
           spaceId: space.id,
-          targetDate: new Date(date),
+          targetDate: dayjs(date).tz(),
           scrollPosition,
         };
       }
@@ -187,16 +188,16 @@ const GuestReservation = (): JSX.Element => {
             )}
             {getReservations.isSuccess &&
               reservations.length === 0 &&
-              !isPastDate(new Date(date)) && (
+              !isPastDate(dayjs(date).tz()) && (
                 <Styled.Message>{MESSAGE.RESERVATION.SUGGESTION}</Styled.Message>
               )}
             {getReservations.isSuccess &&
               reservations.length === 0 &&
-              isPastDate(new Date(date)) && (
+              isPastDate(dayjs(date).tz()) && (
                 <Styled.Message>{MESSAGE.RESERVATION.NOT_EXIST}</Styled.Message>
               )}
-            {(isPastDate(new Date(date), DATE.MIN_DATE) ||
-              isFutureDate(new Date(date), DATE.MAX_DATE)) && (
+            {(isPastDate(dayjs(date).tz(), DATE.MIN_DATE) ||
+              isFutureDate(dayjs(date).tz(), DATE.MAX_DATE)) && (
               <Styled.Message>{MESSAGE.RESERVATION.NOT_EXIST}</Styled.Message>
             )}
             {getReservations.isSuccess && reservations.length > 0 && (

--- a/frontend/src/pages/GuestReservation/GuestReservationSuccess.tsx
+++ b/frontend/src/pages/GuestReservation/GuestReservationSuccess.tsx
@@ -1,3 +1,4 @@
+import dayjs from 'dayjs';
 import { Redirect, useLocation, useParams } from 'react-router';
 import AnimatedLogo from 'components/AnimatedLogo/AnimatedLogo';
 import Header from 'components/Header/Header';
@@ -27,8 +28,8 @@ const GuestReservationSuccess = (): JSX.Element => {
 
   const { space, reservation, targetDate } = location.state;
 
-  const startDateTimeObject = new Date(reservation.startDateTime);
-  const endDateTimeObject = new Date(reservation.endDateTime);
+  const startDateTimeObject = dayjs(reservation.startDateTime).tz();
+  const endDateTimeObject = dayjs(reservation.endDateTime).tz();
 
   const reservationDate = formatDateWithDay(startDateTimeObject);
   const reservationStartTime = formatTime(startDateTimeObject);

--- a/frontend/src/pages/GuestReservation/GuestReservationSuccess.tsx
+++ b/frontend/src/pages/GuestReservation/GuestReservationSuccess.tsx
@@ -14,8 +14,8 @@ export interface GuestReservationSuccessState {
   reservation: {
     name: string;
     description: string;
-    startDateTime: Date;
-    endDateTime: Date;
+    startDateTime: string;
+    endDateTime: string;
   };
 }
 
@@ -27,8 +27,8 @@ const GuestReservationSuccess = (): JSX.Element => {
 
   const { space, reservation, targetDate } = location.state;
 
-  const startDateTimeObject = new Date(reservation.startDateTime.toISOString().slice(0, -1));
-  const endDateTimeObject = new Date(reservation.endDateTime.toISOString().slice(0, -1));
+  const startDateTimeObject = new Date(reservation.startDateTime);
+  const endDateTimeObject = new Date(reservation.endDateTime);
 
   const reservationDate = formatDateWithDay(startDateTimeObject);
   const reservationStartTime = formatTime(startDateTimeObject);

--- a/frontend/src/pages/GuestReservation/units/GuestReservationForm.tsx
+++ b/frontend/src/pages/GuestReservation/units/GuestReservationForm.tsx
@@ -10,7 +10,13 @@ import useInputs from 'hooks/useInputs';
 import useScrollToTop from 'hooks/useScrollToTop';
 import useTimePicker from 'hooks/useTimePicker';
 import { Reservation, Space } from 'types/common';
-import { formatDate, formatTime, formatTimePrettier, isPastDate } from 'utils/datetime';
+import {
+  formatDate,
+  formatTime,
+  formatTimePrettier,
+  formatTimeWithSecond,
+  isPastDate,
+} from 'utils/datetime';
 import { EditReservationParams } from '../GuestReservation';
 import * as Styled from './GuestReservationForm.styles';
 
@@ -66,8 +72,8 @@ const GuestReservationForm = ({
 
     if (range.start === null || range.end === null) return;
 
-    const startDateTime = new Date(`${date}T${formatTime(range.start)}Z`);
-    const endDateTime = new Date(`${date}T${formatTime(range.end)}Z`);
+    const startDateTime = `${date}T${formatTimeWithSecond(range.start)}${DATE.TIMEZONE_OFFSET}`;
+    const endDateTime = `${date}T${formatTimeWithSecond(range.end)}${DATE.TIMEZONE_OFFSET}`;
 
     onSubmit(event, {
       reservation: {

--- a/frontend/src/pages/ManagerMain/ManagerMain.tsx
+++ b/frontend/src/pages/ManagerMain/ManagerMain.tsx
@@ -1,4 +1,5 @@
 import { AxiosError } from 'axios';
+import dayjs, { Dayjs } from 'dayjs';
 import React, { useEffect, useMemo, useState } from 'react';
 import { useMutation } from 'react-query';
 import { useHistory, useLocation } from 'react-router-dom';
@@ -33,7 +34,7 @@ import ReservationList from './units/ReservationList';
 
 export interface ManagerMainState {
   mapId?: number;
-  targetDate?: Date;
+  targetDate?: Dayjs;
 }
 
 const ManagerMain = (): JSX.Element => {
@@ -43,7 +44,7 @@ const ManagerMain = (): JSX.Element => {
   const mapId = location.state?.mapId;
   const targetDate = location.state?.targetDate;
 
-  const [date, setDate] = useState(targetDate ?? new Date());
+  const [date, setDate] = useState(targetDate ?? dayjs().tz());
   const [open, setOpen] = useState(false);
   const [slackModalOpen, setSlackModalOpen] = useState(false);
 

--- a/frontend/src/pages/ManagerReservation/ManagerReservation.tsx
+++ b/frontend/src/pages/ManagerReservation/ManagerReservation.tsx
@@ -1,4 +1,5 @@
 import { AxiosError } from 'axios';
+import dayjs from 'dayjs';
 import { useEffect } from 'react';
 import { useMutation } from 'react-query';
 import { useHistory, useLocation } from 'react-router-dom';
@@ -50,7 +51,7 @@ const ManagerReservation = (): JSX.Element => {
   const getReservations = useManagerSpaceReservations(
     { mapId, spaceId: space.id, date },
     {
-      enabled: !isPastDate(new Date(date), DATE.MIN_DATE) && !!date,
+      enabled: !isPastDate(dayjs(date), DATE.MIN_DATE) && !!date,
     }
   );
   const reservations = getReservations.data?.data?.reservations ?? [];
@@ -61,7 +62,7 @@ const ManagerReservation = (): JSX.Element => {
         pathname: PATH.MANAGER_MAIN,
         state: {
           mapId,
-          targetDate: new Date(date),
+          targetDate: dayjs(date),
         },
       });
     },
@@ -76,7 +77,7 @@ const ManagerReservation = (): JSX.Element => {
         pathname: PATH.MANAGER_MAIN,
         state: {
           mapId,
-          targetDate: new Date(date),
+          targetDate: dayjs(date),
         },
       });
     },
@@ -112,12 +113,12 @@ const ManagerReservation = (): JSX.Element => {
       target: { value },
     } = event;
 
-    if (isPastDate(new Date(date), DATE.MIN_DATE)) {
+    if (isPastDate(dayjs(date), DATE.MIN_DATE)) {
       setDate(DATE.MIN_DATE_STRING);
       return;
     }
 
-    if (isFutureDate(new Date(date), DATE.MAX_DATE)) {
+    if (isFutureDate(dayjs(date), DATE.MAX_DATE)) {
       setDate(DATE.MAX_DATE_STRING);
       return;
     }
@@ -133,7 +134,7 @@ const ManagerReservation = (): JSX.Element => {
       ) {
         location.state = {
           mapId,
-          targetDate: new Date(date),
+          targetDate: dayjs(date),
         };
       }
     });
@@ -165,18 +166,14 @@ const ManagerReservation = (): JSX.Element => {
             {getReservations.isLoading && !getReservations.isLoadingError && (
               <Styled.Message>{MESSAGE.RESERVATION.PENDING}</Styled.Message>
             )}
-            {getReservations.isSuccess &&
-              reservations.length === 0 &&
-              !isPastDate(new Date(date)) && (
-                <Styled.Message>{MESSAGE.RESERVATION.SUGGESTION}</Styled.Message>
-              )}
-            {getReservations.isSuccess &&
-              reservations.length === 0 &&
-              isPastDate(new Date(date)) && (
-                <Styled.Message>{MESSAGE.RESERVATION.NOT_EXIST}</Styled.Message>
-              )}
-            {(isPastDate(new Date(date), DATE.MIN_DATE) ||
-              isFutureDate(new Date(date), DATE.MAX_DATE)) && (
+            {getReservations.isSuccess && reservations.length === 0 && !isPastDate(dayjs(date)) && (
+              <Styled.Message>{MESSAGE.RESERVATION.SUGGESTION}</Styled.Message>
+            )}
+            {getReservations.isSuccess && reservations.length === 0 && isPastDate(dayjs(date)) && (
+              <Styled.Message>{MESSAGE.RESERVATION.NOT_EXIST}</Styled.Message>
+            )}
+            {(isPastDate(dayjs(date), DATE.MIN_DATE) ||
+              isFutureDate(dayjs(date), DATE.MAX_DATE)) && (
               <Styled.Message>{MESSAGE.RESERVATION.NOT_EXIST}</Styled.Message>
             )}
             {getReservations.isSuccess && reservations.length > 0 && (

--- a/frontend/src/pages/ManagerReservation/units/ManagerReservationForm.tsx
+++ b/frontend/src/pages/ManagerReservation/units/ManagerReservationForm.tsx
@@ -11,7 +11,7 @@ import useInputs from 'hooks/useInputs';
 import useScrollToTop from 'hooks/useScrollToTop';
 import useTimePicker from 'hooks/useTimePicker';
 import { ManagerSpaceAPI, Reservation } from 'types/common';
-import { formatDate, formatTime, formatTimePrettier } from 'utils/datetime';
+import { formatDate, formatTime, formatTimePrettier, formatTimeWithSecond } from 'utils/datetime';
 import { CreateReservationParams, EditReservationParams } from '../ManagerReservation';
 import * as Styled from './ManagerReservationForm.styles';
 
@@ -67,8 +67,8 @@ const ManagerReservationForm = ({
 
     if (range.start === null || range.end === null) return;
 
-    const startDateTime = new Date(`${date}T${formatTime(range.start)}Z`);
-    const endDateTime = new Date(`${date}T${formatTime(range.end)}Z`);
+    const startDateTime = `${date}T${formatTimeWithSecond(range.start)}${DATE.TIMEZONE_OFFSET}`;
+    const endDateTime = `${date}T${formatTimeWithSecond(range.end)}${DATE.TIMEZONE_OFFSET}`;
 
     if (!reservation) {
       onCreateReservation({

--- a/frontend/src/utils/datetime.ts
+++ b/frontend/src/utils/datetime.ts
@@ -71,13 +71,13 @@ export const formatTimeWithSecond = (time: Date | Time | Dayjs): string => {
   }
 
   const minute = `${time.minute}`.padStart(2, '0');
+  const second = '00';
 
   if (time.hour === 12) {
-    return `${time.midday === Midday.AM ? '00' : '12'}:${minute}`;
+    return `${time.midday === Midday.AM ? '00' : '12'}:${minute}:${second}`;
   }
 
   const hour = time.midday === Midday.AM ? `${time.hour}`.padStart(2, '0') : `${time.hour + 12}`;
-  const second = '00';
 
   return `${hour}:${minute}:${second}`;
 };

--- a/frontend/src/utils/datetime.ts
+++ b/frontend/src/utils/datetime.ts
@@ -1,7 +1,12 @@
+import dayjs, { Dayjs, isDayjs } from 'dayjs';
 import { Midday, Time } from 'types/time';
 
 // Note: YYYY-MM-DD 형식으로 변환함
-export const formatDate = (value: Date): string => {
+export const formatDate = (value: Date | Dayjs): string => {
+  if (isDayjs(value)) {
+    return value.format('YYYY-MM-DD');
+  }
+
   const year = value.getFullYear();
   const month = `${value.getMonth() + 1}`.padStart(2, '0');
   const date = `${value.getDate()}`.padStart(2, '0');
@@ -12,7 +17,11 @@ export const formatDate = (value: Date): string => {
 const DAY = ['SUN', 'MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT'];
 
 // Note: YYYY/MM/DD (MON) 형식으로 변환함
-export const formatDateWithDay = (value: Date): string => {
+export const formatDateWithDay = (value: Date | Dayjs): string => {
+  if (isDayjs(value)) {
+    return value.format('YYYY-MM-DD (ddd)').toUpperCase();
+  }
+
   const year = value.getFullYear();
   const month = `${value.getMonth() + 1}`.padStart(2, '0');
   const date = `${value.getDate()}`.padStart(2, '0');
@@ -22,7 +31,11 @@ export const formatDateWithDay = (value: Date): string => {
 };
 
 // Note: HH:MM (24시간 기준) 형태로 변환함
-export const formatTime = (time: Date | Time): string => {
+export const formatTime = (time: Date | Time | Dayjs): string => {
+  if (isDayjs(time)) {
+    return time.format('HH:mm');
+  }
+
   if (time instanceof Date) {
     const hour = time.getHours();
     const minute = time.getMinutes();
@@ -42,7 +55,11 @@ export const formatTime = (time: Date | Time): string => {
 };
 
 // Note: HH:MM:SS (24시간 기준) 형태로 변환함
-export const formatTimeWithSecond = (time: Date | Time): string => {
+export const formatTimeWithSecond = (time: Date | Time | Dayjs): string => {
+  if (isDayjs(time)) {
+    return time.format('HH:mm:ss');
+  }
+
   if (time instanceof Date) {
     const hour = time.getHours();
     const minute = time.getMinutes();
@@ -73,14 +90,26 @@ export const formatTimePrettier = (minutes: number): string => {
   return `${hour ? `${hour}시간` : ''}${minute ? ' ' : ''}${minute ? `${minute}분` : ''}`;
 };
 
-export const isPastTime = (time: Date, baseDate: Date = new Date()): boolean => {
+export const isPastTime = (time: Date | Dayjs, baseDate: Date = new Date()): boolean => {
+  if (isDayjs(time)) {
+    return +time < +dayjs(baseDate).tz();
+  }
+
   return time.getTime() < baseDate.getTime();
 };
 
-export const isPastDate = (time: Date, baseDate: Date = new Date()): boolean => {
+export const isPastDate = (time: Date | Dayjs, baseDate: Date = new Date()): boolean => {
+  if (isDayjs(time)) {
+    return +time < +dayjs(baseDate).tz() - 1000 * 60 * 60 * 24;
+  }
+
   return time.getTime() < baseDate.getTime() - 1000 * 60 * 60 * 24;
 };
 
-export const isFutureDate = (time: Date, baseDate: Date = new Date()): boolean => {
+export const isFutureDate = (time: Date | Dayjs, baseDate: Date = new Date()): boolean => {
+  if (isDayjs(time)) {
+    return +time > +dayjs(baseDate).tz() + 1000 * 60 * 60 * 24;
+  }
+
   return time.getTime() > baseDate.getTime() + 1000 * 60 * 60 * 24;
 };

--- a/frontend/src/utils/datetime.ts
+++ b/frontend/src/utils/datetime.ts
@@ -41,11 +41,26 @@ export const formatTime = (time: Date | Time): string => {
   return `${hour}:${minute}`;
 };
 
-// Note: HH:MM:SS 형태로 변환함
-export const formatTimeWithSecond = (time: Date): string => {
-  const hour = `${time.getHours()}`.padStart(2, '0');
-  const minute = `${time.getMinutes()}`.padStart(2, '0');
-  const second = `${time.getSeconds()}`.padStart(2, '0');
+// Note: HH:MM:SS (24시간 기준) 형태로 변환함
+export const formatTimeWithSecond = (time: Date | Time): string => {
+  if (time instanceof Date) {
+    const hour = time.getHours();
+    const minute = time.getMinutes();
+    const second = `${time.getSeconds()}`.padStart(2, '0');
+
+    return `${hour < 10 ? `0${hour}` : `${hour}`}:${
+      minute < 10 ? `0${minute}` : `${minute}`
+    }:${second}`;
+  }
+
+  const minute = `${time.minute}`.padStart(2, '0');
+
+  if (time.hour === 12) {
+    return `${time.midday === Midday.AM ? '00' : '12'}:${minute}`;
+  }
+
+  const hour = time.midday === Midday.AM ? `${time.hour}`.padStart(2, '0') : `${time.hour + 12}`;
+  const second = '00';
 
   return `${hour}:${minute}:${second}`;
 };

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -5899,6 +5899,11 @@ data-urls@^2.0.0:
     whatwg-mimetype "^2.3.0"
     whatwg-url "^8.0.0"
 
+dayjs@^1.10.7:
+  version "1.10.7"
+  resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.10.7.tgz#2cf5f91add28116748440866a0a1d26f3a6ce468"
+  integrity sha512-P6twpd70BcPK34K26uJ1KT3wlhpuOAPoMwJzpsIWUxHZ7wpmbdZL/hQqBDfz7hGurYSa5PhzdhDHtt319hL3ig==
+
 debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.0, debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"


### PR DESCRIPTION
## 구현 기능
- 타임존 문제 해결을 위한 API 변경에 따른 date 관련 데이터 요청 타입 변경
- Dayjs 라이브러리 설치 및 설정
- 기존 시간 관련 함수에 Dayjs 타입도 처리할 수 있도록 수정 구현
- Dayjs를 이용하여 타임존이 Asia/Seoul로 고정되어 보이도록 수정

## 기타
- 변경 사항이 좀 있는 PR입니다. 컴퓨터의 시간대를 변경해서 예약이 잘 수행되는지, 시간대가 UTC+09:00가 적용되어서 잘 출력되는지 이것저것 테스트해보신 후 리뷰 부탁드립니다.
- 날짜/시간 출력에 한정하여 Dayjs를 사용하면서 적용을 최소화하려고 해봤습니다.
- 기존 시간 관련 유틸 함수의 Date 객체 호환성을 유지하면서 동작하도록 구현했습니다. (e.g. `formatTime()`)

Close #745 
