### PR TITLE
feat: 공간 조건 적용 사용성 개선 (FE)

### DIFF
--- a/frontend/src/__mocks__/mockData.ts
+++ b/frontend/src/__mocks__/mockData.ts
@@ -53,6 +53,7 @@ export const spaces: Spaces = {
           reservationTimeUnit: 10,
           reservationMinimumTimeUnit: 10,
           reservationMaximumTimeUnit: 1440,
+          priorityOrder: 0,
           enabledDayOfWeek: {
             monday: true,
             tuesday: true,

--- a/frontend/src/api/setting.ts
+++ b/frontend/src/api/setting.ts
@@ -6,17 +6,20 @@ import api from './api';
 export interface QuerySettingSummaryParams {
   mapId: MapItem['mapId'];
   spaceId: Space['id'];
-  selectedDateTime: string;
+  selectedDateTime: string | null;
+  settingViewType: string | null;
 }
 
 export const querySettingSummary = ({
   mapId,
   spaceId,
   selectedDateTime,
+  settingViewType,
 }: QuerySettingSummaryParams) => {
   return api.get<QuerySettingSummarySuccess>(
     `/maps/${mapId}/spaces/${spaceId}/settings/summary${QS.create({
-      selectedDateTime,
+      selectedDateTime: selectedDateTime,
+      settingViewType: settingViewType,
     })}`
   );
 };

--- a/frontend/src/api/setting.ts
+++ b/frontend/src/api/setting.ts
@@ -1,0 +1,22 @@
+import { QS } from '@toss/utils';
+import { MapItem, Space } from '../types/common';
+import { QuerySettingSummarySuccess } from '../types/response';
+import api from './api';
+
+export interface QuerySettingSummaryParams {
+  mapId: MapItem['mapId'];
+  spaceId: Space['id'];
+  selectedDateTime: string;
+}
+
+export const querySettingSummary = ({
+  mapId,
+  spaceId,
+  selectedDateTime,
+}: QuerySettingSummaryParams) => {
+  return api.get<QuerySettingSummarySuccess>(
+    `/maps/${mapId}/spaces/${spaceId}/settings/summary${QS.create({
+      selectedDateTime,
+    })}`
+  );
+};

--- a/frontend/src/components/Modal/SummaryModal.styles.ts
+++ b/frontend/src/components/Modal/SummaryModal.styles.ts
@@ -1,0 +1,58 @@
+import styled from 'styled-components';
+import { Z_INDEX } from 'constants/style';
+
+interface Props {
+  open?: boolean;
+}
+
+export const Overlay = styled.div<Props>`
+  display: ${({ open }) => (open ? 'flex' : 'none')};
+  position: fixed;
+  justify-content: center;
+  align-items: center;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: ${({ theme }) => theme.modalOverlay};
+  z-index: ${Z_INDEX.MODAL_OVERLAY};
+  overflow: scroll;
+`;
+
+export const Modal = styled.div`
+  width: 80%;
+  max-height: 70%;
+  min-width: 320px;
+  max-width: 768px;
+  position: absolute;
+  border-radius: 4px;
+  background-color: ${({ theme }) => theme.white};
+  overflow: auto;
+`;
+
+export const CloseButton = styled.button`
+  position: absolute;
+  padding: 0.5rem;
+  top: 0.5rem;
+  right: 1.5rem;
+  width: 1rem;
+  cursor: pointer;
+  border: none;
+  background: none;
+
+  &:hover {
+    opacity: 0.7;
+  }
+`;
+
+export const Inner = styled.div`
+  padding: 0.5rem 1rem;
+`;
+
+export const Header = styled.h2`
+  font-weight: 700;
+  padding: 1rem;
+  margin-bottom: 0.5rem;
+`;
+
+export const Content = styled.div``;

--- a/frontend/src/components/Modal/SummaryModal.tsx
+++ b/frontend/src/components/Modal/SummaryModal.tsx
@@ -1,0 +1,53 @@
+import { MouseEventHandler, PropsWithChildren } from 'react';
+import { createPortal } from 'react-dom';
+import { ReactComponent as CloseIcon } from 'assets/svg/close.svg';
+import * as Styled from './SummaryModal.styles';
+
+export interface Props {
+  open: boolean;
+  isClosableDimmer?: boolean;
+  showCloseButton?: boolean;
+  onClose: () => void;
+}
+
+let modalRoot = document.getElementById('modal');
+
+const SummaryModal = ({
+  open,
+  isClosableDimmer,
+  showCloseButton,
+  onClose,
+  children,
+}: PropsWithChildren<Props>): JSX.Element => {
+  if (modalRoot === null) {
+    modalRoot = document.createElement('div');
+    modalRoot.setAttribute('id', 'modal');
+    document.body.appendChild(modalRoot);
+  }
+
+  const handleMouseDownOverlay: MouseEventHandler<HTMLDivElement> = ({ target, currentTarget }) => {
+    if (isClosableDimmer && target === currentTarget) {
+      onClose();
+    }
+  };
+
+  return createPortal(
+    <Styled.Overlay open={open} onMouseDown={handleMouseDownOverlay}>
+      <Styled.Modal>
+        {open && showCloseButton && (
+          <Styled.CloseButton onClick={onClose}>
+            <CloseIcon />
+          </Styled.CloseButton>
+        )}
+        {open && children}
+      </Styled.Modal>
+    </Styled.Overlay>,
+    modalRoot
+  );
+};
+
+SummaryModal.Inner = Styled.Inner;
+SummaryModal.Header = Styled.Header;
+SummaryModal.Content = Styled.Content;
+
+export default SummaryModal;

--- a/frontend/src/hooks/query/useSettingSummary.ts
+++ b/frontend/src/hooks/query/useSettingSummary.ts
@@ -1,0 +1,17 @@
+import { AxiosError, AxiosResponse } from 'axios';
+import { QueryKey, useQuery, UseQueryOptions, UseQueryResult } from 'react-query';
+import { ErrorResponse, QuerySettingSummarySuccess } from 'types/response';
+import { querySettingSummary, QuerySettingSummaryParams } from '../../api/setting';
+
+const useSettingSummary = <TData = AxiosResponse<QuerySettingSummarySuccess>>(
+  params: QuerySettingSummaryParams,
+  options?: UseQueryOptions<
+    AxiosResponse<QuerySettingSummarySuccess>,
+    AxiosError<ErrorResponse>,
+    TData,
+    [QueryKey, QuerySettingSummaryParams]
+  >
+): UseQueryResult<TData, AxiosError<ErrorResponse>> =>
+  useQuery(['getSettingSummary', params], () => querySettingSummary(params), options);
+
+export default useSettingSummary;

--- a/frontend/src/pages/GuestMap/units/ReservationForm.styled.ts
+++ b/frontend/src/pages/GuestMap/units/ReservationForm.styled.ts
@@ -32,26 +32,33 @@ export const InputsRow = styled.div`
   }
 `;
 
-export const TimeFormMessageWrapper = styled.div`
+export const SettingSummaryWrapper = styled.div`
   display: flex;
   flex-direction: column;
   gap: 0.25rem;
   margin-top: 0.5rem;
 `;
 
-export const TimeFormMessageList = styled.div`
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-`;
-
-export const TimeFormMessage = styled.p<{ fontWeight?: string }>`
-  left: 0.75rem;
-  bottom: -1.5rem;
-  font-size: 0.75rem;
-  height: 1.5em;
+/**
+ * 세팅이 많아질 경우를 대비 (펼치기, 접기 용도)
+ */
+export const PartialSettingSummary = styled.p`
+  height: 80px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: horizontal;
   white-space: pre-line;
   line-height: normal;
+  font-size: 0.75rem;
+  color: ${({ theme }) => theme.gray[500]};
+`;
+
+export const SettingSummary = styled.p<{ fontWeight?: string }>`
+  white-space: pre-line;
+  line-height: normal;
+  font-size: 0.75rem;
   color: ${({ theme }) => theme.gray[500]};
   ${({ fontWeight }) => fontWeight && `font-weight: ${fontWeight}`};
 `;

--- a/frontend/src/pages/GuestMap/units/ReservationForm.styled.ts
+++ b/frontend/src/pages/GuestMap/units/ReservationForm.styled.ts
@@ -34,6 +34,7 @@ export const InputsRow = styled.div`
 
 export const TimeFormMessageWrapper = styled.div`
   display: flex;
+  flex-direction: column;
   gap: 0.25rem;
   margin-top: 0.5rem;
 `;
@@ -46,9 +47,11 @@ export const TimeFormMessageList = styled.div`
 
 export const TimeFormMessage = styled.p<{ fontWeight?: string }>`
   left: 0.75rem;
-  bottom: -1rem;
+  bottom: -1.5rem;
   font-size: 0.75rem;
-  height: 1em;
+  height: 1.5em;
+  white-space: pre-line;
+  line-height: normal;
   color: ${({ theme }) => theme.gray[500]};
   ${({ fontWeight }) => fontWeight && `font-weight: ${fontWeight}`};
 `;

--- a/frontend/src/pages/GuestMap/units/ReservationForm.tsx
+++ b/frontend/src/pages/GuestMap/units/ReservationForm.tsx
@@ -25,6 +25,7 @@ import { MapItem } from 'types/common';
 import { ErrorResponse } from 'types/response';
 import { formatTimePrettier, formatTimeWithSecond, isPastDate } from 'utils/datetime';
 import { isNullish } from 'utils/type';
+import useSettingSummary from '../../../hooks/query/useSettingSummary';
 import { GuestMapFormContext } from '../providers/GuestMapFormProvider';
 import * as Styled from './ReservationForm.styled';
 
@@ -63,6 +64,18 @@ const ReservationForm = ({ map }: Props) => {
       })) ?? []
     );
   };
