### PR TITLE
fix: 선택된 맵 ID가 없을 때도 등록된 슬랙 웹훅 URL을 불러오는 문제 수정

### DIFF
--- a/frontend/src/pages/ManagerMain/ManagerMain.tsx
+++ b/frontend/src/pages/ManagerMain/ManagerMain.tsx
@@ -113,6 +113,7 @@ const ManagerMain = (): JSX.Element => {
   const getSlackWebhookUrl = useSlackWebhookUrl(
     { mapId: selectedMapId as number },
     {
+      enabled: !!selectedMapId,
       refetchOnWindowFocus: false,
       onSuccess: (response) => {
         if (!slackUrl) setSlackUrl(response.data.slackUrl);


### PR DESCRIPTION
## 구현 기능
- 선택된 맵 ID가 없을 때도 등록된 슬랙 웹훅 URL을 불필요하게 불러오는 문제를 수정합니다.

Close #810 

