### PR TITLE
refactor: 회원 관련 API의 URL을 `/managers`에서 `/members`로 변경

### DIFF
--- a/frontend/src/api/join.ts
+++ b/frontend/src/api/join.ts
@@ -24,11 +24,11 @@ export const queryValidateEmail: QueryFunction = ({ queryKey }) => {
 
   if (typeof email !== 'string') throw new Error(THROW_ERROR.INVALID_EMAIL_FORMAT);
 
-  return api.get(`/managers?email=${email}`);
+  return api.get(`/members?email=${email}`);
 };
 
 export const postJoin = ({ email, password, organization }: JoinParams): Promise<AxiosResponse> => {
-  return api.post('/managers', { email, password, organization });
+  return api.post('/members', { email, password, organization });
 };
 
 export const postSocialJoin = ({
@@ -36,7 +36,7 @@ export const postSocialJoin = ({
   organization,
   oauthProvider,
 }: SocialJoinParams): Promise<AxiosResponse> =>
-  api.post(`/managers/oauth`, {
+  api.post(`/members/oauth`, {
     email,
     organization,
     oauthProvider,

--- a/frontend/src/api/login.ts
+++ b/frontend/src/api/login.ts
@@ -13,11 +13,11 @@ export interface SocialLoginParams {
 }
 
 export const postLogin = (loginData: LoginParams): Promise<AxiosResponse> => {
-  return api.post('/managers/login/token', loginData);
+  return api.post('/members/login/token', loginData);
 };
 
 export const postTokenValidation = (): Promise<AxiosResponse> => {
-  return api.post('/managers/token');
+  return api.post('/members/token');
 };
 
 export const queryGithubLogin: QueryFunction<
@@ -26,7 +26,7 @@ export const queryGithubLogin: QueryFunction<
 > = ({ queryKey }) => {
   const [, { code }] = queryKey;
 
-  return api.get(`/managers/github/login/token?code=${code}`);
+  return api.get(`/members/github/login/token?code=${code}`);
 };
 
 export const queryGoogleLogin: QueryFunction<
@@ -35,5 +35,5 @@ export const queryGoogleLogin: QueryFunction<
 > = ({ queryKey }) => {
   const [, { code }] = queryKey;
 
-  return api.get(`/managers/google/login/token?code=${code}`);
+  return api.get(`/members/google/login/token?code=${code}`);
 };


### PR DESCRIPTION
## 구현 기능
- 회원 관련 API의 URL이 `/managers`에서 `/members`로 변경됨에 따라 변경된 URL로 API 요청을 보내도록 수정했습니다.