+
+  const getSettingsSummary = useSettingSummary(
+    {
+      mapId: map?.mapId,
+      spaceId: parseInt(selectedSpaceId),
+      selectedDateTime: `${formValues.date}T${formatTimeWithSecond(
+        timePicker?.range.start ?? dayjs().tz()
+      )}${DATE.TIMEZONE_OFFSET}`,
+    },
+    { enabled: selectedSpaceId !== null }
+  );
+  const settingsSummary = getSettingsSummary.data?.data?.summary ?? '';
 
   const onSuccessCreateReservation = (
     _: unknown,
@@ -167,25 +180,7 @@ const ReservationForm = ({ map }: Props) => {
           {spacesMap?.[Number(selectedSpaceId)] && (
             <Styled.TimeFormMessageWrapper>
               <Styled.TimeFormMessage fontWeight="bold">예약 가능 시간</Styled.TimeFormMessage>
-              <Styled.TimeFormMessageList>
-                {spacesMap[Number(selectedSpaceId)].settings.map(
-                  (
-                    {
-                      settingStartTime,
-                      settingEndTime,
-                      reservationMaximumTimeUnit,
-                      reservationMinimumTimeUnit,
-                    },
-                    index
-                  ) => (
-                    <Styled.TimeFormMessage key={index}>
-                      {settingStartTime.slice(0, 5)} ~ {settingEndTime.slice(0, 5)}
-                      (최소 {formatTimePrettier(reservationMinimumTimeUnit)}, 최대{' '}
-                      {formatTimePrettier(reservationMaximumTimeUnit)})
-                    </Styled.TimeFormMessage>
-                  )
-                )}{' '}
-              </Styled.TimeFormMessageList>
+              <Styled.TimeFormMessage>{settingsSummary}</Styled.TimeFormMessage>
             </Styled.TimeFormMessageWrapper>
           )}
         </Styled.InputWrapper>

--- a/frontend/src/pages/GuestMap/units/ReservationForm.tsx
+++ b/frontend/src/pages/GuestMap/units/ReservationForm.tsx
@@ -72,6 +72,7 @@ const ReservationForm = ({ map }: Props) => {
       selectedDateTime: `${formValues.date}T${formatTimeWithSecond(
         timePicker?.range.start ?? dayjs().tz()
       )}${DATE.TIMEZONE_OFFSET}`,
+      settingViewType: 'FLAT',
     },
     { enabled: selectedSpaceId !== null && !isNaN(parseInt(selectedSpaceId)) }
   );

--- a/frontend/src/pages/GuestMap/units/ReservationForm.tsx
+++ b/frontend/src/pages/GuestMap/units/ReservationForm.tsx
@@ -1,6 +1,6 @@
 import { AxiosError } from 'axios';
 import dayjs from 'dayjs';
-import React, { useContext } from 'react';
+import React, { useContext, useState } from 'react';
 import { useMutation } from 'react-query';
 import { useHistory } from 'react-router-dom';
 import {
@@ -23,7 +23,7 @@ import useMember from 'hooks/query/useMember';
 import { AccessTokenContext } from 'providers/AccessTokenProvider';
 import { MapItem } from 'types/common';
 import { ErrorResponse } from 'types/response';
-import { formatTimePrettier, formatTimeWithSecond, isPastDate } from 'utils/datetime';
+import { formatTimeWithSecond, isPastDate } from 'utils/datetime';
 import { isNullish } from 'utils/type';
 import useSettingSummary from '../../../hooks/query/useSettingSummary';
 import { GuestMapFormContext } from '../providers/GuestMapFormProvider';
@@ -73,7 +73,7 @@ const ReservationForm = ({ map }: Props) => {
         timePicker?.range.start ?? dayjs().tz()
       )}${DATE.TIMEZONE_OFFSET}`,
     },
-    { enabled: selectedSpaceId !== null }
+    { enabled: selectedSpaceId !== null && !isNaN(parseInt(selectedSpaceId)) }
   );
   const settingsSummary = getSettingsSummary.data?.data?.summary ?? '';
 
@@ -178,10 +178,10 @@ const ReservationForm = ({ map }: Props) => {
             />
           )}
           {spacesMap?.[Number(selectedSpaceId)] && (
-            <Styled.TimeFormMessageWrapper>
-              <Styled.TimeFormMessage fontWeight="bold">예약 가능 시간</Styled.TimeFormMessage>
-              <Styled.TimeFormMessage>{settingsSummary}</Styled.TimeFormMessage>
-            </Styled.TimeFormMessageWrapper>
+            <Styled.SettingSummaryWrapper>
+              <Styled.SettingSummary fontWeight="bold">예약 가능 시간</Styled.SettingSummary>
+              <Styled.SettingSummary>{settingsSummary}</Styled.SettingSummary>
+            </Styled.SettingSummaryWrapper>
           )}
         </Styled.InputWrapper>
 

--- a/frontend/src/pages/GuestReservation/GuestReservation.tsx
+++ b/frontend/src/pages/GuestReservation/GuestReservation.tsx
@@ -289,6 +289,8 @@ const GuestReservation = (): JSX.Element => {
               <MemberGuestReservationForm
                 isEditMode={isEditMode}
                 space={getSpace.data?.data}
+                spaceId={spaceId}
+                mapId={mapId}
                 reservation={reservation}
                 date={date}
                 userName={userName ?? ''}
@@ -298,6 +300,8 @@ const GuestReservation = (): JSX.Element => {
             ) : (
               <GuestReservationForm
                 isEditMode={isEditMode}
+                mapId={mapId}
+                spaceId={spaceId}
                 space={getSpace.data?.data}
                 reservation={reservation}
                 date={date}

--- a/frontend/src/pages/GuestReservation/units/GuestReservationForm.styles.ts
+++ b/frontend/src/pages/GuestReservation/units/GuestReservationForm.styles.ts
@@ -29,12 +29,15 @@ export const TimeFormMessageWrapper = styled.div`
   margin-top: 0.5rem;
 `;
 
-export const TimeFormMessage = styled.p`
+export const TimeFormMessage = styled.p<{ fontWeight?: string }>`
   left: 0.75rem;
-  bottom: -1rem;
+  bottom: -1.5rem;
   font-size: 0.75rem;
-  height: 1em;
+  height: 1.5em;
+  white-space: pre-line;
+  line-height: normal;
   color: ${({ theme }) => theme.gray[500]};
+  ${({ fontWeight }) => fontWeight && `font-weight: ${fontWeight}`};
 `;
 
 export const ButtonWrapper = styled.div`

--- a/frontend/src/pages/GuestReservation/units/GuestReservationForm.styles.ts
+++ b/frontend/src/pages/GuestReservation/units/GuestReservationForm.styles.ts
@@ -22,20 +22,17 @@ export const InputWrapper = styled.div`
   }
 `;
 
-export const TimeFormMessageWrapper = styled.div`
+export const SettingSummaryWrapper = styled.div`
   display: flex;
   flex-direction: column;
   gap: 0.25rem;
   margin-top: 0.5rem;
 `;
 
