### PR TITLE
feat: 비밀번호 변경 api에서 기존 비밀번호 오기입시 에러 메세지 구체화, 기존 비밀번호에 대해 패턴 검사를 실시하지 않음, dto 패턴 테스트 코드 추가

### DIFF
--- a/backend/src/main/java/com/woowacourse/zzimkkong/dto/member/ChangePasswordRequest.java
+++ b/backend/src/main/java/com/woowacourse/zzimkkong/dto/member/ChangePasswordRequest.java
@@ -1,9 +1,9 @@
 package com.woowacourse.zzimkkong.dto.member;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
 
@@ -12,8 +12,7 @@ import static com.woowacourse.zzimkkong.dto.ValidatorMessage.*;
 @Getter
 @NoArgsConstructor
 public class ChangePasswordRequest {
-    @NotNull(message = EMPTY_MESSAGE)
-    @Pattern(regexp = MEMBER_PW_FORMAT, message = MEMBER_PW_MESSAGE)
+    @NotBlank(message = EMPTY_MESSAGE)
     private String oldPassword;
 
     @NotNull(message = EMPTY_MESSAGE)

--- a/backend/src/main/java/com/woowacourse/zzimkkong/exception/member/PasswordMismatchException.java
+++ b/backend/src/main/java/com/woowacourse/zzimkkong/exception/member/PasswordMismatchException.java
@@ -4,7 +4,7 @@ import com.woowacourse.zzimkkong.exception.InputFieldException;
 import org.springframework.http.HttpStatus;
 
 public class PasswordMismatchException extends InputFieldException {
-    private static final String MESSAGE = "비밀번호가 일치하지 않습니다.";
+    private static final String MESSAGE = "기존 비밀번호가 일치하지 않습니다.";
 
     public PasswordMismatchException() {
         super(MESSAGE, HttpStatus.BAD_REQUEST, PASSWORD);

--- a/backend/src/test/java/com/woowacourse/zzimkkong/dto/ChangePasswordRequestTest.java
+++ b/backend/src/test/java/com/woowacourse/zzimkkong/dto/ChangePasswordRequestTest.java
@@ -3,8 +3,11 @@ package com.woowacourse.zzimkkong.dto;
 import com.woowacourse.zzimkkong.dto.member.ChangePasswordRequest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.NullSource;
 
+import static com.woowacourse.zzimkkong.dto.ValidatorMessage.EMPTY_MESSAGE;
 import static com.woowacourse.zzimkkong.dto.ValidatorMessage.MEMBER_PW_MESSAGE;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -40,5 +43,27 @@ class ChangePasswordRequestTest extends RequestTest {
         assertThat(getConstraintViolations(changePasswordRequest).stream()
                 .anyMatch(violation -> violation.getMessage().equals(MEMBER_PW_MESSAGE)))
                 .isTrue();
+    }
+
+    @ParameterizedTest
+    @NullSource
+    @DisplayName("비밀번호 변경시 새 비밀번호 란에 빈 문자열이 들어오면 처리한다.")
+    void blankPassword(String password) {
+        ChangePasswordRequest changePasswordRequest = new ChangePasswordRequest("oldPassword1234", password, password);
+
+        assertThat(getConstraintViolations(changePasswordRequest).stream()
+                .anyMatch(violation -> violation.getMessage().equals(EMPTY_MESSAGE)))
+                .isTrue();
+    }
+
+    @ParameterizedTest
+    @CsvSource(value = {"test1234!:false", "test1234:false", "1234test:false", "testtest:true", "12341234:true", "test123:true", "test1234test1234test1:true", "한글도실패1231:true"}, delimiter = ':')
+    @DisplayName("비밀번호 변경시 새 비밀번호 란에 옳지 않은 비밀번호 형식의 문자열이 들어오면 처리한다.")
+    void invalidPassword(String password, boolean flag) {
+        ChangePasswordRequest changePasswordRequest = new ChangePasswordRequest("oldPassword1234", password, password);
+
+        assertThat(getConstraintViolations(changePasswordRequest).stream()
+                .anyMatch(violation -> violation.getMessage().equals(MEMBER_PW_MESSAGE)))
+                .isEqualTo(flag);
     }
 }


### PR DESCRIPTION
## 구현 기능
- 비밀번호 변경 api에서 기존 비밀번호 오기입시 에러 메세지를 구체화 합니다.
- 비밀번호 변경 api에서 기존 비밀번호에 대해 패턴 검사를 실행하지 않습니다.

close #909