### PR TITLE
feat: 맵 이름과 공간 이름의 최대길이를 20자로 제한한다

### DIFF
--- a/frontend/src/pages/ManagerMapEditor/ManagerMapEditor.tsx
+++ b/frontend/src/pages/ManagerMapEditor/ManagerMapEditor.tsx
@@ -161,6 +161,7 @@ const ManagerMapEditor = (): JSX.Element => {
                   value={name}
                   onChange={onChangeBoard}
                   placeholder="맵 이름을 입력해주세요"
+                  maxLength={20}
                   required
                 />
                 <Styled.FormControl>

--- a/frontend/src/pages/ManagerSpaceEditor/units/Form.tsx
+++ b/frontend/src/pages/ManagerSpaceEditor/units/Form.tsx
@@ -144,6 +144,7 @@ const Form = ({
               name="name"
               onChange={onChange}
               ref={nameInputRef}
+              maxLength={20}
               required
             />
           </Styled.Row>


### PR DESCRIPTION
## 구현 기능
- [x] 맵 이름과 공간 이름의 최대길이를 20자로 제한한다

Close #813