-export const TimeFormMessage = styled.p<{ fontWeight?: string }>`
-  left: 0.75rem;
-  bottom: -1.5rem;
-  font-size: 0.75rem;
-  height: 1.5em;
+export const SettingSummary = styled.p<{ fontWeight?: string }>`
   white-space: pre-line;
   line-height: normal;
+  font-size: 0.75rem;
   color: ${({ theme }) => theme.gray[500]};
   ${({ fontWeight }) => fontWeight && `font-weight: ${fontWeight}`};
 `;

--- a/frontend/src/pages/GuestReservation/units/GuestReservationForm.tsx
+++ b/frontend/src/pages/GuestReservation/units/GuestReservationForm.tsx
@@ -91,6 +91,7 @@ const GuestReservationForm = ({
       selectedDateTime: `${date}T${formatTimeWithSecond(range.start ?? dayjs().tz())}${
         DATE.TIMEZONE_OFFSET
       }`,
+      settingViewType: 'FLAT',
     },
     {}
   );

--- a/frontend/src/pages/GuestReservation/units/GuestReservationForm.tsx
+++ b/frontend/src/pages/GuestReservation/units/GuestReservationForm.tsx
@@ -168,10 +168,10 @@ const GuestReservationForm = ({
             onChange={onChange}
             onCloseOptions={onCloseOptions}
           />
-          <Styled.TimeFormMessageWrapper>
-            <Styled.TimeFormMessage fontWeight="bold">예약 가능 시간</Styled.TimeFormMessage>
-            <Styled.TimeFormMessage>{settingsSummary}</Styled.TimeFormMessage>
-          </Styled.TimeFormMessageWrapper>
+          <Styled.SettingSummaryWrapper>
+            <Styled.SettingSummary fontWeight="bold">예약 가능 시간</Styled.SettingSummary>
+            <Styled.SettingSummary>{settingsSummary}</Styled.SettingSummary>
+          </Styled.SettingSummaryWrapper>
         </Styled.InputWrapper>
         <Styled.InputWrapper>
           <Input

--- a/frontend/src/pages/GuestReservation/units/GuestReservationForm.tsx
+++ b/frontend/src/pages/GuestReservation/units/GuestReservationForm.tsx
@@ -1,3 +1,4 @@
+import dayjs from 'dayjs';
 import React, { ChangeEventHandler, useMemo } from 'react';
 import { ReactComponent as CalendarIcon } from 'assets/svg/calendar.svg';
 import Input from 'components/Input/Input';
@@ -14,15 +15,17 @@ import { Reservation, Space } from 'types/common';
 import {
   convertSettingTimeToMinutes,
   convertTimeToMinutes,
-  formatTimePrettier,
   formatTimeWithSecond,
   isPastDate,
 } from 'utils/datetime';
+import useSettingSummary from '../../../hooks/query/useSettingSummary';
 import { EditGuestReservationParams } from '../GuestReservation';
 import * as Styled from './GuestReservationForm.styles';
 
 interface Props {
   isEditMode: boolean;
+  mapId: number;
+  spaceId: number;
   space: Pick<Space, 'settings'>;
   reservation?: Reservation;
   date: string;
@@ -41,6 +44,8 @@ interface Form {
 
 const GuestReservationForm = ({
   isEditMode,
+  mapId,
+  spaceId,
   space,
   date,
   reservation,
@@ -78,6 +83,18 @@ const GuestReservationForm = ({
     initialStartTime: !!reservation ? new Date(reservation.startDateTime) : undefined,
     initialEndTime: !!reservation ? new Date(reservation.endDateTime) : undefined,
   });
+
+  const getSettingsSummary = useSettingSummary(
+    {
+      mapId,
+      spaceId,
+      selectedDateTime: `${date}T${formatTimeWithSecond(range.start ?? dayjs().tz())}${
+        DATE.TIMEZONE_OFFSET
+      }`,
+    },
+    {}
+  );
+  const settingsSummary = getSettingsSummary.data?.data?.summary ?? '';
 
   const [{ name, description, password }, onChangeForm] = useInputs<Form>({
     name: reservation?.name ?? '',
@@ -152,26 +169,8 @@ const GuestReservationForm = ({
             onCloseOptions={onCloseOptions}
           />
           <Styled.TimeFormMessageWrapper>
-            <Styled.TimeFormMessage>예약 가능 시간</Styled.TimeFormMessage>
-            {space.settings.map(
-              (
-                {
-                  settingStartTime,
-                  settingEndTime,
-                  reservationMaximumTimeUnit,
-                  reservationMinimumTimeUnit,
-                },
-                index
-              ) => {
-                return (
-                  <Styled.TimeFormMessage key={index}>
-                    {settingStartTime.slice(0, 5)} ~ {settingEndTime.slice(0, 5)}
-                    (최소 {formatTimePrettier(reservationMinimumTimeUnit)}, 최대{' '}
-                    {formatTimePrettier(reservationMaximumTimeUnit)})
-                  </Styled.TimeFormMessage>
-                );
-              }
-            )}
+            <Styled.TimeFormMessage fontWeight="bold">예약 가능 시간</Styled.TimeFormMessage>
+            <Styled.TimeFormMessage>{settingsSummary}</Styled.TimeFormMessage>
           </Styled.TimeFormMessageWrapper>
         </Styled.InputWrapper>
         <Styled.InputWrapper>

--- a/frontend/src/pages/GuestReservation/units/MemberGuestReservationForm.tsx
+++ b/frontend/src/pages/GuestReservation/units/MemberGuestReservationForm.tsx
@@ -1,3 +1,4 @@
+import dayjs from 'dayjs';
 import React, { ChangeEventHandler, useMemo } from 'react';
 import { ReactComponent as CalendarIcon } from 'assets/svg/calendar.svg';
 import Input from 'components/Input/Input';
@@ -13,16 +14,18 @@ import { Reservation, Space } from 'types/common';
 import {
   convertSettingTimeToMinutes,
   convertTimeToMinutes,
-  formatTimePrettier,
   formatTimeWithSecond,
   isPastDate,
 } from 'utils/datetime';
+import useSettingSummary from '../../../hooks/query/useSettingSummary';
 import { EditMemberGuestReservationParams } from '../GuestReservation';
 import * as Styled from './GuestReservationForm.styles';
 
 interface Props {
   isEditMode: boolean;
   space: Pick<Space, 'settings'>;
+  spaceId: number;
+  mapId: number;
   reservation?: Reservation;
   date: string;
   userName: string;
@@ -39,6 +42,8 @@ interface Form {
 
 const MemberGuestReservationForm = ({
   isEditMode,
+  mapId,
+  spaceId,
   space,
   date,
   reservation,
@@ -77,6 +82,18 @@ const MemberGuestReservationForm = ({
     initialStartTime: !!reservation ? new Date(reservation.startDateTime) : undefined,
     initialEndTime: !!reservation ? new Date(reservation.endDateTime) : undefined,
   });
+
+  const getSettingsSummary = useSettingSummary(
+    {
+      mapId,
+      spaceId,
+      selectedDateTime: `${date}T${formatTimeWithSecond(range.start ?? dayjs().tz())}${
+        DATE.TIMEZONE_OFFSET
+      }`,
+    },
+    {}
+  );
+  const settingsSummary = getSettingsSummary.data?.data?.summary ?? '';
 
   const [{ description }, onChangeForm] = useInputs<Form>({
     description: reservation?.description ?? '',
@@ -140,24 +157,8 @@ const MemberGuestReservationForm = ({
             onCloseOptions={onCloseOptions}
           />
           <Styled.TimeFormMessageWrapper>
-            <Styled.TimeFormMessage>예약 가능 시간</Styled.TimeFormMessage>
-            {space.settings.map(
-              (
-                {
-                  settingStartTime,
-                  settingEndTime,
-                  reservationMaximumTimeUnit,
-                  reservationMinimumTimeUnit,
-                },
-                index
-              ) => (
-                <Styled.TimeFormMessage key={index}>
-                  {settingStartTime.slice(0, 5)} ~ {settingEndTime.slice(0, 5)}
-                  (최소 {formatTimePrettier(reservationMinimumTimeUnit)}, 최대{' '}
-                  {formatTimePrettier(reservationMaximumTimeUnit)})
-                </Styled.TimeFormMessage>
-              )
-            )}
+            <Styled.TimeFormMessage fontWeight="bold">예약 가능 시간</Styled.TimeFormMessage>
+            <Styled.TimeFormMessage>{settingsSummary}</Styled.TimeFormMessage>
           </Styled.TimeFormMessageWrapper>
         </Styled.InputWrapper>
       </Styled.Section>

--- a/frontend/src/pages/GuestReservation/units/MemberGuestReservationForm.tsx
+++ b/frontend/src/pages/GuestReservation/units/MemberGuestReservationForm.tsx
@@ -90,6 +90,7 @@ const MemberGuestReservationForm = ({
       selectedDateTime: `${date}T${formatTimeWithSecond(range.start ?? dayjs().tz())}${
         DATE.TIMEZONE_OFFSET
       }`,
+      settingViewType: 'FLAT',
     },
     {}
   );

--- a/frontend/src/pages/GuestReservation/units/MemberGuestReservationForm.tsx
+++ b/frontend/src/pages/GuestReservation/units/MemberGuestReservationForm.tsx
@@ -156,10 +156,10 @@ const MemberGuestReservationForm = ({
             onChange={onChange}
             onCloseOptions={onCloseOptions}
           />
-          <Styled.TimeFormMessageWrapper>
-            <Styled.TimeFormMessage fontWeight="bold">예약 가능 시간</Styled.TimeFormMessage>
-            <Styled.TimeFormMessage>{settingsSummary}</Styled.TimeFormMessage>
-          </Styled.TimeFormMessageWrapper>
+          <Styled.SettingSummaryWrapper>
+            <Styled.SettingSummary fontWeight="bold">예약 가능 시간</Styled.SettingSummary>
+            <Styled.SettingSummary>{settingsSummary}</Styled.SettingSummary>
+          </Styled.SettingSummaryWrapper>
         </Styled.InputWrapper>
       </Styled.Section>
       <Styled.ButtonWrapper>

--- a/frontend/src/pages/ManagerReservation/ManagerReservation.tsx
+++ b/frontend/src/pages/ManagerReservation/ManagerReservation.tsx
@@ -150,6 +150,7 @@ const ManagerReservation = (): JSX.Element => {
           </Styled.PageHeader>
           <ManagerReservationForm
             isEditMode={isEditMode}
+            mapId={mapId}
             space={space}
             reservation={reservation}
             date={date}

--- a/frontend/src/pages/ManagerReservation/units/ManagerReservationForm.styles.ts
+++ b/frontend/src/pages/ManagerReservation/units/ManagerReservationForm.styles.ts
@@ -29,20 +29,17 @@ export const ButtonWrapper = styled.div`
   z-index: ${Z_INDEX.RESERVATION_BUTTON};
 `;
 
-export const TimeFormMessageWrapper = styled.div`
+export const SettingSummaryWrapper = styled.div`
   display: flex;
   flex-direction: column;
   gap: 0.25rem;
   margin-top: 0.5rem;
 `;
 
