### PR TITLE
fix: iOS에서 로그인 후 예약 시 이름 필드 흐리게 보이는 현상 해결

### DIFF
--- a/frontend/src/components/Input/Input.styles.ts
+++ b/frontend/src/components/Input/Input.styles.ts
@@ -70,7 +70,9 @@ export const Input = styled.input<InputProps>`
   }
 
   &:disabled {
+    -webkit-text-fill-color: ${({ theme }) => theme.gray[400]};
     color: ${({ theme }) => theme.gray[400]};
+    opacity: 1;
   }
 `;
 


### PR DESCRIPTION
## 구현 기능
- iOS에서 로그인 후 예약 시 이름 필드 흐리게 보이는 현상 해결

[Before]
<img src="https://user-images.githubusercontent.com/2542730/224538381-e9c64c14-f93f-44bb-a960-0e94d55a91f7.png" width="400px" />


[After]
<img src="https://user-images.githubusercontent.com/2542730/224538489-4e228a63-eabc-4921-b3e3-562e9a163dff.PNG" width="400px" />


Close #907
