### PR TITLE
refactor: 맵 리스트를 API 명세에 맞게 마이그레이션

### DIFF
--- a/frontend/src/api-v2/apiv2.ts
+++ b/frontend/src/api-v2/apiv2.ts
@@ -1,0 +1,53 @@
+import axios, { AxiosError } from 'axios';
+import { history } from 'App';
+import PATH from 'constants/path';
+import { LOCAL_STORAGE_KEY } from 'constants/storage';
+import { ErrorResponse } from 'types/response';
+import { getLocalStorageItem, removeLocalStorageItem } from 'utils/localStorage';
+
+const apiV2 = axios.create({
+  baseURL: 'http://localhost:7742',
+  headers: {
+    'Content-type': 'application/json',
+  },
+});
+
+apiV2.interceptors.request.use(
+  (config) => {
+    const token = getLocalStorageItem({
+      key: LOCAL_STORAGE_KEY.ACCESS_TOKEN,
+      defaultValue: '',
+    });
+
+    if (typeof token !== 'string' || !token) return config;
+
+    config.headers = {
+      'Content-type': 'application/json',
+      Authorization: `Bearer ${token}`,
+    };
+
+    return config;
+  },
+
+  (error) => {
+    return Promise.reject(error);
+  }
+);
+
+apiV2.interceptors.response.use(
+  (response) => {
+    return response;
+  },
+
+  (error: AxiosError<ErrorResponse>) => {
+    if (error?.response?.status === 401) {
+      removeLocalStorageItem({ key: LOCAL_STORAGE_KEY.ACCESS_TOKEN });
+
+      history.push(PATH.LOGIN);
+    }
+
+    return Promise.reject(error);
+  }
+);
+
+export default apiV2;

--- a/frontend/src/api-v2/managerMap.ts
+++ b/frontend/src/api-v2/managerMap.ts
@@ -1,0 +1,7 @@
+import { AxiosResponse } from 'axios';
+import { QueryFunction } from 'react-query';
+import { QueryManagerMapsSuccessV2 } from 'types/response-v2';
+import apiV2 from './apiv2';
+
+export const queryManagerMapsV2: QueryFunction<AxiosResponse<QueryManagerMapsSuccessV2>> = () =>
+  apiV2.get('/api/maps');

--- a/frontend/src/api-v2/managerMap.ts
+++ b/frontend/src/api-v2/managerMap.ts
@@ -3,5 +3,12 @@ import { QueryFunction } from 'react-query';
 import { QueryManagerMapsSuccessV2 } from 'types/response-v2';
 import apiV2 from './apiv2';
 
+interface DeleteMapParamsV2 {
+  mapId: number;
+}
+
 export const queryManagerMapsV2: QueryFunction<AxiosResponse<QueryManagerMapsSuccessV2>> = () =>
   apiV2.get('/api/maps');
+
+export const deleteMapV2 = ({ mapId }: DeleteMapParamsV2): Promise<AxiosResponse<never>> =>
+  apiV2.delete(`/api/maps/${mapId}`);

--- a/frontend/src/components/ManagerIconButtons/SlackNotiButton.tsx
+++ b/frontend/src/components/ManagerIconButtons/SlackNotiButton.tsx
@@ -10,13 +10,15 @@ import Modal from 'components/Modal/Modal';
 import MESSAGE from 'constants/message';
 import useInput from 'hooks/useInput';
 import useSlackWebhookUrl from 'pages/ManagerMapDetail/hooks/useSlackWebhookUrl';
-import { ErrorResponse, QueryManagerMapSuccess } from 'types/response';
+import { ErrorResponse } from 'types/response';
+import { QueryManagerMapSuccessV2 } from 'types/response-v2';
 import * as Styled from './ManagerIconButton.styled';
 
 interface Props extends ComponentProps<typeof IconButton> {
-  map: QueryManagerMapSuccess;
+  map: QueryManagerMapSuccessV2;
 }
 