-export const TimeFormMessage = styled.p<{ fontWeight?: string }>`
-  left: 0.75rem;
-  bottom: -1.5rem;
-  font-size: 0.75rem;
-  height: 1.5em;
+export const SettingSummary = styled.p<{ fontWeight?: string }>`
   white-space: pre-line;
   line-height: normal;
+  font-size: 0.75rem;
   color: ${({ theme }) => theme.gray[500]};
   ${({ fontWeight }) => fontWeight && `font-weight: ${fontWeight}`};
 `;

--- a/frontend/src/pages/ManagerReservation/units/ManagerReservationForm.styles.ts
+++ b/frontend/src/pages/ManagerReservation/units/ManagerReservationForm.styles.ts
@@ -36,10 +36,13 @@ export const TimeFormMessageWrapper = styled.div`
   margin-top: 0.5rem;
 `;
 
-export const TimeFormMessage = styled.p`
+export const TimeFormMessage = styled.p<{ fontWeight?: string }>`
   left: 0.75rem;
-  bottom: -1rem;
+  bottom: -1.5rem;
   font-size: 0.75rem;
-  height: 1em;
+  height: 1.5em;
+  white-space: pre-line;
+  line-height: normal;
   color: ${({ theme }) => theme.gray[500]};
+  ${({ fontWeight }) => fontWeight && `font-weight: ${fontWeight}`};
 `;

