### PR TITLE
feat: 마이페이지 진입점 만들기

### DIFF
--- a/frontend/src/components/Header/Header.tsx
+++ b/frontend/src/components/Header/Header.tsx
@@ -58,7 +58,11 @@ const Header = ({ onClickLogin }: HeaderProps): JSX.Element => {
         <Styled.ButtonContainer>
           {accessToken ? (
             <>
-              <Styled.TextLink to={PATH.MANAGER_MAP_LIST}>마이 페이지</Styled.TextLink>
+              <Styled.TextLink
+                to={location.pathname.includes('/guest') ? PATH.GUEST_MAIN : PATH.MANAGER_MAP_LIST}
+              >
+                마이 페이지
+              </Styled.TextLink>
               <Styled.TextButton variant="text" onClick={handleLogout}>
                 로그아웃
               </Styled.TextButton>

--- a/frontend/src/components/Header/Header.tsx
+++ b/frontend/src/components/Header/Header.tsx
@@ -57,9 +57,12 @@ const Header = ({ onClickLogin }: HeaderProps): JSX.Element => {
         </Styled.HeaderLink>
         <Styled.ButtonContainer>
           {accessToken ? (
-            <Styled.TextButton variant="text" onClick={handleLogout}>
-              로그아웃
-            </Styled.TextButton>
+            <>
+              <Styled.TextLink to={PATH.MANAGER_MAP_LIST}>마이 페이지</Styled.TextLink>
+              <Styled.TextButton variant="text" onClick={handleLogout}>
+                로그아웃
+              </Styled.TextButton>
+            </>
           ) : (
             <>
               <Styled.TextLink to={PATH.GUEST_NON_LOGIN_RESERVATION_SEARCH}>


### PR DESCRIPTION
## 구현 기능
- 예약자 마이 페이지와 관리자 마이페이지 진입점을 라우트에 `/guest`를 포함하는지 여부에 따라 다르게 만들었습니다.
<img width="1007" alt="image" src="https://github.com/woowacourse-teams/2021-zzimkkong/assets/56749516/e172cf7c-9377-4fe4-83ce-15fc226b91b7">

<img width="1677" alt="image" src="https://github.com/woowacourse-teams/2021-zzimkkong/assets/56749516/151eb7c7-a07e-4472-b784-ebc4037a1bd2">


## 논의하고 싶은 내용
-  예약자와 관리자 진입점의 차이를 `/guest` 로 보았습니다. 괜찮을까요?

Close #944 