### PR TITLE
feat: 회원 정보 수정에서 회원 스스로의 닉네임은 중복검사에서 제외하는 분기 생성

### DIFF
--- a/backend/src/main/java/com/woowacourse/zzimkkong/service/MemberService.java
+++ b/backend/src/main/java/com/woowacourse/zzimkkong/service/MemberService.java
@@ -93,7 +93,9 @@ public class MemberService {
         Member member = members.findByEmail(loginUserEmail.getEmail())
                 .orElseThrow(NoSuchMemberException::new);
 
-        validateDuplicateUserName(memberUpdateRequest.getUserName());
+        if (!member.getUserName().equals(memberUpdateRequest.getUserName())) {
+            validateDuplicateUserName(memberUpdateRequest.getUserName());
+        }
 
         member.update(memberUpdateRequest);
     }

--- a/backend/src/test/java/com/woowacourse/zzimkkong/service/MemberServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/zzimkkong/service/MemberServiceTest.java
@@ -193,6 +193,53 @@ class MemberServiceTest extends ServiceTest {
     }
 
     @Test
+    @DisplayName("회원이 자신의 정보를 수정할 때 중복된 닉네임을 입력하면 실패한다.")
+    void updateMemberFailWhenDuplicatedUsername() {
+        // given
+        LoginUserEmail loginUserEmail = LoginUserEmail.from(EMAIL);
+        Member member = Member.builder()
+                .email(EMAIL)
+                .userName(POBI)
+                .emoji(ProfileEmoji.MAN_DARK_SKIN_TONE_TECHNOLOGIST)
+                .password(PW)
+                .organization(ORGANIZATION)
+                .build();
+        MemberUpdateRequest memberUpdateRequest = new MemberUpdateRequest("sakjung", ProfileEmoji.MAN_DARK_SKIN_TONE_TECHNOLOGIST);
+
+        given(members.findByEmail(anyString()))
+                .willReturn(Optional.of(member));
+        given(members.existsByUserName(anyString()))
+                .willReturn(true);
+
+        // when, then
+        assertThatThrownBy(() -> memberService.updateMember(loginUserEmail, memberUpdateRequest))
+                .isInstanceOf(DuplicateUserNameException.class);
+    }
+
+    @Test
+    @DisplayName("회원이 자신의 정보를 수정할 때, 자신의 닉네임은 중복 검사에서 제외한다.")
+    void updateMemberIgnoreUsernameValidationWhenGivenUsernameAsIs() {
+        // given
+        LoginUserEmail loginUserEmail = LoginUserEmail.from(EMAIL);
+        Member member = Member.builder()
+                .email(EMAIL)
+                .userName(POBI)
+                .emoji(ProfileEmoji.MAN_DARK_SKIN_TONE_TECHNOLOGIST)
+                .password(PW)
+                .organization(ORGANIZATION)
+                .build();
+        MemberUpdateRequest memberUpdateRequest = new MemberUpdateRequest(member.getUserName(), ProfileEmoji.MAN_DARK_SKIN_TONE_TECHNOLOGIST);
+
+        given(members.findByEmail(anyString()))
+                .willReturn(Optional.of(member));
+        given(members.existsByUserName(anyString()))
+                .willReturn(true);
+
+        // when, then
+        assertDoesNotThrow(() -> memberService.updateMember(loginUserEmail, memberUpdateRequest));
+    }
+
+    @Test
     @DisplayName("회원을 삭제할 수 있다.")
     void deleteMember() {
         // given


### PR DESCRIPTION
## 구현 기능
- 자신의 닉네임은 중복검사에서 제외합니다.

Close #913