--- a/frontend/src/pages/ManagerReservation/units/ManagerReservationForm.tsx
+++ b/frontend/src/pages/ManagerReservation/units/ManagerReservationForm.tsx
@@ -1,5 +1,5 @@
 import dayjs from 'dayjs';
-import React, { ChangeEventHandler, useMemo } from 'react';
+import React, { ChangeEventHandler, useMemo, useState } from 'react';
 import { ReactComponent as CalendarIcon } from 'assets/svg/calendar.svg';
 import Button from 'components/Button/Button';
 import Input from 'components/Input/Input';
@@ -179,11 +179,10 @@ const ManagerReservationForm = ({
             onChange={onChange}
             onCloseOptions={onCloseOptions}
           />
-
-          <Styled.TimeFormMessageWrapper>
-            <Styled.TimeFormMessage fontWeight="bold">예약 가능 시간</Styled.TimeFormMessage>
-            <Styled.TimeFormMessage>{settingsSummary}</Styled.TimeFormMessage>
-          </Styled.TimeFormMessageWrapper>
+          <Styled.SettingSummaryWrapper>
+            <Styled.SettingSummary fontWeight="bold">예약 가능 시간</Styled.SettingSummary>
+            <Styled.SettingSummary>{settingsSummary}</Styled.SettingSummary>
+          </Styled.SettingSummaryWrapper>
         </Styled.InputWrapper>
 
         {isEditMode || (

--- a/frontend/src/pages/ManagerReservation/units/ManagerReservationForm.tsx
+++ b/frontend/src/pages/ManagerReservation/units/ManagerReservationForm.tsx
@@ -88,6 +88,7 @@ const ManagerReservationForm = ({
       selectedDateTime: `${date}T${formatTimeWithSecond(range.start ?? dayjs().tz())}${
         DATE.TIMEZONE_OFFSET
       }`,
+      settingViewType: 'FLAT',
     },
     {}
   );

--- a/frontend/src/pages/ManagerSpaceEditor/ManagerSpaceEditor.tsx
+++ b/frontend/src/pages/ManagerSpaceEditor/ManagerSpaceEditor.tsx
@@ -109,6 +109,8 @@ const ManagerSpaceEditor = (): JSX.Element => {
     },
   });
 
+  // TODO: handleCreateSpace, handleUpdateSpace 시 priorityOrder 고려해서 request 발송
+  // TODO:
   const handleCreateSpace = (data: Omit<PostManagerSpaceParams, 'mapId'>) =>
     createSpace.mutate({ mapId: Number(mapId), ...data });
 

--- a/frontend/src/pages/ManagerSpaceEditor/data.ts
+++ b/frontend/src/pages/ManagerSpaceEditor/data.ts
@@ -23,6 +23,7 @@ export interface SpaceFormValue {
       saturday: boolean;
       sunday: boolean;
     };
+    priorityOrder: number;
   }[];
 }
 
