### PR TITLE
feat: 헤더에 비회원 예약조회 링크 추가

### DIFF
--- a/frontend/src/components/Header/Header.tsx
+++ b/frontend/src/components/Header/Header.tsx
@@ -62,6 +62,9 @@ const Header = ({ onClickLogin }: HeaderProps): JSX.Element => {
             </Styled.TextButton>
           ) : (
             <>
+              <Styled.TextLink to={PATH.GUEST_NON_LOGIN_RESERVATION_SEARCH}>
+                비회원 예약 조회
+              </Styled.TextLink>
               <Styled.TextLink
                 to={sharingMapId ? HREF.GUEST_MAP(sharingMapId) : PATH.LOGIN}
                 onClick={onClickLogin}

--- a/frontend/src/pages/GuestMap/units/LoginPopup.tsx
+++ b/frontend/src/pages/GuestMap/units/LoginPopup.tsx
@@ -9,6 +9,7 @@ import Modal from 'components/Modal/Modal';
 import SocialLoginButton from 'components/SocialAuthButton/SocialLoginButton';
 import MANAGER from 'constants/manager';
 import MESSAGE from 'constants/message';
+import PATH from 'constants/path';
 import useInputs from 'hooks/useInputs';
 import { AccessTokenContext } from 'providers/AccessTokenProvider';
 import { ErrorResponse, LoginSuccess } from 'types/response';
@@ -116,8 +117,8 @@ const LoginPopup = ({ open, onClose, onLogin }: LoginPopupProps): JSX.Element =>
         </Styled.LoginPopupForm>
         <Styled.Line />
         <Styled.SocialLoginButtonWrapper>
-          <SocialLoginButton provider="GITHUB" variant="icon" />
-          <SocialLoginButton provider="GOOGLE" variant="icon" />
+          <SocialLoginButton provider="GITHUB" variant="icon" href={PATH.GITHUB_LOGIN} />
+          <SocialLoginButton provider="GOOGLE" variant="icon" href={PATH.GOOGLE_LOGIN} />
         </Styled.SocialLoginButtonWrapper>
         <Styled.ContinueWithNonMemberWrapper>
           <Styled.ContinueWithNonMember onClick={onClose}>

--- a/frontend/src/pages/GuestMap/units/ReservationList.styled.ts
+++ b/frontend/src/pages/GuestMap/units/ReservationList.styled.ts
@@ -42,3 +42,8 @@ export const IconButtonWrapper = styled.div`
   display: flex;
   gap: 0.5rem;
 `;
+
+export const MessageWrapper = styled.div`
+  display: flex;
+  justify-content: center;
+`;

--- a/frontend/src/pages/GuestMap/units/ReservationList.tsx
+++ b/frontend/src/pages/GuestMap/units/ReservationList.tsx
@@ -83,8 +83,10 @@ const ReservationList = ({ map: { mapId }, selectedSpaceId, onDelete, onEdit }: 
           </Styled.Message>
         )}
 
-        {isSuccess && reservations?.data.reservations?.length === 0 && isPastDate(dayjs(date)) && (
-          <Styled.Message>예약이 없습니다.</Styled.Message>
+        {isSuccess && reservations?.data.reservations?.length === 0 && (
+          <Styled.MessageWrapper>
+            <Styled.Message>예약이 없습니다.</Styled.Message>
+          </Styled.MessageWrapper>
         )}
 
         {isSuccess && (reservations?.data.reservations?.length ?? 0) > 0 && (

--- a/frontend/src/pages/GuestMap/units/ReservationList.tsx
+++ b/frontend/src/pages/GuestMap/units/ReservationList.tsx
@@ -11,7 +11,7 @@ import useGuestReservations from 'hooks/query/useGuestReservations';
 import useGuestSpace from 'hooks/query/useGuestSpace';
 import { AccessTokenContext } from 'providers/AccessTokenProvider';
 import { MapItem, Reservation } from 'types/common';
-import { formatDate, isPastDate, isPastTime } from 'utils/datetime';
+import { formatDate, isPastTime } from 'utils/datetime';
 import { getReservationStatus } from 'utils/reservation';
 import { isNullish } from 'utils/type';
 import * as Styled from './ReservationList.styled';

--- a/frontend/src/pages/GuestNonLoginReservationSearch/GuestNonLoginReservationSearch.tsx
+++ b/frontend/src/pages/GuestNonLoginReservationSearch/GuestNonLoginReservationSearch.tsx
@@ -38,7 +38,7 @@ const GuestNonLoginReservationSearch = (): JSX.Element => {
     <>
       <Header />
       <Styled.Container>
-        <Styled.ListTitle>비회원 예약 검색</Styled.ListTitle>
+        <Styled.ListTitle>비회원 예약 조회</Styled.ListTitle>
         <Styled.Form onSubmit={handleSubmit}>
           <Input
             type="userName"

--- a/frontend/src/pages/Login/Login.tsx
+++ b/frontend/src/pages/Login/Login.tsx
@@ -90,7 +90,7 @@ const Login = (): JSX.Element => {
           <Styled.HorizontalLine />
           <Styled.JoinLinkMessage>
             비회원으로 예약하셨나요?
-            <Link to={PATH.GUEST_NON_LOGIN_RESERVATION_SEARCH}>비회원 예약 검색</Link>
+            <Link to={PATH.GUEST_NON_LOGIN_RESERVATION_SEARCH}>비회원 예약 조회</Link>
           </Styled.JoinLinkMessage>
         </Styled.Container>
       </Layout>


### PR DESCRIPTION
## 구현 기능
- [x] 헤더에 비회원 예약조회 링크 추가
- [x] 예약현황이 존재하지 않을 때 "예약이 존재하지 않습니다." 메세지 출력
- [x] 로그인 팝업에서 소셜로그인 링크로 이동되지 않던 오류 수정

