### PR TITLE
feat: 비밀번호 변경 기능

### DIFF
--- a/backend/src/main/java/com/woowacourse/zzimkkong/controller/MemberController.java
+++ b/backend/src/main/java/com/woowacourse/zzimkkong/controller/MemberController.java
@@ -2,6 +2,7 @@ package com.woowacourse.zzimkkong.controller;
 
 import com.woowacourse.zzimkkong.config.logaspect.LogMethodExecutionTime;
 import com.woowacourse.zzimkkong.domain.LoginEmail;
+import com.woowacourse.zzimkkong.dto.member.ChangePasswordRequest;
 import com.woowacourse.zzimkkong.dto.member.*;
 import com.woowacourse.zzimkkong.dto.member.oauth.OauthMemberSaveRequest;
 import com.woowacourse.zzimkkong.service.MemberService;
@@ -75,5 +76,11 @@ public class MemberController {
     public ResponseEntity<ProfileEmojisResponse> getEmojis() {
         ProfileEmojisResponse profileEmojis = memberService.getProfileEmojis();
         return ResponseEntity.ok().body(profileEmojis);
+    }
+
+    @PutMapping("/me/password")
+    public ResponseEntity<Void> changePassword(@LoginEmail final LoginUserEmail loginUserEmail, @RequestBody @Valid final ChangePasswordRequest changePasswordRequest) {
+        memberService.changePassword(loginUserEmail, changePasswordRequest);
+        return ResponseEntity.ok().build();
     }
 }

--- a/backend/src/main/java/com/woowacourse/zzimkkong/domain/Member.java
+++ b/backend/src/main/java/com/woowacourse/zzimkkong/domain/Member.java
@@ -78,4 +78,8 @@ public class Member {
     public boolean hasEmail(String email) {
         return this.email.equals(email);
     }
+
+    public void updatePassword(String password) {
+        this.password = password;
+    }
 }

--- a/backend/src/main/java/com/woowacourse/zzimkkong/dto/member/ChangePasswordRequest.java
+++ b/backend/src/main/java/com/woowacourse/zzimkkong/dto/member/ChangePasswordRequest.java
@@ -11,7 +11,6 @@ import static com.woowacourse.zzimkkong.dto.ValidatorMessage.*;
 
 @Getter
 @NoArgsConstructor