@@ -45,6 +46,7 @@ export const initialSpaceFormValueSetting = {
   reservationMinimumTimeUnit: 10,
   reservationMaximumTimeUnit: 120,
   enabledDayOfWeek: initialEnabledDayOfWeek,
+  priorityOrder: 0,
 };
 
 export const initialSpaceFormValue: Omit<SpaceFormValue, 'area'> = {

--- a/frontend/src/pages/ManagerSpaceEditor/providers/SpaceFormProvider.tsx
+++ b/frontend/src/pages/ManagerSpaceEditor/providers/SpaceFormProvider.tsx
@@ -110,7 +110,6 @@ const SpaceFormProvider = ({ children }: Props): JSX.Element => {
     for (let i = 0; i < values.settings.length; i++) {
       const setting = values.settings[i];
       setting['priorityOrder'] = values.settings.length - (i + 1);
-      console.log('setting :', setting);
     }
 
     return {

--- a/frontend/src/pages/ManagerSpaceEditor/providers/SpaceFormProvider.tsx
+++ b/frontend/src/pages/ManagerSpaceEditor/providers/SpaceFormProvider.tsx
@@ -107,6 +107,12 @@ const SpaceFormProvider = ({ children }: Props): JSX.Element => {
   const getRequestValues = () => {
     const todayDate = formatDate(new Date());
 
+    for (let i = 0; i < values.settings.length; i++) {
+      const setting = values.settings[i];
+      setting.priorityOrder = values.settings.length - (i + 1);
+      console.log('setting :', setting);
+    }
+
     return {
       space: {
         ...values,

--- a/frontend/src/pages/ManagerSpaceEditor/providers/SpaceFormProvider.tsx
+++ b/frontend/src/pages/ManagerSpaceEditor/providers/SpaceFormProvider.tsx
@@ -109,7 +109,7 @@ const SpaceFormProvider = ({ children }: Props): JSX.Element => {
 
     for (let i = 0; i < values.settings.length; i++) {
       const setting = values.settings[i];
-      setting.priorityOrder = values.settings.length - (i + 1);
+      setting['priorityOrder'] = values.settings.length - (i + 1);
       console.log('setting :', setting);
     }
 

--- a/frontend/src/pages/ManagerSpaceEditor/units/Form.styles.ts
+++ b/frontend/src/pages/ManagerSpaceEditor/units/Form.styles.ts
@@ -32,6 +32,26 @@ export const TitleContainer = styled.div`
   margin-bottom: 1rem;
 `;
 
+export const InfoMessageWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  margin-top: 0.5rem;
+  justify-content: space-between;
+  margin-bottom: 2rem;
+`;
+
+export const InfoMessage = styled.p<{ fontWeight?: string }>`
+  left: 0.75rem;
+  bottom: -1.5rem;
+  font-size: 0.75rem;
+  height: 1.5em;
+  white-space: pre-line;
+  line-height: normal;
+  color: ${({ theme }) => theme.gray[500]};
+  ${({ fontWeight }) => fontWeight && `font-weight: ${fontWeight}`};
+`;
+
 export const ContentsContainer = styled.div`
   display: flex;
   flex-direction: column;

--- a/frontend/src/pages/ManagerSpaceEditor/units/Form.tsx
+++ b/frontend/src/pages/ManagerSpaceEditor/units/Form.tsx
@@ -17,7 +17,7 @@ import useFormContext from 'hooks/useFormContext';
 import { Area, Color, ManagerSpace, MapElement } from 'types/common';
 import { SpaceEditorMode as Mode } from 'types/editor';
 import { generateSvg, MapSvgData } from 'utils/generateSvg';
-import { colorSelectOptions, timeUnits } from '../data';
+import { colorSelectOptions, initialSpaceFormValueSetting, timeUnits } from '../data';
 import { SpaceFormContext } from '../providers/SpaceFormProvider';
 import * as Styled from './Form.styles';
 import FormDayOfWeekSelect from './FormDayOfWeekSelect';

--- a/frontend/src/pages/ManagerSpaceEditor/units/Form.tsx
+++ b/frontend/src/pages/ManagerSpaceEditor/units/Form.tsx
@@ -1,4 +1,11 @@
-import React, { Dispatch, FormEventHandler, SetStateAction, useEffect, useRef } from 'react';
+import React, {
+  Dispatch,
+  FormEventHandler,
+  SetStateAction,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
 import {
   DeleteManagerSpaceParams,
   PostManagerSpaceParams,
@@ -17,13 +24,13 @@ import useFormContext from 'hooks/useFormContext';
 import { Area, Color, ManagerSpace, MapElement } from 'types/common';
 import { SpaceEditorMode as Mode } from 'types/editor';
 import { generateSvg, MapSvgData } from 'utils/generateSvg';
-import { colorSelectOptions, initialSpaceFormValueSetting, timeUnits } from '../data';
+import { colorSelectOptions, timeUnits } from '../data';
 import { SpaceFormContext } from '../providers/SpaceFormProvider';
 import * as Styled from './Form.styles';
-import { InfoMessage, InfoMessageWrapper } from './Form.styles';
 import FormDayOfWeekSelect from './FormDayOfWeekSelect';
 import FormTimeUnitSelect from './FormTimeUnitSelect';
 import Preset from './Preset';
+import SettingSummaryPopup from './SettingSummaryPopup';
 
 interface Props {
   modeState: [Mode, Dispatch<SetStateAction<Mode>>];
@@ -49,6 +56,7 @@ const Form = ({
   const nameInputRef = useRef<HTMLInputElement | null>(null);
 
   const [mode, setMode] = modeState;
+  const [settingSummaryPopupOpen, setSettingSummaryPopupOpen] = useState(false);
 
   const {
     values,
@@ -186,12 +194,31 @@ const Form = ({
       <Styled.Section>
         <Styled.TitleContainer>
           <Styled.Title>예약 조건</Styled.Title>
+          {selectedSpaceId != null && (
+            <Button
+              size="small"
+              type="button"
+              shape="round"
+              variant="inverse"
+              onClick={() => setSettingSummaryPopupOpen(true)}
+            >
+              현재 적용된 예약 조건 보기
+            </Button>
+          )}
         </Styled.TitleContainer>
         <Styled.InfoMessageWrapper>
           <Styled.InfoMessage>
             예약 조건이 서로 겹칠 시, 뒷 순서의 예약 조건이 앞 순서의 예약 조건을 덮어씁니다.
           </Styled.InfoMessage>
         </Styled.InfoMessageWrapper>
+        {settingSummaryPopupOpen && selectedSpaceId != null && (
+          <SettingSummaryPopup
+            open={settingSummaryPopupOpen}
+            onClose={() => setSettingSummaryPopupOpen(false)}
+            mapId={Number(window.location.pathname.split('/', 3).pop())}
+            spaceId={selectedSpaceId}
+          />
+        )}
 
         <Styled.TabList>
           {values.settings.map((_, index) => (

--- a/frontend/src/pages/ManagerSpaceEditor/units/Form.tsx
+++ b/frontend/src/pages/ManagerSpaceEditor/units/Form.tsx
@@ -1,4 +1,4 @@
-import { Dispatch, FormEventHandler, SetStateAction, useEffect, useRef } from 'react';
+import React, { Dispatch, FormEventHandler, SetStateAction, useEffect, useRef } from 'react';
 import {
   DeleteManagerSpaceParams,
   PostManagerSpaceParams,
@@ -20,6 +20,7 @@ import { generateSvg, MapSvgData } from 'utils/generateSvg';
 import { colorSelectOptions, initialSpaceFormValueSetting, timeUnits } from '../data';
 import { SpaceFormContext } from '../providers/SpaceFormProvider';
 import * as Styled from './Form.styles';
+import { InfoMessage, InfoMessageWrapper } from './Form.styles';
 import FormDayOfWeekSelect from './FormDayOfWeekSelect';
 import FormTimeUnitSelect from './FormTimeUnitSelect';
 import Preset from './Preset';
@@ -186,6 +187,11 @@ const Form = ({
         <Styled.TitleContainer>
           <Styled.Title>예약 조건</Styled.Title>
         </Styled.TitleContainer>
+        <Styled.InfoMessageWrapper>
+          <Styled.InfoMessage>
+            예약 조건이 서로 겹칠 시, 뒷 순서의 예약 조건이 앞 순서의 예약 조건을 덮어씁니다.
+          </Styled.InfoMessage>
+        </Styled.InfoMessageWrapper>
 
         <Styled.TabList>
           {values.settings.map((_, index) => (

--- a/frontend/src/pages/ManagerSpaceEditor/units/Preset.tsx
+++ b/frontend/src/pages/ManagerSpaceEditor/units/Preset.tsx
@@ -72,7 +72,7 @@ const Preset = (): JSX.Element => {
       ...values,
       settings: values.settings.map((setting, index) => {
         if (index === selectedSettingIndex) {
-          return rest;
+          return { ...rest, priorityOrder: 0 };
         }
 
         return setting;

--- a/frontend/src/pages/ManagerSpaceEditor/units/SettingSummaryPopup.styles.ts
+++ b/frontend/src/pages/ManagerSpaceEditor/units/SettingSummaryPopup.styles.ts
@@ -1,0 +1,13 @@
+import styled from 'styled-components';
+
+export const SettingSummaryPopupWrapper = styled.div`
+  padding: 2rem 3rem;
+`;
+
+export const SettingSummary = styled.p<{ fontWeight?: string }>`
+  white-space: pre-line;
+  line-height: normal;
+  font-size: 0.75rem;
+  color: ${({ theme }) => theme.gray[500]};
+  ${({ fontWeight }) => fontWeight && `font-weight: ${fontWeight}`};
+`;

--- a/frontend/src/pages/ManagerSpaceEditor/units/SettingSummaryPopup.tsx
+++ b/frontend/src/pages/ManagerSpaceEditor/units/SettingSummaryPopup.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import Modal from '../../../components/Modal/Modal';
+import SummaryModal from '../../../components/Modal/SummaryModal';
+import useSettingSummary from '../../../hooks/query/useSettingSummary';
+import * as Styled from './SettingSummaryPopup.styles';
+
+interface SettingSummaryProps {
+  mapId: number;
+  spaceId: number;
+  open: boolean;
+  onClose: () => void;
+}
+
+const SettingSummaryPopup = ({
+  mapId,
+  spaceId,
+  open,
+  onClose,
+}: SettingSummaryProps): JSX.Element => {
+  const getSettingsSummary = useSettingSummary(
+    {
+      mapId,
+      spaceId,
+      selectedDateTime: null,
+      settingViewType: 'FLAT',
+    },
+    {}
+  );
+  const settingsSummary = getSettingsSummary.data?.data?.summary ?? '';
+
+  return (
+    <SummaryModal open={open} onClose={onClose} showCloseButton={true} isClosableDimmer={true}>
+      <Styled.SettingSummaryPopupWrapper>
+        <Styled.SettingSummary fontWeight="bold">{settingsSummary}</Styled.SettingSummary>
+      </Styled.SettingSummaryPopupWrapper>
+    </SummaryModal>
+  );
+};
+
+export default SettingSummaryPopup;

--- a/frontend/src/types/common.ts
+++ b/frontend/src/types/common.ts
@@ -112,6 +112,7 @@ export interface SpaceSetting {
     saturday: boolean;
     sunday: boolean;
   };
+  priorityOrder: number;
 }
 
 export interface Preset {

--- a/frontend/src/types/response.ts
+++ b/frontend/src/types/response.ts
@@ -1,5 +1,4 @@
 import {
-  Area,
   Emoji,
   ManagerSpaceAPI,
   MapItem,
@@ -53,6 +52,7 @@ export interface QueryManagerMapsSuccess {
 export interface QueryManagerSpaceReservationsSuccess {
   reservations: Reservation[];
 }
+
 export interface QueryManagerMapReservationsSuccess {
   data: SpaceReservation[];
 }
@@ -90,4 +90,8 @@ export interface QueryMemberReservationsSuccess {
   data: MemberReservation[];
   hasNext: boolean;
   pageNumber: number;
+}
+
+export interface QuerySettingSummarySuccess {
+  summary: string;
 }


### PR DESCRIPTION
## 구현 기능
### 공간 수정 화면
![image](https://user-images.githubusercontent.com/58401309/231222125-04f753c4-72ce-43c2-834d-0c49a745d5fd.png)

### 공간 수정 화면 > 현재 적용된 예약 조건 보기 클릭 > 모달
<img width="1840" alt="스크린샷 2023-04-12 오전 12 42 50" src="https://user-images.githubusercontent.com/58401309/231221795-a2a863a9-ad60-4a84-8cf5-245a4d97cb53.png">

### 예약 화면
![image](https://user-images.githubusercontent.com/58401309/231222605-d4045257-abd8-4803-8f1f-de3691a0f6d4.png)

### 예약 수정 화면
![image](https://user-images.githubusercontent.com/58401309/231222638-e7cd4eae-5a08-4c53-8e39-e437be1e4103.png)

### 공간 관리자 예약 수정 대행 화면
![image](https://user-images.githubusercontent.com/58401309/231222681-08f2867e-87e2-4aca-b61d-bc99ade80fc2.png)

- 공간 조건이 이제 서로 겹칠 수 있습니다
- 우선 순위가 높은 (=priorityOrder 가 낮은) 조건이 우선 순위가 낮은 조건을 덮어씁니다
- 사용자가 보는 조건은 덮어써진 조건을 봅니다
- 사용자가 보는 조건은 TimePicker에서 선택된 요일에 관련된 조건만 봅니다
- 공간 관리자는 공간 관리 페이지에서 `공간 수정 화면 > 현재 적용된 예약 조건 보기 클릭 > 모달` 을 통해 실제 적용 된 조건들 확인이 가능합니다

## 공유하고 싶은 내용
- #963 BE 작업 참고 

Close #960 
Close #961 
