### PR TITLE
feat: 슬랙예약알림 메시지에 교육장 정보 추가

### DIFF
--- a/backend/src/main/java/com/woowacourse/zzimkkong/dto/slack/SlackResponse.java
+++ b/backend/src/main/java/com/woowacourse/zzimkkong/dto/slack/SlackResponse.java
@@ -13,6 +13,7 @@ import static com.woowacourse.zzimkkong.infrastructure.datetime.TimeZoneUtils.UT
 @Getter
 @NoArgsConstructor
 public class SlackResponse {
+    private String mapName;
     private String spaceName;
     private String userName;
     private String reservationTime;
@@ -21,6 +22,7 @@ public class SlackResponse {
     private String slackUrl;
 
     private SlackResponse(
+            final String mapName,
             final String spaceName,
             final String userName,
             final LocalDateTime startTime,
@@ -28,6 +30,7 @@ public class SlackResponse {
             final String description,
             final String sharingMapId,
             final String slackUrl) {
+        this.mapName = "교육장명 : " + mapName;
         this.spaceName = "회의실명 : " + spaceName;
         this.userName = "예약자명 : " + userName;
         this.reservationTime = "예약시간 : " + startTime + " ~ " + endTime;
@@ -41,6 +44,7 @@ public class SlackResponse {
         LocalDateTime reservationEndTimeKST = TimeZoneUtils.convert(reservation.getEndTime(), UTC, KST);
 
         return new SlackResponse(
+                reservation.getSpace().getMap().getName(),
                 reservation.getSpace().getName(),
                 reservation.getUserName(),
                 reservationStartTimeKST,

--- a/backend/src/main/java/com/woowacourse/zzimkkong/dto/slack/SlackResponse.java
+++ b/backend/src/main/java/com/woowacourse/zzimkkong/dto/slack/SlackResponse.java
@@ -30,7 +30,7 @@ public class SlackResponse {
             final String description,
             final String sharingMapId,
             final String slackUrl) {
-        this.mapName = "교육장명 : " + mapName;
+        this.mapName = "장소 : " + mapName;
         this.spaceName = "회의실명 : " + spaceName;
         this.userName = "예약자명 : " + userName;
         this.reservationTime = "예약시간 : " + startTime + " ~ " + endTime;

--- a/backend/src/main/java/com/woowacourse/zzimkkong/dto/slack/SlackResponse.java
+++ b/backend/src/main/java/com/woowacourse/zzimkkong/dto/slack/SlackResponse.java
@@ -56,7 +56,8 @@ public class SlackResponse {
 
     @Override
     public String toString() {
-        return spaceName + "\\n " +
+        return mapName + "\\n " +
+                spaceName + "\\n " +
                 userName + "\\n " +
                 reservationTime + "\\n " +
                 description;


### PR DESCRIPTION
## 구현 기능
- 슬랙 예약알림 메시지에 교육장 정보도 같이 보여지도록 추가했습니다.
  - `장소 : 잠실 캠퍼스`

## 의논하고 싶은 내용
- ~~일단은 우테코에서만 슬랙알림을 쓰고 있어서 필드이름을 `교육장명`이라고 하긴 했는데 범용적으로 사용되길 원하시면 맵이름... 뭐 그런걸로 바꿔야 하긴 합니다. 이부분은 의견 주세요1!~~
=> **`장소` 로 결정!**

## 기타
- 귀찮을 줄 알고 계속 미뤘는데 해보니까 생각보다 수정할 게.. 없네요...? 그냥 머지하면 될듯.... 

Close #798 