-@JsonInclude(JsonInclude.Include.NON_NULL)
 public class ChangePasswordRequest {
     @NotNull(message = EMPTY_MESSAGE)
     @Pattern(regexp = MEMBER_PW_FORMAT, message = MEMBER_PW_MESSAGE)

--- a/backend/src/main/java/com/woowacourse/zzimkkong/dto/member/ChangePasswordRequest.java
+++ b/backend/src/main/java/com/woowacourse/zzimkkong/dto/member/ChangePasswordRequest.java
@@ -1,0 +1,29 @@
+package com.woowacourse.zzimkkong.dto.member;
+
+import lombok.Getter;
+
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Pattern;
+
+import static com.woowacourse.zzimkkong.dto.ValidatorMessage.*;
+
+@Getter
+public class ChangePasswordRequest {
+    @NotNull(message = EMPTY_MESSAGE)
+    @Pattern(regexp = MEMBER_PW_FORMAT, message = MEMBER_PW_MESSAGE)
+    private final String oldPassword;
+
+    @NotNull(message = EMPTY_MESSAGE)
+    @Pattern(regexp = MEMBER_PW_FORMAT, message = MEMBER_PW_MESSAGE)
+    private final String newPassword;
+
+    @NotNull(message = EMPTY_MESSAGE)
+    @Pattern(regexp = MEMBER_PW_FORMAT, message = MEMBER_PW_MESSAGE)
+    private final String newPasswordConfirm;
+
+    public ChangePasswordRequest(String oldPassword, String newPassword, String newPasswordConfirm) {
+        this.oldPassword = oldPassword;
+        this.newPassword = newPassword;
+        this.newPasswordConfirm = newPasswordConfirm;
+    }
+}

--- a/backend/src/main/java/com/woowacourse/zzimkkong/dto/member/ChangePasswordRequest.java
+++ b/backend/src/main/java/com/woowacourse/zzimkkong/dto/member/ChangePasswordRequest.java
@@ -1,6 +1,8 @@
 package com.woowacourse.zzimkkong.dto.member;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
@@ -8,18 +10,20 @@ import javax.validation.constraints.Pattern;
 import static com.woowacourse.zzimkkong.dto.ValidatorMessage.*;
 
 @Getter
+@NoArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class ChangePasswordRequest {
     @NotNull(message = EMPTY_MESSAGE)
     @Pattern(regexp = MEMBER_PW_FORMAT, message = MEMBER_PW_MESSAGE)
-    private final String oldPassword;
+    private String oldPassword;
 
     @NotNull(message = EMPTY_MESSAGE)
     @Pattern(regexp = MEMBER_PW_FORMAT, message = MEMBER_PW_MESSAGE)
-    private final String newPassword;
+    private String newPassword;
 
     @NotNull(message = EMPTY_MESSAGE)
     @Pattern(regexp = MEMBER_PW_FORMAT, message = MEMBER_PW_MESSAGE)
-    private final String newPasswordConfirm;
+    private String newPasswordConfirm;
 
     public ChangePasswordRequest(String oldPassword, String newPassword, String newPasswordConfirm) {
         this.oldPassword = oldPassword;

--- a/backend/src/main/java/com/woowacourse/zzimkkong/exception/member/ConfirmationNewPasswordMismatchException.java
+++ b/backend/src/main/java/com/woowacourse/zzimkkong/exception/member/ConfirmationNewPasswordMismatchException.java
@@ -1,0 +1,12 @@
+package com.woowacourse.zzimkkong.exception.member;
+
+import com.woowacourse.zzimkkong.exception.ZzimkkongException;
+import org.springframework.http.HttpStatus;
+
+public class ConfirmationNewPasswordMismatchException extends ZzimkkongException {
+    private static final String MESSAGE = "새 비밀번호가 확인란과 일치하지 않습니다.";
+
+    public ConfirmationNewPasswordMismatchException() {
+        super(MESSAGE, HttpStatus.BAD_REQUEST);
+    }
+}

--- a/backend/src/main/java/com/woowacourse/zzimkkong/exception/member/PasswordMismatchException.java
+++ b/backend/src/main/java/com/woowacourse/zzimkkong/exception/member/PasswordMismatchException.java
@@ -1,0 +1,12 @@
+package com.woowacourse.zzimkkong.exception.member;
+
+import com.woowacourse.zzimkkong.exception.InputFieldException;
+import org.springframework.http.HttpStatus;
+
+public class PasswordMismatchException extends InputFieldException {
+    private static final String MESSAGE = "비밀번호가 일치하지 않습니다.";
+
+    public PasswordMismatchException() {
+        super(MESSAGE, HttpStatus.BAD_REQUEST, PASSWORD);
+    }
+}

--- a/backend/src/main/java/com/woowacourse/zzimkkong/service/MemberService.java
+++ b/backend/src/main/java/com/woowacourse/zzimkkong/service/MemberService.java
@@ -5,21 +5,15 @@ import com.woowacourse.zzimkkong.domain.OauthProvider;
 import com.woowacourse.zzimkkong.domain.ProfileEmoji;
 import com.woowacourse.zzimkkong.dto.member.*;
 import com.woowacourse.zzimkkong.dto.member.oauth.OauthMemberSaveRequest;
-import com.woowacourse.zzimkkong.exception.member.DuplicateEmailException;
-import com.woowacourse.zzimkkong.exception.member.DuplicateUserNameException;
-import com.woowacourse.zzimkkong.exception.member.NoSuchMemberException;
-import com.woowacourse.zzimkkong.exception.member.ReservationExistsOnMemberException;
+import com.woowacourse.zzimkkong.exception.member.*;
 import com.woowacourse.zzimkkong.repository.MemberRepository;
 import com.woowacourse.zzimkkong.repository.ReservationRepository;
-import net.logstash.logback.encoder.org.apache.commons.lang3.StringUtils;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
-import java.util.Arrays;
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Service
 @Transactional
@@ -112,5 +106,27 @@ public class MemberService {
     @Transactional(readOnly = true)
     public ProfileEmojisResponse getProfileEmojis() {
         return ProfileEmojisResponse.from(List.of(ProfileEmoji.values()));
+    }
+
+    public void changePassword(LoginUserEmail loginUserEmail, ChangePasswordRequest changePasswordRequest) {
+        Member member = members.findByEmail(loginUserEmail.getEmail())
+                .orElseThrow(NoSuchMemberException::new);
+        validateOldPassword(member, changePasswordRequest);
+        validateConfirmationPassword(changePasswordRequest);
+
+        String newPassword = passwordEncoder.encode(changePasswordRequest.getNewPassword());
+        member.updatePassword(newPassword);
+    }
+
+    private void validateOldPassword(Member member, ChangePasswordRequest changePasswordRequest) {
+        if (!passwordEncoder.matches(changePasswordRequest.getOldPassword(), member.getPassword())) {
+            throw new PasswordMismatchException();
+        }
+    }
+
+    private void validateConfirmationPassword(ChangePasswordRequest changePasswordRequest) {
+        if (!changePasswordRequest.getNewPassword().equals(changePasswordRequest.getNewPasswordConfirm())) {
+            throw new ConfirmationNewPasswordMismatchException();
+        }
     }
 }

--- a/backend/src/main/java/com/woowacourse/zzimkkong/service/MemberService.java
+++ b/backend/src/main/java/com/woowacourse/zzimkkong/service/MemberService.java
@@ -108,7 +108,7 @@ public class MemberService {
         return ProfileEmojisResponse.from(List.of(ProfileEmoji.values()));
     }
 
-    public void changePassword(LoginUserEmail loginUserEmail, ChangePasswordRequest changePasswordRequest) {
+    public void changePassword(final LoginUserEmail loginUserEmail, final ChangePasswordRequest changePasswordRequest) {
         Member member = members.findByEmail(loginUserEmail.getEmail())
                 .orElseThrow(NoSuchMemberException::new);
         validateOldPassword(member, changePasswordRequest);
@@ -118,13 +118,13 @@ public class MemberService {
         member.updatePassword(newPassword);
     }
 
-    private void validateOldPassword(Member member, ChangePasswordRequest changePasswordRequest) {
+    private void validateOldPassword(final Member member, final ChangePasswordRequest changePasswordRequest) {
         if (!passwordEncoder.matches(changePasswordRequest.getOldPassword(), member.getPassword())) {
             throw new PasswordMismatchException();
         }
     }
 
-    private void validateConfirmationPassword(ChangePasswordRequest changePasswordRequest) {
+    private void validateConfirmationPassword(final ChangePasswordRequest changePasswordRequest) {
         if (!changePasswordRequest.getNewPassword().equals(changePasswordRequest.getNewPasswordConfirm())) {
             throw new ConfirmationNewPasswordMismatchException();
         }

--- a/backend/src/test/java/com/woowacourse/zzimkkong/controller/MemberControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/zzimkkong/controller/MemberControllerTest.java
@@ -153,6 +153,24 @@ class MemberControllerTest extends AcceptanceTest {
         assertThat(actual).usingRecursiveComparison().isEqualTo(expected);
     }
 
+    @Test
+    @DisplayName("비밀번호를 변경할 수 있다.")
+    void changePassword() {
+        //given
+        String newPassword = "newPassword1234";
+        ChangePasswordRequest changePasswordRequest = new ChangePasswordRequest(PW, newPassword, newPassword);
+
+        //when
+        ExtractableResponse<Response> response = changePassword(changePasswordRequest);
+
+        //then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+
+        LoginRequest loginRequest = new LoginRequest(EMAIL, newPassword);
+        ExtractableResponse<Response> loginResponse = login(loginRequest);
+        assertThat(loginResponse.statusCode()).isEqualTo(HttpStatus.OK.value());
+    }
+
     static ExtractableResponse<Response> saveMember(final MemberSaveRequest memberSaveRequest) {
         return RestAssured
                 .given(getRequestSpecification()).log().all()
@@ -238,6 +256,29 @@ class MemberControllerTest extends AcceptanceTest {
                 .filter(document("member/get/emojis", getRequestPreprocessor(), getResponsePreprocessor()))
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .when().get("/api/members/emojis")
+                .then().log().all().extract();
+    }
+
+    private ExtractableResponse<Response> changePassword(ChangePasswordRequest changePasswordRequest) {
+        return RestAssured
+                .given(getRequestSpecification()).log().all()
+                .accept("application/json")
+                .header("Authorization", AuthorizationExtractor.AUTHENTICATION_TYPE + " " + accessToken)
+                .filter(document("member/password/put", getRequestPreprocessor(), getResponsePreprocessor()))
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(changePasswordRequest)
+                .when().put("/api/members/me/password/put")
+                .then().log().all().extract();
+    }
+
+    private ExtractableResponse<Response> login(final LoginRequest loginRequest) {
+        return RestAssured
+                .given(getRequestSpecification()).log().all()
+                .accept("application/json")
+                .filter(document("member/login", getRequestPreprocessor(), getResponsePreprocessor()))
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(loginRequest)
+                .when().post("/api/members/login/token")
                 .then().log().all().extract();
     }
 }

--- a/backend/src/test/java/com/woowacourse/zzimkkong/dto/ChangePasswordRequestTest.java
+++ b/backend/src/test/java/com/woowacourse/zzimkkong/dto/ChangePasswordRequestTest.java
@@ -1,0 +1,44 @@
+package com.woowacourse.zzimkkong.dto;
+
+import com.woowacourse.zzimkkong.dto.member.ChangePasswordRequest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+
+import static com.woowacourse.zzimkkong.dto.ValidatorMessage.MEMBER_PW_MESSAGE;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ChangePasswordRequestTest extends RequestTest {
+    @ParameterizedTest
+    @NullAndEmptySource
+    @DisplayName("기존 비밀번호 확인란에 빈 문자열이 들어오면 처리한다.")
+    void blankOldPassword(String oldPassword) {
+        ChangePasswordRequest changePasswordRequest = new ChangePasswordRequest(oldPassword, "newPassword", "newPasswordConfirm");
+
+        assertThat(getConstraintViolations(changePasswordRequest).stream()
+                .anyMatch(violation -> violation.getMessage().equals(MEMBER_PW_MESSAGE)))
+                .isTrue();
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    @DisplayName("새 비밀번호란에 빈 문자열이 들어오면 처리한다.")
+    void blankNewPassword(String newPassword) {
+        ChangePasswordRequest changePasswordRequest = new ChangePasswordRequest("oldPassword", newPassword, "newPasswordConfirm");
+
+        assertThat(getConstraintViolations(changePasswordRequest).stream()
+                .anyMatch(violation -> violation.getMessage().equals(MEMBER_PW_MESSAGE)))
+                .isTrue();
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    @DisplayName("새 비밀번호 확인란에 빈 문자열이 들어오면 처리한다.")
+    void blankNewPasswordConfirm(String newPasswordConfirm) {
+        ChangePasswordRequest changePasswordRequest = new ChangePasswordRequest("oldPassword", "newPassword", newPasswordConfirm);
+
+        assertThat(getConstraintViolations(changePasswordRequest).stream()
+                .anyMatch(violation -> violation.getMessage().equals(MEMBER_PW_MESSAGE)))
+                .isTrue();
+    }
+}


### PR DESCRIPTION
## 구현 기능
- 비밀번호 변경 기능을 추가합니다.
- 기존의 비밀번호와 새 비밀번호를 두 번 입력해오면 이에 대해 검증하고 비밀번호를 변경합니다.

백에서 검증은 해주지만, 프론트에서도 새 비밀번호 확인란 비교해서 애초에 걸러주는 로직이 있으면 좋겠네용

Close #909

