### PR TITLE
feat: 회원가입 시 유저명과 프로필 이모지를 입력받도록 폼 수정

### DIFF
--- a/frontend/src/api/join.ts
+++ b/frontend/src/api/join.ts
@@ -12,9 +12,9 @@ interface JoinParams {
 }
 
 interface SocialJoinParams {
+  emoji: string;
   email: string;
   userName: string;
-  organization: string;
   oauthProvider: 'GITHUB' | 'GOOGLE';
 }
 
@@ -48,17 +48,12 @@ export const postJoin = ({
 };
 
 export const postSocialJoin = ({
+  emoji,
   email,
   userName,
-  organization,
   oauthProvider,
 }: SocialJoinParams): Promise<AxiosResponse> =>
-  api.post(`/members/oauth`, {
-    email,
-    userName,
-    organization,
-    oauthProvider,
-  });
+  api.post(`/members/oauth`, { emoji, email, userName, oauthProvider });
 
 export const getEmojiList: QueryFunction<AxiosResponse<QueryEmojiListSuccess>> = () => {
   return api.get('/members/emojis');

--- a/frontend/src/api/join.ts
+++ b/frontend/src/api/join.ts
@@ -1,13 +1,14 @@
 import { AxiosResponse } from 'axios';
 import { QueryFunction } from 'react-query';
 import THROW_ERROR from 'constants/throwError';
+import { QueryEmojiListSuccess } from 'types/response';
 import api from './api';
 
 interface JoinParams {
+  emoji: string;
   email: string;
   password: string;
   userName: string;
-  organization: string;
 }
 
 interface SocialJoinParams {
@@ -29,13 +30,21 @@ export const queryValidateEmail: QueryFunction = ({ queryKey }) => {
   return api.get(`/members?email=${email}`);
 };
 
+export const queryValidateUserName: QueryFunction = ({ queryKey }) => {
+  const [, userName] = queryKey;
+
+  if (typeof userName !== 'string') throw new Error(THROW_ERROR.INVALID_USER_NAME_FORMAT);
+
+  return api.get(`/members?userName=${userName}`);
+};
+
 export const postJoin = ({
+  emoji,
   email,
   password,
   userName,
-  organization,
 }: JoinParams): Promise<AxiosResponse> => {
-  return api.post('/members', { email, password, userName, organization });
+  return api.post('/members', { emoji, email, password, userName });
 };
 
 export const postSocialJoin = ({
@@ -50,3 +59,7 @@ export const postSocialJoin = ({
     organization,
     oauthProvider,
   });
+
+export const getEmojiList: QueryFunction<AxiosResponse<QueryEmojiListSuccess>> = () => {
+  return api.get('/members/emojis');
+};

--- a/frontend/src/api/join.ts
+++ b/frontend/src/api/join.ts
@@ -27,7 +27,7 @@ export const queryValidateEmail: QueryFunction = ({ queryKey }) => {
 
   if (typeof email !== 'string') throw new Error(THROW_ERROR.INVALID_EMAIL_FORMAT);
 
-  return api.get(`/members?email=${email}`);
+  return api.post(`/members/validations/email`, { email });
 };
 
 export const queryValidateUserName: QueryFunction = ({ queryKey }) => {
@@ -35,7 +35,7 @@ export const queryValidateUserName: QueryFunction = ({ queryKey }) => {
 
   if (typeof userName !== 'string') throw new Error(THROW_ERROR.INVALID_USER_NAME_FORMAT);
 
-  return api.get(`/members?userName=${userName}`);
+  return api.post(`/members/validations/username`, { userName });
 };
 
 export const postJoin = (params: JoinParams): Promise<AxiosResponse> => {

--- a/frontend/src/api/join.ts
+++ b/frontend/src/api/join.ts
@@ -6,11 +6,13 @@ import api from './api';
 interface JoinParams {
   email: string;
   password: string;
+  userName: string;
   organization: string;
 }
 
 interface SocialJoinParams {
   email: string;
+  userName: string;
   organization: string;
   oauthProvider: 'GITHUB' | 'GOOGLE';
 }
@@ -27,17 +29,24 @@ export const queryValidateEmail: QueryFunction = ({ queryKey }) => {
   return api.get(`/members?email=${email}`);
 };
 
-export const postJoin = ({ email, password, organization }: JoinParams): Promise<AxiosResponse> => {
-  return api.post('/members', { email, password, organization });
+export const postJoin = ({
+  email,
+  password,
+  userName,
+  organization,
+}: JoinParams): Promise<AxiosResponse> => {
+  return api.post('/members', { email, password, userName, organization });
 };
 
 export const postSocialJoin = ({
   email,
+  userName,
   organization,
   oauthProvider,
 }: SocialJoinParams): Promise<AxiosResponse> =>
   api.post(`/members/oauth`, {
     email,
+    userName,
     organization,
     oauthProvider,
   });

--- a/frontend/src/api/join.ts
+++ b/frontend/src/api/join.ts
@@ -38,22 +38,12 @@ export const queryValidateUserName: QueryFunction = ({ queryKey }) => {
   return api.get(`/members?userName=${userName}`);
 };
 
-export const postJoin = ({
-  emoji,
-  email,
-  password,
-  userName,
-}: JoinParams): Promise<AxiosResponse> => {
-  return api.post('/members', { emoji, email, password, userName });
+export const postJoin = (params: JoinParams): Promise<AxiosResponse> => {
+  return api.post('/members', params);
 };
 
-export const postSocialJoin = ({
-  emoji,
-  email,
-  userName,
-  oauthProvider,
-}: SocialJoinParams): Promise<AxiosResponse> =>
-  api.post(`/members/oauth`, { emoji, email, userName, oauthProvider });
+export const postSocialJoin = (params: SocialJoinParams): Promise<AxiosResponse> =>
+  api.post(`/members/oauth`, params);
 
 export const getEmojiList: QueryFunction<AxiosResponse<QueryEmojiListSuccess>> = () => {
   return api.get('/members/emojis');

--- a/frontend/src/constants/manager.ts
+++ b/frontend/src/constants/manager.ts
@@ -3,6 +3,9 @@ const MANAGER = {
     MIN_LENGTH: 8,
     MAX_LENGTH: 20,
   },
+  USERNAME: {
+    MIN_LENGTH: 1,
+  },
   ORGANIZATION: {
     MIN_LENGTH: 1,
   },

--- a/frontend/src/constants/manager.ts
+++ b/frontend/src/constants/manager.ts
@@ -5,6 +5,7 @@ const MANAGER = {
   },
   USERNAME: {
     MIN_LENGTH: 1,
+    MAX_LENGTH: 20,
   },
   ORGANIZATION: {
     MIN_LENGTH: 1,

--- a/frontend/src/constants/message.ts
+++ b/frontend/src/constants/message.ts
@@ -7,11 +7,14 @@ const MESSAGE = {
     INVALID_PASSWORD: '영어와 숫자를 포함하여 8~20자로 입력해주세요.',
     VALID_PASSWORD_CONFIRM: '비밀번호가 일치합니다.',
     INVALID_PASSWORD_CONFIRM: '비밀번호가 서로 다릅니다.',
-    VALID_USERNAME: '유효한 이름입니다.',
+    VALID_USERNAME: '사용 가능한 이름입니다.',
     INVALID_USERNAME: '특수문자는 _ . , ! ? 만 허용됩니다.',
     VALID_ORGANIZATION: '유효한 조직명입니다.',
     INVALID_ORGANIZATION: '특수문자는 _ . , ! ? 만 허용됩니다.',
-    UNEXPECTED_ERROR: '이메일 중복 확인에 문제가 발생했습니다. 잠시 후에 다시 시도해주세요.',
+    CHECK_EMAIL_UNEXPECTED_ERROR:
+      '이메일 중복 확인에 문제가 발생했습니다. 잠시 후에 다시 시도해주세요.',
+    CHECK_USERNAME_UNEXPECTED_ERROR:
+      '이름 중복 확인에 문제가 발생했습니다. 잠시 후에 다시 시도해주세요.',
   },
   LOGIN: {
     UNEXPECTED_ERROR: '로그인에 문제가 발생했습니다. 잠시 후에 다시 시도해주세요.',

--- a/frontend/src/constants/message.ts
+++ b/frontend/src/constants/message.ts
@@ -7,6 +7,8 @@ const MESSAGE = {
     INVALID_PASSWORD: '영어와 숫자를 포함하여 8~20자로 입력해주세요.',
     VALID_PASSWORD_CONFIRM: '비밀번호가 일치합니다.',
     INVALID_PASSWORD_CONFIRM: '비밀번호가 서로 다릅니다.',
+    VALID_USERNAME: '유효한 이름입니다.',
+    INVALID_USERNAME: '특수문자는 _ . , ! ? 만 허용됩니다.',
     VALID_ORGANIZATION: '유효한 조직명입니다.',
     INVALID_ORGANIZATION: '특수문자는 _ . , ! ? 만 허용됩니다.',
     UNEXPECTED_ERROR: '이메일 중복 확인에 문제가 발생했습니다. 잠시 후에 다시 시도해주세요.',

--- a/frontend/src/constants/regexp.ts
+++ b/frontend/src/constants/regexp.ts
@@ -1,6 +1,7 @@
 const REGEXP = {
   PASSWORD: /^(?=.*[a-zA-Z])(?=.*[0-9]).{8,20}$/,
   RESERVATION_PASSWORD: /^[0-9]{4}$/,
+  USERNAME: /^[a-zA-Z0-9ㄱ-ㅎ가-힣ㅏ-ㅣ-_!?.,\s]{1,}$/,
   ORGANIZATION: /^[a-zA-Z0-9ㄱ-ㅎ가-힣ㅏ-ㅣ-_!?.,\s]{1,}$/,
 };
 

--- a/frontend/src/constants/throwError.ts
+++ b/frontend/src/constants/throwError.ts
@@ -1,5 +1,6 @@
 const THROW_ERROR = {
   INVALID_EMAIL_FORMAT: '이메일은 "string" 형식이어야 합니다.',
+  INVALID_USER_NAME_FORMAT: '이름은 "string" 형식이어야 합니다.',
   INVALID_MAP_ID: '맵 ID가 올바르지 않습니다. 다시 확인해주세요.',
   NOT_EXIST_CONTEXT: 'context가 존재하지 않습니다.',
   NOT_EXIST_PRESET: '프리셋을 찾을 수 없습니다.',

--- a/frontend/src/hooks/query/useEmojiList.ts
+++ b/frontend/src/hooks/query/useEmojiList.ts
@@ -1,0 +1,14 @@
+import { AxiosError, AxiosResponse } from 'axios';
+import { QueryKey, useQuery, UseQueryOptions, UseQueryResult } from 'react-query';
+import { getEmojiList } from 'api/join';
+import { QueryEmojiListSuccess } from 'types/response';
+
+const useEmojiList = <TData = AxiosResponse<QueryEmojiListSuccess>>(
+  options?: UseQueryOptions<AxiosResponse<QueryEmojiListSuccess>, AxiosError, TData, [QueryKey]>
+): UseQueryResult<TData, AxiosError> =>
+  useQuery(['getEmojiList'], getEmojiList, {
+    ...options,
+    refetchOnWindowFocus: false,
+  });
+
+export default useEmojiList;

--- a/frontend/src/pages/ManagerJoin/ManagerJoin.tsx
+++ b/frontend/src/pages/ManagerJoin/ManagerJoin.tsx
@@ -13,10 +13,10 @@ import * as Styled from './ManagerJoin.styles';
 import JoinForm from './units/JoinForm';
 
 export interface JoinParams {
+  emoji: string;
   email: string;
   password: string;
   userName: string;
-  organization: string;
 }
 
 const ManagerJoin = (): JSX.Element => {
@@ -33,10 +33,10 @@ const ManagerJoin = (): JSX.Element => {
     },
   });
 
-  const handleSubmit = ({ email, password, userName, organization }: JoinParams) => {
-    if (!email || !password || !userName || !organization) return;
+  const handleSubmit = ({ emoji, email, password, userName }: JoinParams) => {
+    if (!emoji || !email || !password || !userName) return;
 
-    join.mutate({ email, password, userName, organization });
+    join.mutate({ emoji, email, password, userName });
   };
 
   return (

--- a/frontend/src/pages/ManagerJoin/ManagerJoin.tsx
+++ b/frontend/src/pages/ManagerJoin/ManagerJoin.tsx
@@ -15,6 +15,7 @@ import JoinForm from './units/JoinForm';
 export interface JoinParams {
   email: string;
   password: string;
+  userName: string;
   organization: string;
 }
 
@@ -32,10 +33,10 @@ const ManagerJoin = (): JSX.Element => {
     },
   });
 
-  const handleSubmit = ({ email, password, organization }: JoinParams) => {
-    if (!email || !password || !organization) return;
+  const handleSubmit = ({ email, password, userName, organization }: JoinParams) => {
+    if (!email || !password || !userName || !organization) return;
 
-    join.mutate({ email, password, organization });
+    join.mutate({ email, password, userName, organization });
   };
 
   return (

--- a/frontend/src/pages/ManagerJoin/units/EmojiSelector.styles.ts
+++ b/frontend/src/pages/ManagerJoin/units/EmojiSelector.styles.ts
@@ -1,0 +1,78 @@
+import styled from 'styled-components';
+
+export const EmojiSelector = styled.div`
+  position: relative;
+  padding: 0.75rem;
+  margin-top: 0.5rem;
+  margin-bottom: 2rem;
+  width: 100%;
+  border-top: 1px solid ${({ theme }) => theme.gray[500]};
+  background: none;
+  outline: none;
+  display: flex;
+  justify-content: center;
+`;
+
+export const LabelText = styled.span`
+  position: absolute;
+  display: inline-block;
+  top: -0.375rem;
+  left: 50%;
+  transform: translateX(-50%);
+  padding: 0 0.25rem;
+  font-size: 0.75rem;
+  background-color: white;
+  color: ${({ theme }) => theme.gray[500]};
+`;
+
+export const EmojiList = styled.div`
+  margin-top: 1rem;
+  font-size: 2.5rem;
+  display: grid;
+  grid-template-rows: repeat(2, 4rem);
+  grid-template-columns: repeat(5, 4rem);
+  gap: 1.25rem;
+
+  @media (max-width: ${({ theme: { breakpoints } }) => breakpoints.sm}px) {
+    font-size: 1.5rem;
+    grid-template-rows: repeat(2, 3rem);
+    grid-template-columns: repeat(5, 3rem);
+    gap: 0.5rem;
+  }
+`;
+
+export const EmojiItem = styled.label`
+  position: relative;
+  margin-bottom: 0;
+  justify-self: center;
+  align-self: center;
+`;
+
+export const EmojiCode = styled.div`
+  cursor: pointer;
+  border-radius: 999px;
+  width: 4rem;
+  height: 4rem;
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  background-color: ${({ theme }) => theme.gray[100]};
+
+  input:checked + & {
+    background-color: ${({ theme }) => theme.primary[400]};
+  }
+
+  @media (max-width: ${({ theme: { breakpoints } }) => breakpoints.sm}px) {
+    width: 3rem;
+    height: 3rem;
+  }
+`;
+
+export const Radio = styled.input`
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 0;
+  height: 0;
+  visibility: hidden;
+`;

--- a/frontend/src/pages/ManagerJoin/units/EmojiSelector.tsx
+++ b/frontend/src/pages/ManagerJoin/units/EmojiSelector.tsx
@@ -1,0 +1,41 @@
+import { useMemo } from 'react';
+import useEmojiList from 'hooks/query/useEmojiList';
+import * as Styled from './EmojiSelector.styles';
+
+interface EmojiSelectorProps {
+  onSelect?: (emoji: string) => void;
+}
+
+const EmojiSelector = ({ onSelect }: EmojiSelectorProps): JSX.Element => {
+  const emojiListQuery = useEmojiList();
+
+  const emojiList = useMemo(
+    () => emojiListQuery.data?.data.emojis ?? [],
+    [emojiListQuery.data?.data.emojis]
+  );
+
+  const handleSelect = (emoji: string) => {
+    onSelect?.(emoji);
+  };
+
+  return (
+    <Styled.EmojiSelector>
+      <Styled.LabelText>프로필 이모지 선택</Styled.LabelText>
+      <Styled.EmojiList>
+        {emojiList.map((emoji) => (
+          <Styled.EmojiItem key={emoji.name}>
+            <Styled.Radio
+              type="radio"
+              name="emoji"
+              id={emoji.name}
+              onChange={() => handleSelect(emoji.name)}
+            />
+            <Styled.EmojiCode>{emoji.code}</Styled.EmojiCode>
+          </Styled.EmojiItem>
+        ))}
+      </Styled.EmojiList>
+    </Styled.EmojiSelector>
+  );
+};
+
+export default EmojiSelector;

--- a/frontend/src/pages/ManagerJoin/units/JoinForm.styles.ts
+++ b/frontend/src/pages/ManagerJoin/units/JoinForm.styles.ts
@@ -2,8 +2,8 @@ import styled from 'styled-components';
 
 export const Form = styled.form`
   margin: 3.75rem 0 1rem;
+`;
 
-  label {
-    margin-bottom: 3rem;
-  }
+export const InputWrapper = styled.div`
+  margin-bottom: 3rem;
 `;

--- a/frontend/src/pages/ManagerJoin/units/JoinForm.tsx
+++ b/frontend/src/pages/ManagerJoin/units/JoinForm.tsx
@@ -49,7 +49,7 @@ const JoinForm = ({ onSubmit }: Props): JSX.Element => {
     },
 
     onError: (error: AxiosError<ErrorResponse>) => {
-      setEmailMessage(error.response?.data.message ?? '');
+      setEmailMessage(error.response?.data.message ?? MESSAGE.JOIN.CHECK_EMAIL_UNEXPECTED_ERROR);
     },
   });
 
@@ -65,7 +65,9 @@ const JoinForm = ({ onSubmit }: Props): JSX.Element => {
       },
 
       onError: (error: AxiosError<ErrorResponse>) => {
-        setUserNameMessage(error.response?.data.message ?? '');
+        setUserNameMessage(
+          error.response?.data.message ?? MESSAGE.JOIN.CHECK_USERNAME_UNEXPECTED_ERROR
+        );
       },
     }
   );

--- a/frontend/src/pages/ManagerJoin/units/JoinForm.tsx
+++ b/frontend/src/pages/ManagerJoin/units/JoinForm.tsx
@@ -16,27 +16,32 @@ interface Form {
   email: string;
   password: string;
   passwordConfirm: string;
+  userName: string;
   organization: string;
 }
 
 interface Props {
-  onSubmit: ({ email, password, organization }: JoinParams) => void;
+  onSubmit: ({ email, password, userName, organization }: JoinParams) => void;
 }
 
 const JoinForm = ({ onSubmit }: Props): JSX.Element => {
-  const [{ email, password, passwordConfirm, organization }, onChangeForm] = useInputs<Form>({
-    email: '',
-    password: '',
-    passwordConfirm: '',
-    organization: '',
-  });
+  const [{ email, password, passwordConfirm, userName, organization }, onChangeForm] =
+    useInputs<Form>({
+      email: '',
+      password: '',
+      passwordConfirm: '',
+      userName: '',
+      organization: '',
+    });
 
   const [emailMessage, setEmailMessage] = useState('');
   const [passwordMessage, setPasswordMessage] = useState('');
   const [passwordConfirmMessage, setPasswordConfirmMessage] = useState('');
+  const [userNameMessage, setUserNameMessage] = useState('');
   const [organizationMessage, setOrganizationMessage] = useState('');
 
   const isValidPassword = REGEXP.PASSWORD.test(password);
+  const isValidUsername = REGEXP.ORGANIZATION.test(userName);
   const isValidOrganization = REGEXP.ORGANIZATION.test(organization);
 
   const checkValidateEmail = useQuery(['checkValidateEmail', email], queryValidateEmail, {
@@ -67,7 +72,7 @@ const JoinForm = ({ onSubmit }: Props): JSX.Element => {
       return;
     }
 
-    onSubmit({ email, password, organization });
+    onSubmit({ email, password, userName, organization });
   };
 
   useEffect(() => {
@@ -87,6 +92,18 @@ const JoinForm = ({ onSubmit }: Props): JSX.Element => {
         : MESSAGE.JOIN.INVALID_PASSWORD_CONFIRM
     );
   }, [password, passwordConfirm]);
+
+  useEffect(() => {
+    if (!userName) {
+      setUserNameMessage('');
+
+      return;
+    }
+
+    setUserNameMessage(
+      isValidUsername ? MESSAGE.JOIN.VALID_USERNAME : MESSAGE.JOIN.INVALID_USERNAME
+    );
+  }, [userName, isValidUsername]);
 
   useEffect(() => {
     if (!organization) {
@@ -136,6 +153,17 @@ const JoinForm = ({ onSubmit }: Props): JSX.Element => {
         onChange={onChangeForm}
         message={passwordConfirmMessage}
         status={password === passwordConfirm ? 'success' : 'error'}
+        required
+      />
+      <Input
+        type="text"
+        label="이름"
+        name="userName"
+        minLength={MANAGER.USERNAME.MIN_LENGTH}
+        value={userName}
+        onChange={onChangeForm}
+        message={userNameMessage}
+        status={isValidUsername ? 'success' : 'error'}
         required
       />
       <Input

--- a/frontend/src/pages/ManagerSocialJoin/ManagerSocialJoin.tsx
+++ b/frontend/src/pages/ManagerSocialJoin/ManagerSocialJoin.tsx
@@ -12,6 +12,7 @@ import SocialJoinForm from './units/SocialJoinForm';
 
 export interface SocialJoinParams {
   email: string;
+  userName: string;
   organization: string;
 }
 
@@ -37,10 +38,10 @@ const ManagerSocialJoin = (): JSX.Element => {
     },
   });
 
-  const handleSubmit = ({ email, organization }: SocialJoinParams) => {
-    if (!email || !organization || !oauthProvider || socialJoin.isLoading) return;
+  const handleSubmit = ({ email, userName, organization }: SocialJoinParams) => {
+    if (!email || !userName || !organization || !oauthProvider || socialJoin.isLoading) return;
 
-    socialJoin.mutate({ email, organization, oauthProvider });
+    socialJoin.mutate({ email, userName, organization, oauthProvider });
   };
 
   if (!email || !oauthProvider) {

--- a/frontend/src/pages/ManagerSocialJoin/ManagerSocialJoin.tsx
+++ b/frontend/src/pages/ManagerSocialJoin/ManagerSocialJoin.tsx
@@ -11,9 +11,9 @@ import * as Styled from './ManagerSocialJoin.styles';
 import SocialJoinForm from './units/SocialJoinForm';
 
 export interface SocialJoinParams {
+  emoji: string;
   email: string;
   userName: string;
-  organization: string;
 }
 
 interface SocialJoinState {
@@ -38,10 +38,10 @@ const ManagerSocialJoin = (): JSX.Element => {
     },
   });
 
-  const handleSubmit = ({ email, userName, organization }: SocialJoinParams) => {
-    if (!email || !userName || !organization || !oauthProvider || socialJoin.isLoading) return;
+  const handleSubmit = ({ emoji, email, userName }: SocialJoinParams) => {
+    if (!emoji || !email || !userName || !oauthProvider || socialJoin.isLoading) return;
 
-    socialJoin.mutate({ email, userName, organization, oauthProvider });
+    socialJoin.mutate({ emoji, email, userName, oauthProvider });
   };
 
   if (!email || !oauthProvider) {

--- a/frontend/src/pages/ManagerSocialJoin/units/SocialJoinForm.styles.ts
+++ b/frontend/src/pages/ManagerSocialJoin/units/SocialJoinForm.styles.ts
@@ -2,8 +2,8 @@ import styled from 'styled-components';
 
 export const Form = styled.form`
   margin: 3.75rem 0 1rem;
+`;
 
-  label {
-    margin-bottom: 3rem;
-  }
+export const InputWrapper = styled.div`
+  margin-bottom: 3rem;
 `;

--- a/frontend/src/pages/ManagerSocialJoin/units/SocialJoinForm.tsx
+++ b/frontend/src/pages/ManagerSocialJoin/units/SocialJoinForm.tsx
@@ -36,7 +36,9 @@ const SocialJoinForm = ({ email, oauthProvider, onSubmit }: Props): JSX.Element 
       },
 
       onError: (error: AxiosError<ErrorResponse>) => {
-        setUserNameMessage(error.response?.data.message ?? '');
+        setUserNameMessage(
+          error.response?.data.message ?? MESSAGE.JOIN.CHECK_USERNAME_UNEXPECTED_ERROR
+        );
       },
     }
   );

--- a/frontend/src/pages/ManagerSocialJoin/units/SocialJoinForm.tsx
+++ b/frontend/src/pages/ManagerSocialJoin/units/SocialJoinForm.tsx
@@ -11,21 +11,36 @@ import * as Styled from './SocialJoinForm.styles';
 interface Props {
   email: string;
   oauthProvider: 'GITHUB' | 'GOOGLE';
-  onSubmit: ({ email, organization }: SocialJoinParams) => void;
+  onSubmit: ({ email, userName, organization }: SocialJoinParams) => void;
 }
 
 const SocialJoinForm = ({ email, oauthProvider, onSubmit }: Props): JSX.Element => {
-  const [organization, onChangeForm] = useInput('');
+  const [userName, onChangeUserName] = useInput('');
+  const [organization, onChangeOrganization] = useInput('');
 
+  const [userNameMessage, setUserNameMessage] = useState('');
   const [organizationMessage, setOrganizationMessage] = useState('');
 
+  const isValidUsername = REGEXP.USERNAME.test(userName);
   const isValidOrganization = REGEXP.ORGANIZATION.test(organization);
 
   const handleSubmit: FormEventHandler<HTMLFormElement> = (event) => {
     event.preventDefault();
 
-    onSubmit({ email, organization });
+    onSubmit({ email, userName, organization });
   };
+
+  useEffect(() => {
+    if (!userName) {
+      setUserNameMessage('');
+
+      return;
+    }
+
+    setUserNameMessage(
+      isValidUsername ? MESSAGE.JOIN.VALID_USERNAME : MESSAGE.JOIN.INVALID_USERNAME
+    );
+  }, [userName, isValidUsername]);
 
   useEffect(() => {
     if (!organization) {
@@ -46,9 +61,21 @@ const SocialJoinForm = ({ email, oauthProvider, onSubmit }: Props): JSX.Element 
         label="이메일"
         name="email"
         value={email}
-        onChange={onChangeForm}
+        onChange={onChangeOrganization}
         required
         disabled
+      />
+      <Input
+        type="text"
+        label="이름"
+        name="userName"
+        minLength={MANAGER.USERNAME.MIN_LENGTH}
+        value={userName}
+        onChange={onChangeUserName}
+        message={userNameMessage}
+        status={isValidUsername ? 'success' : 'error'}
+        required
+        autoFocus
       />
       <Input
         type="text"
@@ -56,7 +83,7 @@ const SocialJoinForm = ({ email, oauthProvider, onSubmit }: Props): JSX.Element 
         name="organization"
         minLength={MANAGER.ORGANIZATION.MIN_LENGTH}
         value={organization}
-        onChange={onChangeForm}
+        onChange={onChangeOrganization}
         message={organizationMessage}
         status={isValidOrganization ? 'success' : 'error'}
         required

--- a/frontend/src/pages/ManagerSocialJoin/units/SocialJoinForm.tsx
+++ b/frontend/src/pages/ManagerSocialJoin/units/SocialJoinForm.tsx
@@ -1,94 +1,91 @@
-import { FormEventHandler, useEffect, useState } from 'react';
+import { AxiosError } from 'axios';
+import { FormEventHandler, useState } from 'react';
+import { useQuery } from 'react-query';
+import { queryValidateUserName } from 'api/join';
 import Input from 'components/Input/Input';
 import SocialJoinButton from 'components/SocialAuthButton/SocialJoinButton';
 import MANAGER from 'constants/manager';
 import MESSAGE from 'constants/message';
-import REGEXP from 'constants/regexp';
 import useInput from 'hooks/useInput';
+import EmojiSelector from 'pages/ManagerJoin/units/EmojiSelector';
+import { ErrorResponse } from 'types/response';
 import { SocialJoinParams } from '../ManagerSocialJoin';
 import * as Styled from './SocialJoinForm.styles';
 
 interface Props {
   email: string;
   oauthProvider: 'GITHUB' | 'GOOGLE';
-  onSubmit: ({ email, userName, organization }: SocialJoinParams) => void;
+  onSubmit: ({ emoji, email, userName }: SocialJoinParams) => void;
 }
 
 const SocialJoinForm = ({ email, oauthProvider, onSubmit }: Props): JSX.Element => {
+  const [emoji, setEmoji] = useState('');
   const [userName, onChangeUserName] = useInput('');
-  const [organization, onChangeOrganization] = useInput('');
 
   const [userNameMessage, setUserNameMessage] = useState('');
-  const [organizationMessage, setOrganizationMessage] = useState('');
 
-  const isValidUsername = REGEXP.USERNAME.test(userName);
-  const isValidOrganization = REGEXP.ORGANIZATION.test(organization);
+  const checkValidateUserName = useQuery(
+    ['checkValidateUserName', userName],
+    queryValidateUserName,
+    {
+      enabled: false,
+      retry: false,
+
+      onSuccess: () => {
+        setUserNameMessage(MESSAGE.JOIN.VALID_USERNAME);
+      },
+
+      onError: (error: AxiosError<ErrorResponse>) => {
+        setUserNameMessage(error.response?.data.message ?? '');
+      },
+    }
+  );
+
+  const handleChangeUserName = (event: React.ChangeEvent<HTMLInputElement>) => {
+    onChangeUserName(event);
+    setUserNameMessage('');
+  };
+
+  const handleValidateUserName = () => {
+    if (!userName) return;
+
+    checkValidateUserName.refetch();
+  };
+
+  const handleSelectEmoji = (emoji: string) => {
+    setEmoji(emoji);
+  };
 
   const handleSubmit: FormEventHandler<HTMLFormElement> = (event) => {
     event.preventDefault();
 
-    onSubmit({ email, userName, organization });
+    if (!emoji || !email || !userName) return;
+
+    onSubmit({ emoji, email, userName });
   };
-
-  useEffect(() => {
-    if (!userName) {
-      setUserNameMessage('');
-
-      return;
-    }
-
-    setUserNameMessage(
-      isValidUsername ? MESSAGE.JOIN.VALID_USERNAME : MESSAGE.JOIN.INVALID_USERNAME
-    );
-  }, [userName, isValidUsername]);
-
-  useEffect(() => {
-    if (!organization) {
-      setOrganizationMessage('');
-
-      return;
-    }
-
-    setOrganizationMessage(
-      isValidOrganization ? MESSAGE.JOIN.VALID_ORGANIZATION : MESSAGE.JOIN.INVALID_ORGANIZATION
-    );
-  }, [organization, isValidOrganization]);
 
   return (
     <Styled.Form onSubmit={handleSubmit}>
-      <Input
-        type="email"
-        label="이메일"
-        name="email"
-        value={email}
-        onChange={onChangeOrganization}
-        required
-        disabled
-      />
-      <Input
-        type="text"
-        label="이름"
-        name="userName"
-        minLength={MANAGER.USERNAME.MIN_LENGTH}
-        value={userName}
-        onChange={onChangeUserName}
-        message={userNameMessage}
-        status={isValidUsername ? 'success' : 'error'}
-        required
-        autoFocus
-      />
-      <Input
-        type="text"
-        label="조직명"
-        name="organization"
-        minLength={MANAGER.ORGANIZATION.MIN_LENGTH}
-        value={organization}
-        onChange={onChangeOrganization}
-        message={organizationMessage}
-        status={isValidOrganization ? 'success' : 'error'}
-        required
-        autoFocus
-      />
+      <EmojiSelector onSelect={handleSelectEmoji} />
+      <Styled.InputWrapper>
+        <Input type="email" label="이메일" name="email" value={email} required disabled />
+      </Styled.InputWrapper>
+      <Styled.InputWrapper>
+        <Input
+          type="text"
+          label="이름"
+          name="userName"
+          minLength={MANAGER.USERNAME.MIN_LENGTH}
+          maxLength={MANAGER.USERNAME.MAX_LENGTH}
+          value={userName}
+          onChange={handleChangeUserName}
+          onBlur={handleValidateUserName}
+          message={userNameMessage}
+          status={checkValidateUserName.isSuccess ? 'success' : 'error'}
+          required
+          autoFocus
+        />
+      </Styled.InputWrapper>
       <SocialJoinButton provider={oauthProvider} />
     </Styled.Form>
   );

--- a/frontend/src/types/common.ts
+++ b/frontend/src/types/common.ts
@@ -176,3 +176,8 @@ export interface EditorBoard {
   y: number;
   scale: number;
 }
+
+export interface Emoji {
+  name: string;
+  code: string;
+}

--- a/frontend/src/types/response.ts
+++ b/frontend/src/types/response.ts
@@ -1,4 +1,12 @@
-import { MapItem, Reservation, Space, SpaceReservation, ManagerSpaceAPI, Preset } from './common';
+import {
+  MapItem,
+  Reservation,
+  Space,
+  SpaceReservation,
+  ManagerSpaceAPI,
+  Preset,
+  Emoji,
+} from './common';
 
 export interface MapItemResponse extends Omit<MapItem, 'mapDrawing'> {
   mapDrawing: string;
@@ -25,6 +33,10 @@ export interface SocialLoginFailure {
 export interface QuerySocialEmailSuccess {
   email: string;
   oauthProvider: 'GITHUB' | 'GOOGLE';
+}
+
+export interface QueryEmojiListSuccess {
+  emojis: Emoji[];
 }
 
 export type QueryGuestMapSuccess = MapItemResponse;


### PR DESCRIPTION
## 구현 기능
- 회원가입 시 유저명과 프로필 이모지를 입력받도록 폼 수정
  - 유저명 입력 후, blur 시 이름 중복을 확인하는 API를 요청합니다.
- OAuth로 회원가입 시 유저명과 프로필 이모지를 입력받도록 폼 수정
<img width="400" alt="스크린샷 2022-12-29 오후 8 54 42" src="https://user-images.githubusercontent.com/2542730/209947582-6872af53-e575-4d62-94ca-459ab21aab02.png">

## 공유하고 싶은 내용
- 로컬 환경에서는 소셜 회원가입 화면을 확인할 수 없어 dev 환경에 배포 이후 동작을 확인해야 합니다. 이에 따라 추가 수정을 위한 PR을 올릴 수 있습니다.

Close #879 

