### PR TITLE
fix: 공지사항 글자수초과 예외메시지 수정

### DIFF
--- a/backend/src/main/java/com/woowacourse/zzimkkong/dto/ValidatorMessage.java
+++ b/backend/src/main/java/com/woowacourse/zzimkkong/dto/ValidatorMessage.java
@@ -12,6 +12,7 @@ public class ValidatorMessage {
     public static final String NAME_MESSAGE = "이름은 특수문자(-_!?.,)를 포함하여 20자 이내로 작성 가능합니다.";
     public static final String PRESET_NAME_MESSAGE = "프리셋 이름은 공백과 특수문자(-_!?.,)를 포함하여 20자 이내로 작성 가능합니다.";
     public static final String DESCRIPTION_MESSAGE = "예약 내용은 100자 이내로 작성 가능합니다.";
+    public static final String NOTICE_MESSAGE = "공지사항은 100자 이내로 작성 가능합니다.";
     public static final String FORMAT_MESSAGE = "날짜 및 시간 데이터 형식이 올바르지 않습니다.";
     public static final String DAY_OF_WEEK_MESSAGE = "올바른 요일 형식이 아닙니다.";
     public static final String SERVER_ERROR_MESSAGE = "예상치 못한 문제가 발생했습니다. 개발자에게 문의하세요.";

--- a/backend/src/main/java/com/woowacourse/zzimkkong/dto/map/NoticeCreateRequest.java
+++ b/backend/src/main/java/com/woowacourse/zzimkkong/dto/map/NoticeCreateRequest.java
@@ -5,12 +5,12 @@ import lombok.NoArgsConstructor;
 
 import javax.validation.constraints.Size;
 
-import static com.woowacourse.zzimkkong.dto.ValidatorMessage.DESCRIPTION_MESSAGE;
+import static com.woowacourse.zzimkkong.dto.ValidatorMessage.NOTICE_MESSAGE;
 
 @Getter
 @NoArgsConstructor
 public class NoticeCreateRequest {
-    @Size(max = 100, message = DESCRIPTION_MESSAGE)
+    @Size(max = 100, message = NOTICE_MESSAGE)
     private String notice;
 
     public NoticeCreateRequest(final String notice) {

--- a/backend/src/test/java/com/woowacourse/zzimkkong/dto/NoticeCreateRequestTest.java
+++ b/backend/src/test/java/com/woowacourse/zzimkkong/dto/NoticeCreateRequestTest.java
@@ -4,7 +4,7 @@ import com.woowacourse.zzimkkong.dto.map.NoticeCreateRequest;
 import org.junit.jupiter.api.Test;
 import org.springframework.context.annotation.Description;
 
-import static com.woowacourse.zzimkkong.dto.ValidatorMessage.DESCRIPTION_MESSAGE;
+import static com.woowacourse.zzimkkong.dto.ValidatorMessage.NOTICE_MESSAGE;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class NoticeCreateRequestTest extends RequestTest {
@@ -15,7 +15,7 @@ class NoticeCreateRequestTest extends RequestTest {
                 "iamtenwordiamtenwordiamtenwordiamtenwordiamtenwordiamtenwordiamtenwordiamtenwordiamtenwordiamtenword1");
 
         assertThat(getConstraintViolations(noticeCreateRequest).stream()
-                .anyMatch(violation -> violation.getMessage().equals(DESCRIPTION_MESSAGE)))
+                .anyMatch(violation -> violation.getMessage().equals(NOTICE_MESSAGE)))
                 .isTrue();
     }
 }


### PR DESCRIPTION
## 구현 기능
- 공지사항 글자수초과 시 나오는 메시지가 예약내용에 사용하던 애로 나오고 있어서 공지사항 관련 메시지 추가 후 수정했습니다.

Close #827 

