### PR TITLE
feat: 비회원 예약 조회 API 추가

### DIFF
--- a/backend/src/docs/asciidoc/reservation.adoc
+++ b/backend/src/docs/asciidoc/reservation.adoc
@@ -127,3 +127,12 @@ include::{snippets}/reservation/guest/getAllUpcomingMine/http-response.adoc[]
 include::{snippets}/reservation/guest/getAllPreviousMine/http-request.adoc[]
 ===== Response
 include::{snippets}/reservation/guest/getAllPreviousMine/http-response.adoc[]
+
+=== 비로그인 예약 조회
+==== Request
+include::{snippets}/reservation/guest/getAllUpcomingNonLogin/http-request.adoc[]
+NOTE: request param의 searchStartTime의 format은 다음과 같다: `yyyy-MM-dd'T'HH:mm:ssxxx`
+e.g. "2023-01-30T10:00:00+09:00"
+
+==== Response
+include::{snippets}/reservation/guest/getAllUpcomingNonLogin/http-response.adoc[]

--- a/backend/src/main/java/com/woowacourse/zzimkkong/controller/GuestReservationController.java
+++ b/backend/src/main/java/com/woowacourse/zzimkkong/controller/GuestReservationController.java
@@ -6,6 +6,7 @@ import com.woowacourse.zzimkkong.domain.ReservationType;
 import com.woowacourse.zzimkkong.dto.member.LoginUserEmail;
 import com.woowacourse.zzimkkong.dto.reservation.*;
 import com.woowacourse.zzimkkong.dto.slack.SlackResponse;
+import com.woowacourse.zzimkkong.infrastructure.datetime.TimeZoneUtils;
 import com.woowacourse.zzimkkong.service.ReservationService;
 import com.woowacourse.zzimkkong.service.SlackService;
 import org.springframework.data.domain.Pageable;
@@ -45,7 +46,7 @@ public class GuestReservationController {
             @PageableDefault(sort = {"reservationTime.date"}) final Pageable Pageable) {
         ReservationInfiniteScrollResponse reservationInfiniteScrollResponse = reservationService.findUpcomingNonLoginReservations(
                 userName,
-                searchStartTime.withZoneSameInstant(UTC.toZoneId()).toLocalDateTime(),
+                TimeZoneUtils.convertToUTC(searchStartTime),
                 Pageable);
         return ResponseEntity.ok().body(reservationInfiniteScrollResponse);
     }

