### PR TITLE
fix: 비회원 예약 조회 > 수정 버튼 클릭시 예약 수정 페이지로 정상적으로 넘어가도록 수정

### DIFF
--- a/frontend/src/pages/GuestNonLoginReservationSearch/units/GuestNonLoginReservationSearchResult.tsx
+++ b/frontend/src/pages/GuestNonLoginReservationSearch/units/GuestNonLoginReservationSearchResult.tsx
@@ -69,25 +69,12 @@ const GuestNonLoginReservationSearchResult = ({
     });
   };
 
-  const handleEdit = async (reservation: MemberReservation) => {
-    const space = await api
-      .get<ManagerSpaceAPI>(`/guests/maps/${reservation.mapId}/spaces/${reservation.spaceId}`)
-      .then((promise) => promise.data)
-      .catch(() => {
-        alert(MESSAGE.MANAGER_MAIN.UNEXPECTED_GET_DATA_ERROR);
-        return null;
-      });
-
-    if (space == null) {
-      return;
-    }
-
-    space.id = reservation.spaceId;
+  const handleEdit = (reservation: MemberReservation) => {
     history.push({
       pathname: HREF.GUEST_RESERVATION_EDIT(reservation.sharingMapId),
       state: {
         mapId: reservation.mapId,
-        space: space,
+        spaceId: reservation.spaceId,
         reservation,
         selectedDate: formatDate(new Date(reservation.startDateTime)),
       },
@@ -98,7 +85,6 @@ const GuestNonLoginReservationSearchResult = ({
     refetch();
   }, [refetch, searchStartTime]);
 
-  console.log(isFetchingReservations);
   return (
     <>
       <Styled.HorizontalLine />


### PR DESCRIPTION
## 구현 기능
- 비회원 예약 조회 > 예약 수정 아이콘 클릭 > 예약 수정 페이지로 이동 하도록 수정

## 공유하고 싶은 내용
- commit 4abc424b8c764a172fc4bdcd3d9b709730ca8547 영향
- 해당 커밋 내역보고 맞춰서 수정했습니다

Close #953 