+// TODO: 슬랙 API 개발시 이부분 API 요청 변경해야함.
 const SlackNotiButton = ({ map, ...props }: Props): JSX.Element => {
   const [isModalOpened, setIsModalOpened] = useState(false);
   const [slackUrl, onChangeSlackUrl, setSlackUrl] = useInput();

--- a/frontend/src/components/MapListItem/MapListItem.tsx
+++ b/frontend/src/components/MapListItem/MapListItem.tsx
@@ -1,11 +1,11 @@
 import { ReactNode } from 'react';
 import { theme } from 'App.styles';
 import { ReactComponent as CaretIcon } from 'assets/svg/caret-right.svg';
-import { MapItemResponse } from 'types/response';
+import { MapItemResponseV2 } from 'types/response-v2';
 import * as Styled from './MapListItem.styles';
 
 export interface Props {
-  map: MapItemResponse;
+  map: MapItemResponseV2;
   control?: ReactNode;
   onClick?: () => void;
 }

--- a/frontend/src/hooks/query-v2/useManagerMapsV2.ts
+++ b/frontend/src/hooks/query-v2/useManagerMapsV2.ts
@@ -1,0 +1,17 @@
+import { AxiosError, AxiosResponse } from 'axios';
+import { QueryKey, useQuery, UseQueryOptions, UseQueryResult } from 'react-query';
+import { queryManagerMapsV2 } from 'api-v2/managerMap';
+import { ErrorResponse } from 'types/response';
+import { QueryManagerMapsSuccessV2 } from 'types/response-v2';
+
+const useManagerMapsV2 = <TData = AxiosResponse<QueryManagerMapsSuccessV2>>(
+  options?: UseQueryOptions<
+    AxiosResponse<QueryManagerMapsSuccessV2>,
+    AxiosError<ErrorResponse>,
+    TData,
+    [QueryKey]
+  >
+): UseQueryResult<TData, AxiosError<ErrorResponse>> =>
+  useQuery(['getManagerMapsV2'], queryManagerMapsV2, { ...options });
+
+export default useManagerMapsV2;

--- a/frontend/src/hooks/query/useManagerMaps.ts
+++ b/frontend/src/hooks/query/useManagerMaps.ts
@@ -1,17 +1,16 @@
 import { AxiosError, AxiosResponse } from 'axios';
 import { QueryKey, useQuery, UseQueryOptions, UseQueryResult } from 'react-query';
-import { queryManagerMapsV2 } from 'api-v2/managerMap';
-import { ErrorResponse } from 'types/response';
-import { QueryManagerMapsSuccessV2 } from 'types/response-v2';
+import { queryManagerMaps } from 'api/managerMap';
+import { ErrorResponse, QueryManagerMapsSuccess } from 'types/response';
 
-const useManagerMaps = <TData = AxiosResponse<QueryManagerMapsSuccessV2>>(
+const useManagerMaps = <TData = AxiosResponse<QueryManagerMapsSuccess>>(
   options?: UseQueryOptions<
-    AxiosResponse<QueryManagerMapsSuccessV2>,
+    AxiosResponse<QueryManagerMapsSuccess>,
     AxiosError<ErrorResponse>,
     TData,
     [QueryKey]
   >
 ): UseQueryResult<TData, AxiosError<ErrorResponse>> =>
-  useQuery(['getManagerMaps'], queryManagerMapsV2, { ...options });
+  useQuery(['getManagerMaps'], queryManagerMaps, options);
 
 export default useManagerMaps;

--- a/frontend/src/hooks/query/useManagerMaps.ts
+++ b/frontend/src/hooks/query/useManagerMaps.ts
@@ -1,16 +1,17 @@
 import { AxiosError, AxiosResponse } from 'axios';
 import { QueryKey, useQuery, UseQueryOptions, UseQueryResult } from 'react-query';
-import { queryManagerMaps } from 'api/managerMap';
-import { ErrorResponse, QueryManagerMapsSuccess } from 'types/response';
+import { queryManagerMapsV2 } from 'api-v2/managerMap';
+import { ErrorResponse } from 'types/response';
+import { QueryManagerMapsSuccessV2 } from 'types/response-v2';
 
-const useManagerMaps = <TData = AxiosResponse<QueryManagerMapsSuccess>>(
+const useManagerMaps = <TData = AxiosResponse<QueryManagerMapsSuccessV2>>(
   options?: UseQueryOptions<
-    AxiosResponse<QueryManagerMapsSuccess>,
+    AxiosResponse<QueryManagerMapsSuccessV2>,
     AxiosError<ErrorResponse>,
     TData,
     [QueryKey]
   >
 ): UseQueryResult<TData, AxiosError<ErrorResponse>> =>
-  useQuery(['getManagerMaps'], queryManagerMaps, options);
+  useQuery(['getManagerMaps'], queryManagerMapsV2, { ...options });
 
 export default useManagerMaps;

--- a/frontend/src/pages/ManagerMapList/ManagerMapList.tsx
+++ b/frontend/src/pages/ManagerMapList/ManagerMapList.tsx
@@ -2,7 +2,7 @@ import { AxiosError } from 'axios';
 import React from 'react';
 import { useMutation } from 'react-query';
 import { useHistory } from 'react-router-dom';
-import { deleteMap } from 'api/managerMap';
+import { deleteMapV2 } from 'api-v2/managerMap';
 import { ReactComponent as DeleteIcon } from 'assets/svg/delete.svg';
 import Header from 'components/Header/Header';
 import IconButton from 'components/IconButton/IconButton';
@@ -25,7 +25,7 @@ const ManagerMapList = (): JSX.Element => {
     },
   });
 
-  const removeMap = useMutation(deleteMap, {
+  const removeMap = useMutation(deleteMapV2, {
     onSuccess: () => {
       alert(MESSAGE.MANAGER_MAIN.MAP_DELETED);
     },

--- a/frontend/src/pages/ManagerMapList/ManagerMapList.tsx
+++ b/frontend/src/pages/ManagerMapList/ManagerMapList.tsx
@@ -12,14 +12,14 @@ import TabLayout from 'components/TabLayout/TabLayout';
 import MESSAGE from 'constants/message';
 import PATH, { HREF } from 'constants/path';
 import { TAB_LABEL, TAB_LIST, TAB_PATH_FOR_LABEL } from 'constants/tab';
-import useManagerMaps from 'hooks/query/useManagerMaps';
+import useManagerMapsV2 from 'hooks/query-v2/useManagerMapsV2';
 import { ErrorResponse } from 'types/response';
 import * as Styled from './ManagerMapList.styles';
 
 const ManagerMapList = (): JSX.Element => {
   const history = useHistory();
 
-  const { data: maps } = useManagerMaps({
+  const { data: maps } = useManagerMapsV2({
     onError: (error: AxiosError<ErrorResponse>) => {
       alert(error.response?.data.message ?? MESSAGE.MANAGER_MAIN.UNEXPECTED_GET_DATA_ERROR);
     },

--- a/frontend/src/pages/ManagerMapList/ManagerMapList.tsx
+++ b/frontend/src/pages/ManagerMapList/ManagerMapList.tsx
@@ -49,8 +49,6 @@ const ManagerMapList = (): JSX.Element => {
         defaultTabLabel={TAB_LABEL.MANAGER}
         onClick={(selectedTab) => history.push(TAB_PATH_FOR_LABEL[selectedTab])}
       >
-        <MemberInfo />
-
         <Styled.MapListContainer>
           <Styled.MapListTitle>나의 맵</Styled.MapListTitle>
 

--- a/frontend/src/pages/ManagerMapList/ManagerMapList.tsx
+++ b/frontend/src/pages/ManagerMapList/ManagerMapList.tsx
@@ -6,11 +6,8 @@ import { deleteMap } from 'api/managerMap';
 import { ReactComponent as DeleteIcon } from 'assets/svg/delete.svg';
 import Header from 'components/Header/Header';
 import IconButton from 'components/IconButton/IconButton';
-import MapNoticeButton from 'components/ManagerIconButtons/MapNoticeButton';
-import ShareLinkButton from 'components/ManagerIconButtons/ShareLinkButton';
 import SlackNotiButton from 'components/ManagerIconButtons/SlackNotiButton';
 import MapListItem from 'components/MapListItem/MapListItem';
-import MemberInfo from 'components/MemberInfo/MemberInfo';
 import TabLayout from 'components/TabLayout/TabLayout';
 import MESSAGE from 'constants/message';
 import PATH, { HREF } from 'constants/path';
@@ -50,7 +47,7 @@ const ManagerMapList = (): JSX.Element => {
         onClick={(selectedTab) => history.push(TAB_PATH_FOR_LABEL[selectedTab])}
       >
         <Styled.MapListContainer>
-          <Styled.MapListTitle>나의 맵</Styled.MapListTitle>
+          <Styled.MapListTitle>맵 리스트</Styled.MapListTitle>
 
           <Styled.MapList role="list">
             {maps?.data.maps.map((map) => (
@@ -60,8 +57,6 @@ const ManagerMapList = (): JSX.Element => {
                 onClick={() => history.push(HREF.MANAGER_MAP_DETAIL(map.mapId))}
                 control={
                   <>
-                    <ShareLinkButton map={map} />
-                    <MapNoticeButton map={map} />
                     <SlackNotiButton map={map} />
                     <IconButton onClick={() => handleMapRemove(map.mapId)}>
                       <DeleteIcon width="24" height="24" />

--- a/frontend/src/types/response-v2.ts
+++ b/frontend/src/types/response-v2.ts
@@ -1,0 +1,13 @@
+import { MapItem } from './common';
+
+export interface MapItemResponseV2
+  extends Omit<MapItem, 'mapDrawing' | 'sharingMapId' | 'notice' | 'managerEmail'> {
+  mapDrawing: string;
+}
+
+export interface QueryManagerMapsSuccessV2 {
+  maps: MapItemResponseV2[];
+  organization: string;
+}
+
+export type QueryManagerMapSuccessV2 = MapItemResponseV2;


### PR DESCRIPTION
## 구현 기능
### API 분리
일단은 기존의 찜꽁의 기능과 현재 개발중인 기능을 mocking 함수에서 사용하기 위해, 기존의 `api/api.ts` 파일을 그대로 복사해
api-v2/api.ts 를 생성했습니다. 일단은 BASE_URL을 하드코딩없이 localhost 주소를 고정해두었습니다.

mockoon으로 mocking 할 경우, `7742`번 포트를 사용해주시기 바랍니다. 시간 상 임의로 정한 점 양해 부탁드립니다! 

### API 명세에 따른 기능 구현
명세는 [Open API 문서](https://github.com/Songusika/woowa-announcement-attendance/blob/main/docs/contract/zzimkkong-contract.yaml) 를 참고해주시면 됩니다. 여기서 구현된 기능은 이슈(#975)에서 말씀드렸듯이, Map에 관한 GET, DELETE 기능이 마이그레이션이 필요했습니다.

- GET `/api/maps` 관련해서, api 명세상 notice와, sharingMapId 가 사라져, 해당 버튼을 컴포넌트에서 삭제했습니다.
- GET `/api/maps` 관련해서, 기존의 데이터 스키마를 바꾸는 명세가 코드 상으론 약간..은 부담스러워 백엔드에게 요청했습니다.
  - 주노 감사합니다 ㅎㅎ (아마 수정된 사항은 바로 API 명세 문서에 반영될 것 같아요. 하지만 참고하셔야 될 것 같아 알려드립니다.)
- 삭제 버튼도 지금의 API 명세에 맞게 변경했습니다.
- User 정보를 불러오는 부분을 삭제했습니다.

아래 변경 전/후 스크린샷을 보면 어떤 점이 변경되었는지 가시적으로 이해하실 수 있으리라 생각합니다. 참고바랍니다.
|변경 전| 변경 후|
|---|---|
|<img width="1349" alt="image" src="https://github.com/woowacourse-teams/2021-zzimkkong/assets/56749516/0f1390e9-291f-4421-b39f-f2ffb9b71961">|<img width="1349" alt="image" src="https://github.com/woowacourse-teams/2021-zzimkkong/assets/56749516/a0cdefad-2d5a-41a8-9843-bcd8190e8807">|

## 논의하고 싶은 내용
~~또 api v2를 하면서 고민한 부분이 있습니다. 일단은 api 관련 로직과 타입은 새로 정의해주었는데, (v2 postfix 로 작성된 네이밍은 모두 새로정의된 부분입니다.) query등은 기존의 코드를 수정하였습니다. query는 굳이 새로 정의해줄 필요가 없고 기존의 코드를 변경하면 좋다고 생각했는데, 어떻게 생각하시나요?~~

- 개발 중 query 같은 경우도 함께 V2로 이전해야겠다고 느꼈습니다. 그 이유는 #979 에서 맵 단건 조회 API 를 변경하는데, 이 맵 단건 조회 API가 다른 페이지에서도 사용되다보니 만약 기존의 코드를 변경한다면 다른 페이지에도 영향을 끼쳐 작업 범위를 넘어가게 해 복잡해질 것 같아 query자체도 분리하면 좋을 것 같습니다!


Close #975 