--- a/backend/src/main/java/com/woowacourse/zzimkkong/controller/GuestReservationController.java
+++ b/backend/src/main/java/com/woowacourse/zzimkkong/controller/GuestReservationController.java
@@ -43,7 +43,7 @@ public class GuestReservationController {
     public ResponseEntity<ReservationInfiniteScrollResponse> findUpcomingNonLoginReservations(
             @RequestParam final String userName,
             @RequestParam @DateTimeFormat(pattern = DATETIME_FORMAT) final ZonedDateTime searchStartTime,
-            @PageableDefault(sort = {"reservationTime.date"}) final Pageable Pageable) {
+            @PageableDefault(sort = {"reservationTime.startTime"}) final Pageable Pageable) {
         ReservationInfiniteScrollResponse reservationInfiniteScrollResponse = reservationService.findUpcomingNonLoginReservations(
                 userName,
                 TimeZoneUtils.convertToUTC(searchStartTime),
@@ -54,7 +54,7 @@ public class GuestReservationController {
     @GetMapping("/reservations")
     public ResponseEntity<ReservationInfiniteScrollResponse> findUpcomingReservations(
             @LoginEmail final LoginUserEmail loginUserEmail,
-            @PageableDefault(sort = {"reservationTime.date"}) final Pageable Pageable) {
+            @PageableDefault(sort = {"reservationTime.startTime"}) final Pageable Pageable) {
         ReservationInfiniteScrollResponse reservationInfiniteScrollResponse = reservationService.findUpcomingReservations(loginUserEmail, Pageable);
         return ResponseEntity.ok().body(reservationInfiniteScrollResponse);
     }
@@ -62,7 +62,7 @@ public class GuestReservationController {
     @GetMapping("/reservations/history")
     public ResponseEntity<ReservationInfiniteScrollResponse> findPreviousReservations(
             @LoginEmail final LoginUserEmail loginUserEmail,
-            @PageableDefault(sort = {"reservationTime.date"}, direction = Sort.Direction.DESC) final Pageable Pageable) {
+            @PageableDefault(sort = {"reservationTime.endTime"}, direction = Sort.Direction.DESC) final Pageable Pageable) {
         ReservationInfiniteScrollResponse reservationFindPreviousResponse = reservationService.findPreviousReservations(loginUserEmail, Pageable);
         return ResponseEntity.ok().body(reservationFindPreviousResponse);
     }

--- a/backend/src/main/java/com/woowacourse/zzimkkong/controller/GuestReservationController.java
+++ b/backend/src/main/java/com/woowacourse/zzimkkong/controller/GuestReservationController.java
@@ -18,7 +18,9 @@ import org.springframework.web.bind.annotation.*;
 import javax.validation.Valid;
 import java.net.URI;
 import java.time.LocalDate;
+import java.time.ZonedDateTime;
 
+import static com.woowacourse.zzimkkong.dto.ValidatorMessage.DATETIME_FORMAT;
 import static com.woowacourse.zzimkkong.dto.ValidatorMessage.DATE_FORMAT;
 
 @LogMethodExecutionTime(group = "controller")
@@ -33,6 +35,18 @@ public class GuestReservationController {
             final ReservationService reservationService) {
         this.slackService = slackService;
         this.reservationService = reservationService;
+    }
+
+    @GetMapping("/non-login/reservations")
+    public ResponseEntity<ReservationInfiniteScrollResponse> findUpcomingNonLoginReservations(
+            @RequestParam final String userName,
+            @RequestParam @DateTimeFormat(pattern = DATETIME_FORMAT) final ZonedDateTime searchStartTime,
+            @PageableDefault(sort = {"reservationTime.date"}) final Pageable Pageable) {
+        ReservationInfiniteScrollResponse reservationInfiniteScrollResponse = reservationService.findUpcomingNonLoginReservations(
+                userName,
+                searchStartTime.toLocalDateTime(),
+                Pageable);
+        return ResponseEntity.ok().body(reservationInfiniteScrollResponse);
     }
 
     @GetMapping("/reservations")

--- a/backend/src/main/java/com/woowacourse/zzimkkong/controller/GuestReservationController.java
+++ b/backend/src/main/java/com/woowacourse/zzimkkong/controller/GuestReservationController.java
@@ -62,7 +62,7 @@ public class GuestReservationController {
     @GetMapping("/reservations/history")
     public ResponseEntity<ReservationInfiniteScrollResponse> findPreviousReservations(
             @LoginEmail final LoginUserEmail loginUserEmail,
-            @PageableDefault(sort = {"reservationTime.endTime"}, direction = Sort.Direction.DESC) final Pageable Pageable) {
+            @PageableDefault(sort = {"reservationTime.startTime"}, direction = Sort.Direction.DESC) final Pageable Pageable) {
         ReservationInfiniteScrollResponse reservationFindPreviousResponse = reservationService.findPreviousReservations(loginUserEmail, Pageable);
         return ResponseEntity.ok().body(reservationFindPreviousResponse);
     }

--- a/backend/src/main/java/com/woowacourse/zzimkkong/controller/GuestReservationController.java
+++ b/backend/src/main/java/com/woowacourse/zzimkkong/controller/GuestReservationController.java
@@ -22,6 +22,7 @@ import java.time.ZonedDateTime;
 
 import static com.woowacourse.zzimkkong.dto.ValidatorMessage.DATETIME_FORMAT;
 import static com.woowacourse.zzimkkong.dto.ValidatorMessage.DATE_FORMAT;
+import static com.woowacourse.zzimkkong.infrastructure.datetime.TimeZoneUtils.UTC;
 
 @LogMethodExecutionTime(group = "controller")
 @RestController
@@ -44,7 +45,7 @@ public class GuestReservationController {
             @PageableDefault(sort = {"reservationTime.date"}) final Pageable Pageable) {
         ReservationInfiniteScrollResponse reservationInfiniteScrollResponse = reservationService.findUpcomingNonLoginReservations(
                 userName,
-                searchStartTime.toLocalDateTime(),
+                searchStartTime.withZoneSameInstant(UTC.toZoneId()).toLocalDateTime(),
                 Pageable);
         return ResponseEntity.ok().body(reservationInfiniteScrollResponse);
     }

--- a/backend/src/main/java/com/woowacourse/zzimkkong/domain/Reservation.java
+++ b/backend/src/main/java/com/woowacourse/zzimkkong/domain/Reservation.java
@@ -129,7 +129,17 @@ public class Reservation {
         return this.member != null;
     }
 
-    public boolean isNonLoginReservation() {
-        return StringUtils.isBlank(this.password);
+    public Long getMemberId() {
+        if (!hasMember()) {
+            return null;
+        }
+        return this.member.getId();
+    }
+
+    public String getUserName() {
+        if (hasMember()) {
+            return this.member.getUserName();
+        }
+        return this.userName;
     }
 }

--- a/backend/src/main/java/com/woowacourse/zzimkkong/domain/Reservation.java
+++ b/backend/src/main/java/com/woowacourse/zzimkkong/domain/Reservation.java
@@ -3,6 +3,7 @@ package com.woowacourse.zzimkkong.domain;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import net.logstash.logback.encoder.org.apache.commons.lang3.StringUtils;
 
 import javax.persistence.*;
 import java.time.DayOfWeek;
@@ -126,5 +127,9 @@ public class Reservation {
 
     public boolean hasMember() {
         return this.member != null;
+    }
+
+    public boolean isNonLoginReservation() {
+        return StringUtils.isBlank(this.password);
     }
 }

--- a/backend/src/main/java/com/woowacourse/zzimkkong/dto/reservation/ReservationCreateUpdateRequest.java
+++ b/backend/src/main/java/com/woowacourse/zzimkkong/dto/reservation/ReservationCreateUpdateRequest.java
@@ -3,6 +3,7 @@ package com.woowacourse.zzimkkong.dto.reservation;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.woowacourse.zzimkkong.infrastructure.datetime.TimeZoneUtils;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -55,10 +56,10 @@ public class ReservationCreateUpdateRequest {
     }
 
     public LocalDateTime localStartDateTime() {
-        return startDateTime.withZoneSameInstant(UTC.toZoneId()).toLocalDateTime();
+        return TimeZoneUtils.convertToUTC(startDateTime);
     }
 
     public LocalDateTime localEndDateTime() {
-        return endDateTime.withZoneSameInstant(UTC.toZoneId()).toLocalDateTime();
+        return TimeZoneUtils.convertToUTC(endDateTime);
     }
 }

--- a/backend/src/main/java/com/woowacourse/zzimkkong/dto/reservation/ReservationCreateUpdateRequest.java
+++ b/backend/src/main/java/com/woowacourse/zzimkkong/dto/reservation/ReservationCreateUpdateRequest.java
@@ -55,10 +55,10 @@ public class ReservationCreateUpdateRequest {
     }
 
     public LocalDateTime localStartDateTime() {
-        return startDateTime.toLocalDateTime();
+        return startDateTime.withZoneSameInstant(UTC.toZoneId()).toLocalDateTime();
     }
 
     public LocalDateTime localEndDateTime() {
-        return endDateTime.toLocalDateTime();
+        return endDateTime.withZoneSameInstant(UTC.toZoneId()).toLocalDateTime();
     }
 }

--- a/backend/src/main/java/com/woowacourse/zzimkkong/dto/reservation/ReservationOwnerResponse.java
+++ b/backend/src/main/java/com/woowacourse/zzimkkong/dto/reservation/ReservationOwnerResponse.java
@@ -32,7 +32,6 @@ public class ReservationOwnerResponse {
     private String spaceColor;
 
     public static ReservationOwnerResponse from(final Reservation reservation) {
-        Member member = reservation.getMember();
         Space space = reservation.getSpace();
         Map map = space.getMap();
 
@@ -40,8 +39,8 @@ public class ReservationOwnerResponse {
                 .id(reservation.getId())
                 .startDateTime(reservation.getStartTime().atZone(UTC.toZoneId()))
                 .endDateTime(reservation.getEndTime().atZone(UTC.toZoneId()))
-                .memberId(member.getId())
-                .name(member.getUserName())
+                .memberId(reservation.getMemberId())
+                .name(reservation.getUserName())
                 .description(reservation.getDescription())
                 .mapId(map.getId())
                 .sharingMapId(map.getSharingMapId())

--- a/backend/src/main/java/com/woowacourse/zzimkkong/infrastructure/datetime/TimeZoneUtils.java
+++ b/backend/src/main/java/com/woowacourse/zzimkkong/infrastructure/datetime/TimeZoneUtils.java
@@ -4,6 +4,7 @@ import com.woowacourse.zzimkkong.domain.ServiceZone;
 
 import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.TimeZone;
 
 public class TimeZoneUtils {
@@ -13,5 +14,9 @@ public class TimeZoneUtils {
         return dateTime.atZone(UTC.toZoneId())
                 .withZoneSameInstant(ZoneId.of(serviceZone.getTimeZone()))
                 .toLocalDateTime();
+    }
+
+    public static LocalDateTime convertToUTC(final ZonedDateTime zonedDateTime) {
+        return zonedDateTime.withZoneSameInstant(UTC.toZoneId()).toLocalDateTime();
     }
 }

--- a/backend/src/main/java/com/woowacourse/zzimkkong/repository/ReservationRepository.java
+++ b/backend/src/main/java/com/woowacourse/zzimkkong/repository/ReservationRepository.java
@@ -30,7 +30,7 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long>,
             final Collection<Long> spaceIds,
             final LocalDate date);
 
-    Slice<Reservation> findAllByMemberAndReservationTimeDateGreaterThanEqualAndReservationTimeStartTimeGreaterThanEqual(
+    Slice<Reservation> findAllByMemberAndReservationTimeDateGreaterThanEqualAndReservationTimeEndTimeGreaterThanEqual(
             final Member member,
             final LocalDate date,
             final LocalDateTime dateTime,

--- a/backend/src/main/java/com/woowacourse/zzimkkong/repository/ReservationRepository.java
+++ b/backend/src/main/java/com/woowacourse/zzimkkong/repository/ReservationRepository.java
@@ -42,7 +42,7 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long>,
             final LocalDateTime dateTime,
             final Pageable pageable);
 
-    Slice<Reservation> findAllByUserNameAndReservationTimeDateGreaterThanEqualAndReservationTimeStartTimeGreaterThanEqual(
+    Slice<Reservation> findAllByUserNameAndReservationTimeDateGreaterThanEqualAndReservationTimeStartTimeGreaterThanEqualAndMemberIsNull(
             final String userName,
             final LocalDate date,
             final LocalDateTime dateTime,

--- a/backend/src/main/java/com/woowacourse/zzimkkong/repository/ReservationRepository.java
+++ b/backend/src/main/java/com/woowacourse/zzimkkong/repository/ReservationRepository.java
@@ -40,6 +40,11 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long>,
             final LocalDate date,
             final Pageable pageable);
 
+    Slice<Reservation> findAllByUserNameAndReservationTimeDateGreaterThanEqual(
+            final String userName,
+            final LocalDate date,
+            final Pageable pageable);
+
     Boolean existsBySpaceIdAndReservationTimeEndTimeAfter(final Long spaceId, final LocalDateTime now);
 
     @Query(value = "select r from Reservation r inner join fetch r.space s " +

--- a/backend/src/main/java/com/woowacourse/zzimkkong/repository/ReservationRepository.java
+++ b/backend/src/main/java/com/woowacourse/zzimkkong/repository/ReservationRepository.java
@@ -30,19 +30,22 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long>,
             final Collection<Long> spaceIds,
             final LocalDate date);
 
-    Slice<Reservation> findAllByMemberAndReservationTimeDateGreaterThanEqual(
+    Slice<Reservation> findAllByMemberAndReservationTimeDateGreaterThanEqualAndReservationTimeStartTimeGreaterThanEqual(
             final Member member,
             final LocalDate date,
+            final LocalDateTime dateTime,
             final Pageable pageable);
 
-    Slice<Reservation> findAllByMemberAndReservationTimeDateLessThanEqual(
+    Slice<Reservation> findAllByMemberAndReservationTimeDateLessThanEqualAndReservationTimeEndTimeLessThanEqual(
             final Member member,
             final LocalDate date,
+            final LocalDateTime dateTime,
             final Pageable pageable);
 
-    Slice<Reservation> findAllByUserNameAndReservationTimeDateGreaterThanEqual(
+    Slice<Reservation> findAllByUserNameAndReservationTimeDateGreaterThanEqualAndReservationTimeStartTimeGreaterThanEqual(
             final String userName,
             final LocalDate date,
+            final LocalDateTime dateTime,
             final Pageable pageable);
 
     Boolean existsBySpaceIdAndReservationTimeEndTimeAfter(final Long spaceId, final LocalDateTime now);

--- a/backend/src/main/java/com/woowacourse/zzimkkong/service/ReservationService.java
+++ b/backend/src/main/java/com/woowacourse/zzimkkong/service/ReservationService.java
@@ -146,7 +146,6 @@ public class ReservationService {
                 pageable);
         List<Reservation> upcomingReservations = reservationSlice.getContent()
                 .stream()
-                .filter(reservation -> !reservation.isExpired(now))
                 .sorted(Comparator.comparing(Reservation::getStartTime))
                 .peek(reservation -> reservation.getSpace().getMap().activateSharingMapId(sharingIdGenerator))
                 .collect(Collectors.toList());
@@ -168,7 +167,6 @@ public class ReservationService {
 
         List<Reservation> previousReservations = reservationSlice.getContent()
                 .stream()
-                .filter(reservation -> reservation.isExpired(now))
                 .sorted(Comparator.comparing(Reservation::getStartTime).reversed())
                 .peek(reservation -> reservation.getSpace().getMap().activateSharingMapId(sharingIdGenerator))
                 .collect(Collectors.toList());

--- a/backend/src/main/java/com/woowacourse/zzimkkong/service/ReservationService.java
+++ b/backend/src/main/java/com/woowacourse/zzimkkong/service/ReservationService.java
@@ -187,7 +187,7 @@ public class ReservationService {
         List<Reservation> upcomingNonLoginReservations = reservationSlice.getContent()
                 .stream()
                 .filter(reservation -> !reservation.isExpired(searchStartTime))
-                .filter(Reservation::isNonLoginReservation)
+                .filter(reservation -> !reservation.hasMember())
                 .sorted(Comparator.comparing(Reservation::getStartTime))
                 .peek(reservation -> reservation.getSpace().getMap().activateSharingMapId(sharingIdGenerator))
                 .collect(Collectors.toList());

--- a/backend/src/main/java/com/woowacourse/zzimkkong/service/ReservationService.java
+++ b/backend/src/main/java/com/woowacourse/zzimkkong/service/ReservationService.java
@@ -139,9 +139,10 @@ public class ReservationService {
                 .orElseThrow(NoSuchMemberException::new);
 
         LocalDateTime now = LocalDateTime.now();
-        Slice<Reservation> reservationSlice = reservations.findAllByMemberAndReservationTimeDateGreaterThanEqual(
+        Slice<Reservation> reservationSlice = reservations.findAllByMemberAndReservationTimeDateGreaterThanEqualAndReservationTimeStartTimeGreaterThanEqual(
                 member,
                 TimeZoneUtils.convertTo(now, ServiceZone.KOREA).toLocalDate(),
+                now,
                 pageable);
         List<Reservation> upcomingReservations = reservationSlice.getContent()
                 .stream()
@@ -159,9 +160,10 @@ public class ReservationService {
                 .orElseThrow(NoSuchMemberException::new);
 
         LocalDateTime now = LocalDateTime.now();
-        Slice<Reservation> reservationSlice = reservations.findAllByMemberAndReservationTimeDateLessThanEqual(
+        Slice<Reservation> reservationSlice = reservations.findAllByMemberAndReservationTimeDateLessThanEqualAndReservationTimeEndTimeLessThanEqual(
                 member,
                 TimeZoneUtils.convertTo(now, ServiceZone.KOREA).toLocalDate(),
+                now,
                 pageable);
 
         List<Reservation> previousReservations = reservationSlice.getContent()
@@ -179,14 +181,14 @@ public class ReservationService {
             final String userName,
             final LocalDateTime searchStartTime,
             final Pageable pageable) {
-        Slice<Reservation> reservationSlice = reservations.findAllByUserNameAndReservationTimeDateGreaterThanEqual(
+        Slice<Reservation> reservationSlice = reservations.findAllByUserNameAndReservationTimeDateGreaterThanEqualAndReservationTimeStartTimeGreaterThanEqual(
                 userName,
                 TimeZoneUtils.convertTo(searchStartTime, ServiceZone.KOREA).toLocalDate(),
+                searchStartTime,
                 pageable);
 
         List<Reservation> upcomingNonLoginReservations = reservationSlice.getContent()
                 .stream()
-                .filter(reservation -> !reservation.isExpired(searchStartTime))
                 .filter(reservation -> !reservation.hasMember())
                 .sorted(Comparator.comparing(Reservation::getStartTime))
                 .peek(reservation -> reservation.getSpace().getMap().activateSharingMapId(sharingIdGenerator))

--- a/backend/src/main/java/com/woowacourse/zzimkkong/service/ReservationService.java
+++ b/backend/src/main/java/com/woowacourse/zzimkkong/service/ReservationService.java
@@ -179,7 +179,7 @@ public class ReservationService {
             final String userName,
             final LocalDateTime searchStartTime,
             final Pageable pageable) {
-        Slice<Reservation> reservationSlice = reservations.findAllByUserNameAndReservationTimeDateGreaterThanEqualAndReservationTimeStartTimeGreaterThanEqual(
+        Slice<Reservation> reservationSlice = reservations.findAllByUserNameAndReservationTimeDateGreaterThanEqualAndReservationTimeStartTimeGreaterThanEqualAndMemberIsNull(
                 userName,
                 TimeZoneUtils.convertTo(searchStartTime, ServiceZone.KOREA).toLocalDate(),
                 searchStartTime,
@@ -187,7 +187,6 @@ public class ReservationService {
 
         List<Reservation> upcomingNonLoginReservations = reservationSlice.getContent()
                 .stream()
-                .filter(reservation -> !reservation.hasMember())
                 .sorted(Comparator.comparing(Reservation::getStartTime))
                 .peek(reservation -> reservation.getSpace().getMap().activateSharingMapId(sharingIdGenerator))
                 .collect(Collectors.toList());

--- a/backend/src/main/java/com/woowacourse/zzimkkong/service/ReservationService.java
+++ b/backend/src/main/java/com/woowacourse/zzimkkong/service/ReservationService.java
@@ -139,7 +139,7 @@ public class ReservationService {
                 .orElseThrow(NoSuchMemberException::new);
 
         LocalDateTime now = LocalDateTime.now();
-        Slice<Reservation> reservationSlice = reservations.findAllByMemberAndReservationTimeDateGreaterThanEqualAndReservationTimeStartTimeGreaterThanEqual(
+        Slice<Reservation> reservationSlice = reservations.findAllByMemberAndReservationTimeDateGreaterThanEqualAndReservationTimeEndTimeGreaterThanEqual(
                 member,
                 TimeZoneUtils.convertTo(now, ServiceZone.KOREA).toLocalDate(),
                 now,

--- a/backend/src/main/resources/db/migration/prod/V19__add_non_null_member_data.sql
+++ b/backend/src/main/resources/db/migration/prod/V19__add_non_null_member_data.sql
@@ -1,4 +1,11 @@
-UPDATE member SET user_name = (SELECT SUBSTR(REPLACE(UUID(),'-',''), 1, 20));
+UPDATE member SET user_name = CONCAT(
+        SUBSTRING('abcdefghijklmnopqrstuvwxyz', FLOOR(RAND()*26) + 1, 1),
+        SUBSTRING('abcdefghijklmnopqrstuvwxyz', FLOOR(RAND()*26) + 1, 1),
+        SUBSTRING('abcdefghijklmnopqrstuvwxyz', FLOOR(RAND()*26) + 1, 1),
+        SUBSTRING('abcdefghijklmnopqrstuvwxyz', FLOOR(RAND()*26) + 1, 1),
+        SUBSTRING('abcdefghijklmnopqrstuvwxyz', FLOOR(RAND()*26) + 1, 1),
+        SUBSTRING('abcdefghijklmnopqrstuvwxyz', FLOOR(RAND()*26) + 1, 1)
+    );
 UPDATE member SET emoji = 'MAN_MEDIUM_LIGHT_SKIN_TONE_TECHNOLOGIST';
 
 ALTER TABLE member ADD UNIQUE (user_name);

--- a/backend/src/main/resources/db/migration/prod/V21__non_login_reservation.sql
+++ b/backend/src/main/resources/db/migration/prod/V21__non_login_reservation.sql
@@ -1,0 +1,2 @@
+-- indexing
+CREATE INDEX i_username_date on reservation(user_name, date);

--- a/backend/src/test/java/com/woowacourse/zzimkkong/Constants.java
+++ b/backend/src/test/java/com/woowacourse/zzimkkong/Constants.java
@@ -60,7 +60,6 @@ public class Constants {
 
     public static final ZonedDateTime BE_AM_TEN_ELEVEN_START_TIME_KST = THE_DAY_AFTER_TOMORROW.atTime(10, 0).atZone(ZoneId.of(ServiceZone.KOREA.getTimeZone()));
     public static final ZonedDateTime BE_AM_TEN_ELEVEN_END_TIME_KST = THE_DAY_AFTER_TOMORROW.atTime(11, 0).atZone(ZoneId.of(ServiceZone.KOREA.getTimeZone()));
-
     public static final String BE_AM_TEN_ELEVEN_DESCRIPTION = DESCRIPTION;
     public static final String BE_AM_TEN_ELEVEN_USERNAME = RESERVATION_USER_NAME;
     public static final String BE_AM_TEN_ELEVEN_PW = RESERVATION_PW;

--- a/backend/src/test/java/com/woowacourse/zzimkkong/controller/GuestReservationControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/zzimkkong/controller/GuestReservationControllerTest.java
@@ -3,6 +3,7 @@ package com.woowacourse.zzimkkong.controller;
 import com.woowacourse.zzimkkong.domain.*;
 import com.woowacourse.zzimkkong.dto.reservation.*;
 import com.woowacourse.zzimkkong.infrastructure.auth.AuthorizationExtractor;
+import com.woowacourse.zzimkkong.infrastructure.datetime.TimeZoneUtils;
 import com.woowacourse.zzimkkong.infrastructure.sharingid.SharingIdGenerator;
 import com.woowacourse.zzimkkong.service.SlackService;
 import io.restassured.RestAssured;
@@ -577,8 +578,8 @@ class GuestReservationControllerTest extends AcceptanceTest {
                 .id(getNonLoginReservationIdAfterSave(beReservationApi, beAmZeroOneRequest))
                 .reservationTime(
                         ReservationTime.ofDefaultServiceZone(
-                                BE_AM_TEN_ELEVEN_START_TIME_KST.withZoneSameInstant(UTC.toZoneId()).toLocalDateTime(),
-                                BE_AM_TEN_ELEVEN_END_TIME_KST.withZoneSameInstant(UTC.toZoneId()).toLocalDateTime()))
+                                TimeZoneUtils.convertToUTC(BE_AM_TEN_ELEVEN_START_TIME_KST),
+                                TimeZoneUtils.convertToUTC(BE_AM_TEN_ELEVEN_END_TIME_KST)))
                 .description(BE_AM_TEN_ELEVEN_DESCRIPTION)
                 .userName(BE_AM_TEN_ELEVEN_USERNAME)
                 .password(BE_AM_TEN_ELEVEN_PW)
@@ -589,8 +590,8 @@ class GuestReservationControllerTest extends AcceptanceTest {
                 .id(getNonLoginReservationIdAfterSave(beReservationApi, bePmOneTwoRequest))
                 .reservationTime(
                         ReservationTime.ofDefaultServiceZone(
-                                BE_PM_ONE_TWO_START_TIME_KST.withZoneSameInstant(UTC.toZoneId()).toLocalDateTime(),
-                                BE_PM_ONE_TWO_END_TIME_KST.withZoneSameInstant(UTC.toZoneId()).toLocalDateTime()))
+                                TimeZoneUtils.convertToUTC(BE_PM_ONE_TWO_START_TIME_KST),
+                                TimeZoneUtils.convertToUTC(BE_PM_ONE_TWO_END_TIME_KST)))
                 .description(BE_PM_ONE_TWO_DESCRIPTION)
                 .userName(BE_PM_ONE_TWO_USERNAME)
                 .password(BE_PM_ONE_TWO_PW)
@@ -601,8 +602,8 @@ class GuestReservationControllerTest extends AcceptanceTest {
                 .id(getNonLoginReservationIdAfterSave(beReservationApi, beNextDayAmSixTwelveRequest))
                 .reservationTime(
                         ReservationTime.ofDefaultServiceZone(
-                                BE_NEXT_DAY_PM_FOUR_TO_SIX_START_TIME_KST.withZoneSameInstant(UTC.toZoneId()).toLocalDateTime(),
-                                BE_NEXT_DAY_PM_FOUR_TO_SIX_END_TIME_KST.withZoneSameInstant(UTC.toZoneId()).toLocalDateTime()))
+                                TimeZoneUtils.convertToUTC(BE_NEXT_DAY_PM_FOUR_TO_SIX_START_TIME_KST),
+                                TimeZoneUtils.convertToUTC(BE_NEXT_DAY_PM_FOUR_TO_SIX_END_TIME_KST)))
                 .description(BE_NEXT_DAY_PM_FOUR_TO_SIX_DESCRIPTION)
                 .userName(BE_NEXT_DAY_PM_FOUR_TO_SIX_USERNAME)
                 .password(BE_NEXT_DAY_PM_FOUR_TO_SIX_PW)
@@ -613,8 +614,8 @@ class GuestReservationControllerTest extends AcceptanceTest {
                 .id(getNonLoginReservationIdAfterSave(fe1ReservationApi, feZeroOneRequest))
                 .reservationTime(
                         ReservationTime.ofDefaultServiceZone(
-                                FE1_AM_TEN_ELEVEN_START_TIME_KST.withZoneSameInstant(UTC.toZoneId()).toLocalDateTime(),
-                                FE1_AM_TEN_ELEVEN_END_TIME_KST.withZoneSameInstant(UTC.toZoneId()).toLocalDateTime()))
+                                TimeZoneUtils.convertToUTC(FE1_AM_TEN_ELEVEN_START_TIME_KST),
+                                TimeZoneUtils.convertToUTC(FE1_AM_TEN_ELEVEN_END_TIME_KST)))
                 .description(FE1_AM_TEN_ELEVEN_DESCRIPTION)
                 .userName(FE1_AM_TEN_ELEVEN_USERNAME)
                 .password(FE1_AM_TEN_ELEVEN_PW)
@@ -625,8 +626,8 @@ class GuestReservationControllerTest extends AcceptanceTest {
                 .id(getLoginReservationIdAfterSave(beReservationApi, bePmTwoThreeRequestPobi))
                 .reservationTime(
                         ReservationTime.ofDefaultServiceZone(
-                                BE_PM_TWO_THREE_START_TIME_KST.withZoneSameInstant(UTC.toZoneId()).toLocalDateTime(),
-                                BE_PM_TWO_THREE_END_TIME_KST.withZoneSameInstant(UTC.toZoneId()).toLocalDateTime()))
+                                TimeZoneUtils.convertToUTC(BE_PM_TWO_THREE_START_TIME_KST),
+                                TimeZoneUtils.convertToUTC(BE_PM_TWO_THREE_END_TIME_KST)))
                 .description(BE_PM_TWO_THREE_DESCRIPTION)
                 .member(pobi)
                 .userName(pobi.getUserName())
@@ -637,8 +638,8 @@ class GuestReservationControllerTest extends AcceptanceTest {
                 .id(getLoginReservationIdAfterSave(fe1ReservationApi, fe1PmTwoThreeRequestPobi))
                 .reservationTime(
                         ReservationTime.ofDefaultServiceZone(
-                                FE1_PM_TWO_THREE_START_TIME_KST.withZoneSameInstant(UTC.toZoneId()).toLocalDateTime(),
-                                FE1_PM_TWO_THREE_END_TIME_KST.withZoneSameInstant(UTC.toZoneId()).toLocalDateTime()))
+                                TimeZoneUtils.convertToUTC(FE1_PM_TWO_THREE_START_TIME_KST),
+                                TimeZoneUtils.convertToUTC(FE1_PM_TWO_THREE_END_TIME_KST)))
                 .description(FE1_PM_TWO_THREE_DESCRIPTION)
                 .member(pobi)
                 .userName(pobi.getUserName())
@@ -649,8 +650,8 @@ class GuestReservationControllerTest extends AcceptanceTest {
                 .id(getLoginReservationIdAfterSave(beReservationApi.replaceAll("guests", "managers"), beFiveDaysAgoPmTwoThreeRequestPobi))
                 .reservationTime(
                         ReservationTime.ofDefaultServiceZone(
-                                BE_FIVE_DAYS_AGO_PM_TWO_THREE_START_TIME_KST.withZoneSameInstant(UTC.toZoneId()).toLocalDateTime(),
-                                BE_FIVE_DAYS_AGO_PM_TWO_THREE_END_TIME_KST.withZoneSameInstant(UTC.toZoneId()).toLocalDateTime()))
+                                TimeZoneUtils.convertToUTC(BE_FIVE_DAYS_AGO_PM_TWO_THREE_START_TIME_KST),
+                                TimeZoneUtils.convertToUTC(BE_FIVE_DAYS_AGO_PM_TWO_THREE_END_TIME_KST)))
                 .description(BE_FIVE_DAYS_AGO_PM_TWO_THREE_DESCRIPTION)
                 .member(pobi)
                 .userName(pobi.getUserName())

--- a/backend/src/test/java/com/woowacourse/zzimkkong/controller/ManagerReservationControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/zzimkkong/controller/ManagerReservationControllerTest.java
@@ -3,6 +3,7 @@ package com.woowacourse.zzimkkong.controller;
 import com.woowacourse.zzimkkong.domain.*;
 import com.woowacourse.zzimkkong.dto.reservation.*;
 import com.woowacourse.zzimkkong.infrastructure.auth.AuthorizationExtractor;
+import com.woowacourse.zzimkkong.infrastructure.datetime.TimeZoneUtils;
 import com.woowacourse.zzimkkong.service.SlackService;
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
@@ -482,8 +483,8 @@ class ManagerReservationControllerTest extends AcceptanceTest {
                 .id(getReservationIdAfterSave(beReservationApi, beAmZeroOneRequest))
                 .reservationTime(
                         ReservationTime.ofDefaultServiceZone(
-                                BE_AM_TEN_ELEVEN_START_TIME_KST.withZoneSameInstant(UTC.toZoneId()).toLocalDateTime(),
-                                BE_AM_TEN_ELEVEN_END_TIME_KST.withZoneSameInstant(UTC.toZoneId()).toLocalDateTime()))
+                                TimeZoneUtils.convertToUTC(BE_AM_TEN_ELEVEN_START_TIME_KST),
+                                TimeZoneUtils.convertToUTC(BE_AM_TEN_ELEVEN_END_TIME_KST)))
                 .description(BE_AM_TEN_ELEVEN_DESCRIPTION)
                 .userName(BE_AM_TEN_ELEVEN_USERNAME)
                 .password(BE_AM_TEN_ELEVEN_PW)
@@ -494,8 +495,8 @@ class ManagerReservationControllerTest extends AcceptanceTest {
                 .id(getReservationIdAfterSave(beReservationApi, bePmOneTwoRequest))
                 .reservationTime(
                         ReservationTime.ofDefaultServiceZone(
-                                BE_PM_ONE_TWO_START_TIME_KST.withZoneSameInstant(UTC.toZoneId()).toLocalDateTime(),
-                                BE_PM_ONE_TWO_END_TIME_KST.withZoneSameInstant(UTC.toZoneId()).toLocalDateTime()))
+                                TimeZoneUtils.convertToUTC(BE_PM_ONE_TWO_START_TIME_KST),
+                                TimeZoneUtils.convertToUTC(BE_PM_ONE_TWO_END_TIME_KST)))
                 .description(BE_PM_ONE_TWO_DESCRIPTION)
                 .userName(BE_PM_ONE_TWO_USERNAME)
                 .password(BE_PM_ONE_TWO_PW)
@@ -508,8 +509,8 @@ class ManagerReservationControllerTest extends AcceptanceTest {
                 .id(getReservationIdAfterSave(fe1ReservationApi, feZeroOneRequest))
                 .reservationTime(
                         ReservationTime.ofDefaultServiceZone(
-                                FE1_AM_TEN_ELEVEN_START_TIME_KST.withZoneSameInstant(UTC.toZoneId()).toLocalDateTime(),
-                                FE1_AM_TEN_ELEVEN_END_TIME_KST.withZoneSameInstant(UTC.toZoneId()).toLocalDateTime()))
+                                TimeZoneUtils.convertToUTC(FE1_AM_TEN_ELEVEN_START_TIME_KST),
+                                TimeZoneUtils.convertToUTC(FE1_AM_TEN_ELEVEN_END_TIME_KST)))
                 .description(FE1_AM_TEN_ELEVEN_DESCRIPTION)
                 .userName(FE1_AM_TEN_ELEVEN_USERNAME)
                 .password(FE1_AM_TEN_ELEVEN_PW)
@@ -520,8 +521,8 @@ class ManagerReservationControllerTest extends AcceptanceTest {
                 .id(getReservationIdAfterSave(beReservationApi, bePmTwoThreeRequestPobi))
                 .reservationTime(
                         ReservationTime.ofDefaultServiceZone(
-                                BE_PM_TWO_THREE_START_TIME_KST.withZoneSameInstant(UTC.toZoneId()).toLocalDateTime(),
-                                BE_PM_TWO_THREE_END_TIME_KST.withZoneSameInstant(UTC.toZoneId()).toLocalDateTime()))
+                                TimeZoneUtils.convertToUTC(BE_PM_TWO_THREE_START_TIME_KST),
+                                TimeZoneUtils.convertToUTC(BE_PM_TWO_THREE_END_TIME_KST)))
                 .description(BE_PM_TWO_THREE_DESCRIPTION)
                 .member(pobi)
                 .userName(pobi.getUserName())
@@ -532,8 +533,8 @@ class ManagerReservationControllerTest extends AcceptanceTest {
                 .id(getReservationIdAfterSave(fe1ReservationApi, fe1PmTwoThreeRequestPobi))
                 .reservationTime(
                         ReservationTime.ofDefaultServiceZone(
-                                FE1_PM_TWO_THREE_START_TIME_KST.withZoneSameInstant(UTC.toZoneId()).toLocalDateTime(),
-                                FE1_PM_TWO_THREE_END_TIME_KST.withZoneSameInstant(UTC.toZoneId()).toLocalDateTime()))
+                                TimeZoneUtils.convertToUTC(FE1_PM_TWO_THREE_START_TIME_KST),
+                                TimeZoneUtils.convertToUTC(FE1_PM_TWO_THREE_END_TIME_KST)))
                 .description(FE1_PM_TWO_THREE_DESCRIPTION)
                 .member(pobi)
                 .userName(pobi.getUserName())
@@ -544,8 +545,8 @@ class ManagerReservationControllerTest extends AcceptanceTest {
                 .id(getReservationIdAfterSave(beReservationApi, beFiveDaysAgoPmTwoThreeRequestPobi))
                 .reservationTime(
                         ReservationTime.ofDefaultServiceZone(
-                                BE_FIVE_DAYS_AGO_PM_TWO_THREE_START_TIME_KST.withZoneSameInstant(UTC.toZoneId()).toLocalDateTime(),
-                                BE_FIVE_DAYS_AGO_PM_TWO_THREE_END_TIME_KST.withZoneSameInstant(UTC.toZoneId()).toLocalDateTime()))
+                                TimeZoneUtils.convertToUTC(BE_FIVE_DAYS_AGO_PM_TWO_THREE_START_TIME_KST),
+                                TimeZoneUtils.convertToUTC(BE_FIVE_DAYS_AGO_PM_TWO_THREE_END_TIME_KST)))
                 .description(BE_FIVE_DAYS_AGO_PM_TWO_THREE_DESCRIPTION)
                 .member(pobi)
                 .userName(pobi.getUserName())

--- a/backend/src/test/java/com/woowacourse/zzimkkong/repository/ReservationRepositoryImplTest.java
+++ b/backend/src/test/java/com/woowacourse/zzimkkong/repository/ReservationRepositoryImplTest.java
@@ -1,6 +1,7 @@
 package com.woowacourse.zzimkkong.repository;
 
 import com.woowacourse.zzimkkong.domain.*;
+import com.woowacourse.zzimkkong.infrastructure.datetime.TimeZoneUtils;
 import org.assertj.core.api.AssertionsForClassTypes;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -67,8 +68,8 @@ class ReservationRepositoryImplTest extends RepositoryTest {
             Reservation beAmZeroOne = Reservation.builder()
                     .reservationTime(
                             ReservationTime.ofDefaultServiceZone(
-                                    BE_AM_TEN_ELEVEN_START_TIME_KST.withZoneSameInstant(UTC.toZoneId()).toLocalDateTime(),
-                                    BE_AM_TEN_ELEVEN_END_TIME_KST.withZoneSameInstant(UTC.toZoneId()).toLocalDateTime()))
+                                    TimeZoneUtils.convertToUTC(BE_AM_TEN_ELEVEN_START_TIME_KST),
+                                    TimeZoneUtils.convertToUTC(BE_AM_TEN_ELEVEN_END_TIME_KST)))
                     .description(BE_AM_TEN_ELEVEN_DESCRIPTION)
                     .userName(BE_AM_TEN_ELEVEN_USERNAME)
                     .password(BE_AM_TEN_ELEVEN_PW)

--- a/backend/src/test/java/com/woowacourse/zzimkkong/repository/ReservationRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/zzimkkong/repository/ReservationRepositoryTest.java
@@ -269,7 +269,7 @@ class ReservationRepositoryTest extends RepositoryTest {
     @DisplayName("로그인한 예약자의 특정 시간 이후 (Inclusive) 예약 내역을 조회한다")
     void findAllByMemberAndReservationTimeDateGreaterThanEqualAndReservationTimeStartTimeGreaterThanEqual() {
         PageRequest pageRequest = PageRequest.of(0, 10, Sort.by("reservationTime.startTime"));
-        Slice<Reservation> actual = reservations.findAllByMemberAndReservationTimeDateGreaterThanEqualAndReservationTimeStartTimeGreaterThanEqual(
+        Slice<Reservation> actual = reservations.findAllByMemberAndReservationTimeDateGreaterThanEqualAndReservationTimeEndTimeGreaterThanEqual(
                 pobi,
                 THE_DAY_AFTER_TOMORROW,
                 TimeZoneUtils.convertToUTC(BE_PM_TWO_THREE_START_TIME_KST),

--- a/backend/src/test/java/com/woowacourse/zzimkkong/repository/ReservationRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/zzimkkong/repository/ReservationRepositoryTest.java
@@ -17,7 +17,6 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 import static com.woowacourse.zzimkkong.Constants.*;
-import static com.woowacourse.zzimkkong.infrastructure.datetime.TimeZoneUtils.UTC;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
@@ -267,10 +266,14 @@ class ReservationRepositoryTest extends RepositoryTest {
     }
 
     @Test
-    @DisplayName("로그인한 예약자의 특정 날짜 이후 (Inclusive) 예약 내역을 조회한다")
-    void findAllByMemberAndReservationTimeDateGreaterThanEqual() {
-        PageRequest pageRequest = PageRequest.of(0, 10, Sort.by("reservationTime.date"));
-        Slice<Reservation> actual = reservations.findAllByMemberAndReservationTimeDateGreaterThanEqual(pobi, THE_DAY_AFTER_TOMORROW, pageRequest);
+    @DisplayName("로그인한 예약자의 특정 시간 이후 (Inclusive) 예약 내역을 조회한다")
+    void findAllByMemberAndReservationTimeDateGreaterThanEqualAndReservationTimeStartTimeGreaterThanEqual() {
+        PageRequest pageRequest = PageRequest.of(0, 10, Sort.by("reservationTime.startTime"));
+        Slice<Reservation> actual = reservations.findAllByMemberAndReservationTimeDateGreaterThanEqualAndReservationTimeStartTimeGreaterThanEqual(
+                pobi,
+                THE_DAY_AFTER_TOMORROW,
+                TimeZoneUtils.convertToUTC(BE_PM_TWO_THREE_START_TIME_KST),
+                pageRequest);
 
         List<Reservation> expectedContent = List.of(bePmTwoThreeByPobi);
         assertThat(actual.getContent()).isEqualTo(expectedContent);
@@ -279,10 +282,13 @@ class ReservationRepositoryTest extends RepositoryTest {
     @Test
     @DisplayName("로그인한 예약자의 특정 날짜 이전 (Inclusive) 예약 내역을 조회한다")
     void findAllByMemberAndReservationTimeDateLessThanEqual() {
-        PageRequest pageRequest = PageRequest.of(0, 10, Sort.by("reservationTime.date"));
-        Slice<Reservation> actual = reservations.findAllByMemberAndReservationTimeDateLessThanEqual(pobi, THE_DAY_AFTER_TOMORROW, pageRequest);
+        PageRequest pageRequest = PageRequest.of(0, 10, Sort.by("reservationTime.endTime").descending());
+        Slice<Reservation> actual = reservations.findAllByMemberAndReservationTimeDateLessThanEqualAndReservationTimeEndTimeLessThanEqual(
+                pobi,
+                THE_DAY_AFTER_TOMORROW,
+                TimeZoneUtils.convertToUTC(BE_PM_TWO_THREE_END_TIME_KST),
+                pageRequest);
 
-        List<Reservation> expectedContent = List.of(bePmTwoThreeByPobi, beFiveDaysAgoPmTwoThreeByPobi);
-        assertThat(actual.getContent()).containsExactlyInAnyOrderElementsOf(expectedContent);
+        assertThat(actual.getContent()).containsExactly(bePmTwoThreeByPobi, beFiveDaysAgoPmTwoThreeByPobi);
     }
 }

--- a/backend/src/test/java/com/woowacourse/zzimkkong/repository/ReservationRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/zzimkkong/repository/ReservationRepositoryTest.java
@@ -1,6 +1,7 @@
 package com.woowacourse.zzimkkong.repository;
 
 import com.woowacourse.zzimkkong.domain.*;
+import com.woowacourse.zzimkkong.infrastructure.datetime.TimeZoneUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -90,8 +91,8 @@ class ReservationRepositoryTest extends RepositoryTest {
         beAmZeroOne = Reservation.builder()
                 .reservationTime(
                         ReservationTime.ofDefaultServiceZone(
-                                BE_AM_TEN_ELEVEN_START_TIME_KST.withZoneSameInstant(UTC.toZoneId()).toLocalDateTime(),
-                                BE_AM_TEN_ELEVEN_END_TIME_KST.withZoneSameInstant(UTC.toZoneId()).toLocalDateTime()))
+                                TimeZoneUtils.convertToUTC(BE_AM_TEN_ELEVEN_START_TIME_KST),
+                                TimeZoneUtils.convertToUTC(BE_AM_TEN_ELEVEN_END_TIME_KST)))
                 .description(BE_AM_TEN_ELEVEN_DESCRIPTION)
                 .userName(BE_AM_TEN_ELEVEN_USERNAME)
                 .password(BE_AM_TEN_ELEVEN_PW)
@@ -101,8 +102,8 @@ class ReservationRepositoryTest extends RepositoryTest {
         bePmOneTwo = Reservation.builder()
                 .reservationTime(
                         ReservationTime.ofDefaultServiceZone(
-                                BE_PM_ONE_TWO_START_TIME_KST.withZoneSameInstant(UTC.toZoneId()).toLocalDateTime(),
-                                BE_PM_ONE_TWO_END_TIME_KST.withZoneSameInstant(UTC.toZoneId()).toLocalDateTime()))
+                                TimeZoneUtils.convertToUTC(BE_PM_ONE_TWO_START_TIME_KST),
+                                TimeZoneUtils.convertToUTC(BE_PM_ONE_TWO_END_TIME_KST)))
                 .description(BE_PM_ONE_TWO_DESCRIPTION)
                 .userName(BE_PM_ONE_TWO_USERNAME)
                 .password(BE_PM_ONE_TWO_PW)
@@ -112,8 +113,8 @@ class ReservationRepositoryTest extends RepositoryTest {
         beNextDayAmSixTwelve = Reservation.builder()
                 .reservationTime(
                         ReservationTime.ofDefaultServiceZone(
-                                BE_NEXT_DAY_PM_FOUR_TO_SIX_START_TIME_KST.withZoneSameInstant(UTC.toZoneId()).toLocalDateTime(),
-                                BE_NEXT_DAY_PM_FOUR_TO_SIX_END_TIME_KST.withZoneSameInstant(UTC.toZoneId()).toLocalDateTime()))
+                                TimeZoneUtils.convertToUTC(BE_NEXT_DAY_PM_FOUR_TO_SIX_START_TIME_KST),
+                                TimeZoneUtils.convertToUTC(BE_NEXT_DAY_PM_FOUR_TO_SIX_END_TIME_KST)))
                 .description(BE_NEXT_DAY_PM_FOUR_TO_SIX_DESCRIPTION)
                 .userName(BE_NEXT_DAY_PM_FOUR_TO_SIX_USERNAME)
                 .password(BE_NEXT_DAY_PM_FOUR_TO_SIX_PW)
@@ -123,8 +124,8 @@ class ReservationRepositoryTest extends RepositoryTest {
         fe1ZeroOne = Reservation.builder()
                 .reservationTime(
                         ReservationTime.ofDefaultServiceZone(
-                                FE1_AM_TEN_ELEVEN_START_TIME_KST.withZoneSameInstant(UTC.toZoneId()).toLocalDateTime(),
-                                FE1_AM_TEN_ELEVEN_END_TIME_KST.withZoneSameInstant(UTC.toZoneId()).toLocalDateTime()))
+                                TimeZoneUtils.convertToUTC(FE1_AM_TEN_ELEVEN_START_TIME_KST),
+                                TimeZoneUtils.convertToUTC(FE1_AM_TEN_ELEVEN_END_TIME_KST)))
                 .description(FE1_AM_TEN_ELEVEN_DESCRIPTION)
                 .userName(FE1_AM_TEN_ELEVEN_USERNAME)
                 .password(FE1_AM_TEN_ELEVEN_PW)
@@ -134,8 +135,8 @@ class ReservationRepositoryTest extends RepositoryTest {
         bePmTwoThreeByPobi = Reservation.builder()
                 .reservationTime(
                         ReservationTime.ofDefaultServiceZone(
-                                BE_PM_TWO_THREE_START_TIME_KST.withZoneSameInstant(UTC.toZoneId()).toLocalDateTime(),
-                                BE_PM_TWO_THREE_END_TIME_KST.withZoneSameInstant(UTC.toZoneId()).toLocalDateTime()))
+                                TimeZoneUtils.convertToUTC(BE_PM_TWO_THREE_START_TIME_KST),
+                                TimeZoneUtils.convertToUTC(BE_PM_TWO_THREE_END_TIME_KST)))
                 .description(BE_PM_TWO_THREE_DESCRIPTION)
                 .userName(pobi.getUserName())
                 .member(pobi)
@@ -145,8 +146,8 @@ class ReservationRepositoryTest extends RepositoryTest {
         beFiveDaysAgoPmTwoThreeByPobi = Reservation.builder()
                 .reservationTime(
                         ReservationTime.ofDefaultServiceZone(
-                                BE_FIVE_DAYS_AGO_PM_TWO_THREE_START_TIME_KST.withZoneSameInstant(UTC.toZoneId()).toLocalDateTime(),
-                                BE_FIVE_DAYS_AGO_PM_TWO_THREE_END_TIME_KST.withZoneSameInstant(UTC.toZoneId()).toLocalDateTime()))
+                                TimeZoneUtils.convertToUTC(BE_FIVE_DAYS_AGO_PM_TWO_THREE_START_TIME_KST),
+                                TimeZoneUtils.convertToUTC(BE_FIVE_DAYS_AGO_PM_TWO_THREE_END_TIME_KST)))
                 .description(BE_FIVE_DAYS_AGO_PM_TWO_THREE_DESCRIPTION)
                 .userName(pobi.getUserName())
                 .member(pobi)
@@ -238,7 +239,7 @@ class ReservationRepositoryTest extends RepositoryTest {
         //given, when
         Boolean actual = reservations.existsBySpaceIdAndReservationTimeEndTimeAfter(
                 be.getId(),
-                BE_NEXT_DAY_PM_FOUR_TO_SIX_END_TIME_KST.withZoneSameInstant(UTC.toZoneId()).toLocalDateTime().minusMinutes(minusMinute));
+                TimeZoneUtils.convertToUTC(BE_NEXT_DAY_PM_FOUR_TO_SIX_END_TIME_KST).minusMinutes(minusMinute));
 
         //then
         assertThat(actual).isEqualTo(expected);

--- a/backend/src/test/java/com/woowacourse/zzimkkong/service/AdminServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/zzimkkong/service/AdminServiceTest.java
@@ -8,6 +8,7 @@ import com.woowacourse.zzimkkong.dto.member.TokenResponse;
 import com.woowacourse.zzimkkong.dto.reservation.ReservationResponse;
 import com.woowacourse.zzimkkong.dto.space.SpaceFindDetailWithIdResponse;
 import com.woowacourse.zzimkkong.exception.member.IdPasswordMismatchException;
+import com.woowacourse.zzimkkong.infrastructure.datetime.TimeZoneUtils;
 import com.woowacourse.zzimkkong.infrastructure.sharingid.SharingIdGenerator;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -177,8 +178,8 @@ class AdminServiceTest extends ServiceTest {
         Reservation beAmZeroOne = Reservation.builder()
                 .reservationTime(
                         ReservationTime.ofDefaultServiceZone(
-                                BE_AM_TEN_ELEVEN_START_TIME_KST.withZoneSameInstant(UTC.toZoneId()).toLocalDateTime(),
-                                BE_AM_TEN_ELEVEN_END_TIME_KST.withZoneSameInstant(UTC.toZoneId()).toLocalDateTime()))
+                                TimeZoneUtils.convertToUTC(BE_AM_TEN_ELEVEN_START_TIME_KST),
+                                TimeZoneUtils.convertToUTC(BE_AM_TEN_ELEVEN_END_TIME_KST)))
                 .description(BE_AM_TEN_ELEVEN_DESCRIPTION)
                 .userName(BE_AM_TEN_ELEVEN_USERNAME)
                 .password(BE_AM_TEN_ELEVEN_PW)

--- a/backend/src/test/java/com/woowacourse/zzimkkong/service/GuestReservationServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/zzimkkong/service/GuestReservationServiceTest.java
@@ -114,8 +114,8 @@ class GuestReservationServiceTest extends ServiceTest {
                 .id(1L)
                 .reservationTime(
                         ReservationTime.ofDefaultServiceZone(
-                                BE_AM_TEN_ELEVEN_START_TIME_KST.withZoneSameInstant(UTC.toZoneId()).toLocalDateTime(),
-                                BE_AM_TEN_ELEVEN_END_TIME_KST.withZoneSameInstant(UTC.toZoneId()).toLocalDateTime()))
+                                TimeZoneUtils.convertToUTC(BE_AM_TEN_ELEVEN_START_TIME_KST),
+                                TimeZoneUtils.convertToUTC(BE_AM_TEN_ELEVEN_END_TIME_KST)))
                 .description(BE_AM_TEN_ELEVEN_DESCRIPTION)
                 .userName(BE_AM_TEN_ELEVEN_USERNAME)
                 .password(BE_AM_TEN_ELEVEN_PW)
@@ -126,8 +126,8 @@ class GuestReservationServiceTest extends ServiceTest {
                 .id(2L)
                 .reservationTime(
                         ReservationTime.ofDefaultServiceZone(
-                                BE_PM_ONE_TWO_START_TIME_KST.withZoneSameInstant(UTC.toZoneId()).toLocalDateTime(),
-                                BE_PM_ONE_TWO_END_TIME_KST.withZoneSameInstant(UTC.toZoneId()).toLocalDateTime()))
+                                TimeZoneUtils.convertToUTC(BE_PM_ONE_TWO_START_TIME_KST),
+                                TimeZoneUtils.convertToUTC(BE_PM_ONE_TWO_END_TIME_KST)))
                 .description(BE_PM_ONE_TWO_DESCRIPTION)
                 .userName(BE_PM_ONE_TWO_USERNAME)
                 .password(BE_PM_ONE_TWO_PW)

--- a/backend/src/test/java/com/woowacourse/zzimkkong/service/ManagerReservationServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/zzimkkong/service/ManagerReservationServiceTest.java
@@ -130,8 +130,8 @@ class ManagerReservationServiceTest extends ServiceTest {
                 .id(1L)
                 .reservationTime(
                         ReservationTime.ofDefaultServiceZone(
-                                BE_AM_TEN_ELEVEN_START_TIME_KST.withZoneSameInstant(UTC.toZoneId()).toLocalDateTime(),
-                                BE_AM_TEN_ELEVEN_END_TIME_KST.withZoneSameInstant(UTC.toZoneId()).toLocalDateTime()))
+                                TimeZoneUtils.convertToUTC(BE_AM_TEN_ELEVEN_START_TIME_KST),
+                                TimeZoneUtils.convertToUTC(BE_AM_TEN_ELEVEN_END_TIME_KST)))
                 .description(BE_AM_TEN_ELEVEN_DESCRIPTION)
                 .userName(BE_AM_TEN_ELEVEN_USERNAME)
                 .password(BE_AM_TEN_ELEVEN_PW)
@@ -142,8 +142,8 @@ class ManagerReservationServiceTest extends ServiceTest {
                 .id(2L)
                 .reservationTime(
                         ReservationTime.ofDefaultServiceZone(
-                                BE_PM_ONE_TWO_START_TIME_KST.withZoneSameInstant(UTC.toZoneId()).toLocalDateTime(),
-                                BE_PM_ONE_TWO_END_TIME_KST.withZoneSameInstant(UTC.toZoneId()).toLocalDateTime()))
+                                TimeZoneUtils.convertToUTC(BE_PM_ONE_TWO_START_TIME_KST),
+                                TimeZoneUtils.convertToUTC(BE_PM_ONE_TWO_END_TIME_KST)))
                 .description(BE_PM_ONE_TWO_DESCRIPTION)
                 .userName(BE_PM_ONE_TWO_USERNAME)
                 .password(BE_PM_ONE_TWO_PW)
@@ -193,8 +193,8 @@ class ManagerReservationServiceTest extends ServiceTest {
                 .id(1L)
                 .reservationTime(
                         ReservationTime.ofDefaultServiceZone(
-                                BE_AM_TEN_ELEVEN_START_TIME_KST.minusDays(5).withZoneSameInstant(UTC.toZoneId()).toLocalDateTime(),
-                                BE_AM_TEN_ELEVEN_END_TIME_KST.minusDays(5).withZoneSameInstant(UTC.toZoneId()).toLocalDateTime()))
+                                TimeZoneUtils.convertToUTC(BE_AM_TEN_ELEVEN_START_TIME_KST.minusDays(5)),
+                                TimeZoneUtils.convertToUTC(BE_AM_TEN_ELEVEN_END_TIME_KST.minusDays(5))))
                 .description(BE_AM_TEN_ELEVEN_DESCRIPTION)
                 .userName(BE_AM_TEN_ELEVEN_USERNAME)
                 .password(BE_AM_TEN_ELEVEN_PW)


### PR DESCRIPTION
## 구현 기능
- username을 입력받으면 해당 username에 exact match 하는 예약내역을 조회한다
- searchStartTime 을 request param으로 받아 이를 기준으로 pagination 처리
- #892 이슈 얹어서 처리 (페이지 네이션 쿼리에서 예약 시간 컷 다 끝내야함)

Close #889 #892

