### PR TITLE
feat: ControllerAdvice 개편

### DIFF
--- a/backend/src/main/java/com/woowacourse/zzimkkong/controller/ControllerAdvice.java
+++ b/backend/src/main/java/com/woowacourse/zzimkkong/controller/ControllerAdvice.java
@@ -18,6 +18,7 @@ import org.springframework.security.web.firewall.RequestRejectedHandler;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
@@ -80,7 +81,7 @@ public class ControllerAdvice implements RequestRejectedHandler {
         return ResponseEntity.badRequest().body(ErrorResponse.from(exception));
     }
 
-    @ExceptionHandler({InvalidFormatException.class, HttpMessageNotReadableException.class})
+    @ExceptionHandler({InvalidFormatException.class, HttpMessageNotReadableException.class, MethodArgumentTypeMismatchException.class})
     public ResponseEntity<ErrorResponse> invalidFormatHandler(final Exception exception) {
         logInfo(exception);
         return ResponseEntity.badRequest().body(ErrorResponse.invalidFormat());

--- a/backend/src/main/java/com/woowacourse/zzimkkong/dto/ErrorResponse.java
+++ b/backend/src/main/java/com/woowacourse/zzimkkong/dto/ErrorResponse.java
@@ -6,6 +6,7 @@ import lombok.NoArgsConstructor;
 import javax.validation.ConstraintViolationException;
 
 import static com.woowacourse.zzimkkong.dto.ValidatorMessage.FORMAT_MESSAGE;
+import static com.woowacourse.zzimkkong.dto.ValidatorMessage.SERVER_ERROR_MESSAGE;
 
 @Getter
 @NoArgsConstructor
@@ -27,5 +28,9 @@ public class ErrorResponse {
 
     public static ErrorResponse invalidFormat() {
         return new ErrorResponse(FORMAT_MESSAGE);
+    }
+
+    public static ErrorResponse internalServerError() {
+        return new ErrorResponse(SERVER_ERROR_MESSAGE);
     }
 }

--- a/backend/src/main/java/com/woowacourse/zzimkkong/dto/ValidatorMessage.java
+++ b/backend/src/main/java/com/woowacourse/zzimkkong/dto/ValidatorMessage.java
@@ -15,7 +15,7 @@ public class ValidatorMessage {
     public static final String NOTICE_MESSAGE = "공지사항은 100자 이내로 작성 가능합니다.";
     public static final String FORMAT_MESSAGE = "날짜 및 시간 데이터 형식이 올바르지 않습니다.";
     public static final String DAY_OF_WEEK_MESSAGE = "올바른 요일 형식이 아닙니다.";
-    public static final String SERVER_ERROR_MESSAGE = "예상치 못한 문제가 발생했습니다. 개발자에게 문의하세요.";
+    public static final String SERVER_ERROR_MESSAGE = "일시적으로 접속이 원활하지 않습니다. 잠시 후 다시 이용해 주시기 바랍니다.";
     public static final String TIME_UNIT_MESSAGE = "시간 단위는 10, 30, 60, 120입니다.";
     public static final String SETTING_COUNT_MESSAGE = "공간의 예약 조건이 최소 1개는 존재해야 합니다.";
 

--- a/backend/src/main/java/com/woowacourse/zzimkkong/exception/authorization/TokenExpiredException.java
+++ b/backend/src/main/java/com/woowacourse/zzimkkong/exception/authorization/TokenExpiredException.java
@@ -4,7 +4,7 @@ import com.woowacourse.zzimkkong.exception.ZzimkkongException;
 import org.springframework.http.HttpStatus;
 
 public class TokenExpiredException extends ZzimkkongException {
-    private static final String MESSAGE = "로그인이 필요한 서비스입니다.";
+    private static final String MESSAGE = "로그인 인증 유효기간이 만료되었습니다. 다시 로그인 해주세요.";
 
     public TokenExpiredException() {
         super(MESSAGE, HttpStatus.UNAUTHORIZED);

--- a/backend/src/main/java/com/woowacourse/zzimkkong/infrastructure/auth/JwtUtils.java
+++ b/backend/src/main/java/com/woowacourse/zzimkkong/infrastructure/auth/JwtUtils.java
@@ -48,7 +48,13 @@ public class JwtUtils {
     }
 
     public String getPayload(String token) {
-        return jwtParser.parseClaimsJws(token).getBody().getSubject();
+        try {
+            return jwtParser.parseClaimsJws(token).getBody().getSubject();
+        } catch (ExpiredJwtException e) {
+            throw new TokenExpiredException();
+        } catch (JwtException e) {
+            throw new InvalidTokenException();
+        }
     }
 
     public static PayloadBuilder payloadBuilder() {


### PR DESCRIPTION
## 구현 기능
- 이슈 #948 #949 함께 해결
- ControllerAdvice 코드 수정 
  - logging 시 발생한 exception 도 같이 찍도록 수정
  - Error Response handler 별로 알맞게 수정

## 논의하고 싶은 내용
- internal server error 발생 시, 클라측에 나가는 메세지 (i.e. 사용자가 볼 메세지) 변경
  - `일시적으로 접속이 원활하지 않습니다. 잠시 후 다시 이용해 주시기 바랍니다.`
- 기존에 ControllerAdvice에서 클라측에 나갈 메세지가 로그로 찍히는 부분이 있었음
  - 우리가 클라측에 나갈만한 안내 메세지를 로그에서 봐서 도움 되는 부분이 없으므로 Exception의 메세지를 대신 찍도록 변경했습니다

Close #948 
#949 는 엄밀히 따지면 FE 의 버그 사항이므로 Close 하지 않습니다
