### PR TITLE
refactor: 맵 편집/생성 페이지를 API 명세에 맞게 마이그레이션

### DIFF
--- a/frontend/src/api-v2/apiv2.ts
+++ b/frontend/src/api-v2/apiv2.ts
@@ -1,0 +1,53 @@
+import axios, { AxiosError } from 'axios';
+import { history } from 'App';
+import PATH from 'constants/path';
+import { LOCAL_STORAGE_KEY } from 'constants/storage';
+import { ErrorResponse } from 'types/response';
+import { getLocalStorageItem, removeLocalStorageItem } from 'utils/localStorage';
+
+const apiV2 = axios.create({
+  baseURL: 'http://localhost:7742',
+  headers: {
+    'Content-type': 'application/json',
+  },
+});
+
+apiV2.interceptors.request.use(
+  (config) => {
+    const token = getLocalStorageItem({
+      key: LOCAL_STORAGE_KEY.ACCESS_TOKEN,
+      defaultValue: '',
+    });
+
+    if (typeof token !== 'string' || !token) return config;
+
+    config.headers = {
+      'Content-type': 'application/json',
+      Authorization: `Bearer ${token}`,
+    };
+
+    return config;
+  },
+
+  (error) => {
+    return Promise.reject(error);
+  }
+);
+
+apiV2.interceptors.response.use(
+  (response) => {
+    return response;
+  },
+
+  (error: AxiosError<ErrorResponse>) => {
+    if (error?.response?.status === 401) {
+      removeLocalStorageItem({ key: LOCAL_STORAGE_KEY.ACCESS_TOKEN });
+
+      history.push(PATH.LOGIN);
+    }
+
+    return Promise.reject(error);
+  }
+);
+
+export default apiV2;

--- a/frontend/src/api-v2/managerMap.ts
+++ b/frontend/src/api-v2/managerMap.ts
@@ -14,6 +14,14 @@ interface PostMapParamsV2 {
   slackUrl: string;
 }
 
+interface PutMapParamsV2 {
+  mapId: number;
+  mapName: string;
+  mapDrawing: string;
+  thumbnail: string;
+  slackUrl: string;
+}
+
 export const queryManagerMapV2: QueryFunction<
   AxiosResponse<QueryManagerMapSuccessV2>,
   [QueryKey, QueryManagerMapParamsV2]
@@ -31,3 +39,12 @@ export const postMapV2 = ({
   slackUrl,
 }: PostMapParamsV2): Promise<AxiosResponse<never>> =>
   apiV2.post('/api/maps', { mapName, mapDrawing, thumbnail, slackUrl });
+
+export const putMapV2 = ({
+  mapId,
+  mapName,
+  mapDrawing,
+  thumbnail,
+  slackUrl,
+}: PutMapParamsV2): Promise<AxiosResponse<never>> =>
+  apiV2.put(`/api/maps/${mapId}`, { mapName, mapDrawing, thumbnail, slackUrl });

--- a/frontend/src/api-v2/managerMap.ts
+++ b/frontend/src/api-v2/managerMap.ts
@@ -1,0 +1,18 @@
+import { AxiosResponse } from 'axios';
+import { QueryFunction, QueryKey } from 'react-query';
+import { QueryManagerMapSuccessV2 } from 'types/response-v2';
+import apiV2 from './apiv2';
+
+export interface QueryManagerMapParamsV2 {
+  mapId: number;
+}
+
+export const queryManagerMapV2: QueryFunction<
+  AxiosResponse<QueryManagerMapSuccessV2>,
+  [QueryKey, QueryManagerMapParamsV2]
+> = ({ queryKey }) => {
+  const [, data] = queryKey;
+  const { mapId } = data;
+
+  return apiV2.get(`/api/maps/${mapId}`);
+};

--- a/frontend/src/api-v2/managerMap.ts
+++ b/frontend/src/api-v2/managerMap.ts
@@ -7,6 +7,13 @@ export interface QueryManagerMapParamsV2 {
   mapId: number;
 }
 
+interface PostMapParamsV2 {
+  mapName: string;
+  mapDrawing: string;
+  thumbnail: string;
+  slackUrl: string;
+}
+
 export const queryManagerMapV2: QueryFunction<
   AxiosResponse<QueryManagerMapSuccessV2>,
   [QueryKey, QueryManagerMapParamsV2]
@@ -16,3 +23,11 @@ export const queryManagerMapV2: QueryFunction<
 
   return apiV2.get(`/api/maps/${mapId}`);
 };
+
+export const postMapV2 = ({
+  mapName,
+  mapDrawing,
+  thumbnail,
+  slackUrl,
+}: PostMapParamsV2): Promise<AxiosResponse<never>> =>
+  apiV2.post('/api/maps', { mapName, mapDrawing, thumbnail, slackUrl });

--- a/frontend/src/hooks/query-v2/useManagerMapV2.ts
+++ b/frontend/src/hooks/query-v2/useManagerMapV2.ts
@@ -13,6 +13,6 @@ const useManagerMapV2 = <TData = AxiosResponse<QueryManagerMapSuccessV2>>(
     [QueryKey, QueryManagerMapParamsV2]
   >
 ): UseQueryResult<TData, AxiosError<ErrorResponse>> =>
-  useQuery(['getManagerMap', { mapId }], queryManagerMapV2, { ...options });
+  useQuery(['getManagerMapV2', { mapId }], queryManagerMapV2, { ...options });
 
 export default useManagerMapV2;

--- a/frontend/src/hooks/query-v2/useManagerMapV2.ts
+++ b/frontend/src/hooks/query-v2/useManagerMapV2.ts
@@ -1,0 +1,18 @@
+import { AxiosError, AxiosResponse } from 'axios';
+import { QueryKey, useQuery, UseQueryOptions, UseQueryResult } from 'react-query';
+import { QueryManagerMapParamsV2, queryManagerMapV2 } from 'api-v2/managerMap';
+import { ErrorResponse } from 'types/response';
+import { QueryManagerMapSuccessV2 } from 'types/response-v2';
+
+const useManagerMapV2 = <TData = AxiosResponse<QueryManagerMapSuccessV2>>(
+  { mapId }: QueryManagerMapParamsV2,
+  options?: UseQueryOptions<
+    AxiosResponse<QueryManagerMapSuccessV2>,
+    AxiosError<ErrorResponse>,
+    TData,
+    [QueryKey, QueryManagerMapParamsV2]
+  >
+): UseQueryResult<TData, AxiosError<ErrorResponse>> =>
+  useQuery(['getManagerMap', { mapId }], queryManagerMapV2, { ...options });
+
+export default useManagerMapV2;

--- a/frontend/src/pages/ManagerMapEditor/ManagerMapEditor.tsx
+++ b/frontend/src/pages/ManagerMapEditor/ManagerMapEditor.tsx
@@ -2,6 +2,7 @@ import { AxiosError } from 'axios';
 import React, { createRef, useMemo, useState } from 'react';
 import { useMutation } from 'react-query';
 import { useHistory, useParams } from 'react-router';
+import { postMapV2 } from 'api-v2/managerMap';
 import { postMap, putMap } from 'api/managerMap';
 import Button from 'components/Button/Button';
 import EditorOverlay from 'components/EditorOverlay/EditorOverlay';
@@ -84,7 +85,7 @@ const ManagerMapEditor = (): JSX.Element => {
     }
   );
 
-  const createMap = useMutation(postMap, {
+  const createMap = useMutation(postMapV2, {
     onSuccess: (response) => {
       const headers = response.headers as { location: string };
       const mapId = Number(headers.location.split('/').pop());
@@ -141,7 +142,7 @@ const ManagerMapEditor = (): JSX.Element => {
       return;
     }
 
-    createMap.mutate({ mapName: name, mapDrawing, thumbnail });
+    createMap.mutate({ mapName: name, mapDrawing, thumbnail, slackUrl: '' });
   };
 
   return (

--- a/frontend/src/pages/ManagerMapEditor/ManagerMapEditor.tsx
+++ b/frontend/src/pages/ManagerMapEditor/ManagerMapEditor.tsx
@@ -2,8 +2,7 @@ import { AxiosError } from 'axios';
 import React, { createRef, useMemo, useState } from 'react';
 import { useMutation } from 'react-query';
 import { useHistory, useParams } from 'react-router';
-import { postMapV2 } from 'api-v2/managerMap';
-import { postMap, putMap } from 'api/managerMap';
+import { postMapV2, putMapV2 } from 'api-v2/managerMap';
 import Button from 'components/Button/Button';
 import EditorOverlay from 'components/EditorOverlay/EditorOverlay';
 import Header from 'components/Header/Header';
@@ -42,6 +41,7 @@ const ManagerMapEditor = (): JSX.Element => {
     width: `${BOARD.DEFAULT_WIDTH}`,
     height: `${BOARD.DEFAULT_HEIGHT}`,
   });
+  const [mapSlackUrl, setMapSlackUrl] = useState('');
 
   const managerSpaces = useManagerSpaces({ mapId: Number(mapId) }, { enabled: isEdit });
   const spaces: ManagerSpace[] = useMemo(() => {
@@ -63,8 +63,8 @@ const ManagerMapEditor = (): JSX.Element => {
       enabled: isEdit,
       refetchOnWindowFocus: false,
       onSuccess: ({ data }) => {
-        const { mapName, mapDrawing } = data;
-
+        const { mapName, mapDrawing, slackUrl } = data;
+        setMapSlackUrl(slackUrl);
         try {
           const { mapElements, width, height } = JSON.parse(mapDrawing) as MapDrawing;
           const mapElementsWithRef = mapElements.map((element) => ({
@@ -103,7 +103,7 @@ const ManagerMapEditor = (): JSX.Element => {
     },
   });
 
-  const updateMap = useMutation(putMap, {
+  const updateMap = useMutation(putMapV2, {
     onSuccess: () => {
       alert(MESSAGE.MANAGER_MAP.UPDATE_SUCCESS);
     },
@@ -137,12 +137,18 @@ const ManagerMapEditor = (): JSX.Element => {
     });
 
     if (isEdit) {
-      updateMap.mutate({ mapId: Number(mapId), mapName: name, mapDrawing, thumbnail });
+      updateMap.mutate({
+        mapId: Number(mapId),
+        mapName: name,
+        mapDrawing,
+        thumbnail,
+        slackUrl: mapSlackUrl,
+      });
 
       return;
     }
 
-    createMap.mutate({ mapName: name, mapDrawing, thumbnail, slackUrl: '' });
+    createMap.mutate({ mapName: name, mapDrawing, thumbnail, slackUrl: mapSlackUrl });
   };
 
   return (

--- a/frontend/src/pages/ManagerMapEditor/ManagerMapEditor.tsx
+++ b/frontend/src/pages/ManagerMapEditor/ManagerMapEditor.tsx
@@ -10,7 +10,7 @@ import Layout from 'components/Layout/Layout';
 import { BOARD } from 'constants/editor';
 import MESSAGE from 'constants/message';
 import PATH, { HREF } from 'constants/path';
-import useManagerMap from 'hooks/query/useManagerMap';
+import useManagerMapV2 from 'hooks/query-v2/useManagerMapV2';
 import useManagerSpaces from 'hooks/query/useManagerSpaces';
 import useInputs from 'hooks/useInputs';
 import { Area, ManagerSpace, MapDrawing, MapElement } from 'types/common';
@@ -56,7 +56,7 @@ const ManagerMapEditor = (): JSX.Element => {
     }
   }, [managerSpaces.data?.data.spaces]);
 
-  useManagerMap(
+  useManagerMapV2(
     { mapId: Number(mapId) },
     {
       enabled: isEdit,

--- a/frontend/src/types/response-v2.ts
+++ b/frontend/src/types/response-v2.ts
@@ -1,0 +1,8 @@
+import { MapItem } from './common';
+
+export interface MapItemResponseV2
+  extends Omit<MapItem, 'mapDrawing' | 'sharingMapId' | 'notice' | 'managerEmail'> {
+  mapDrawing: string;
+}
+
+export type QueryManagerMapSuccessV2 = MapItemResponseV2;

--- a/frontend/src/types/response-v2.ts
+++ b/frontend/src/types/response-v2.ts
@@ -3,6 +3,7 @@ import { MapItem } from './common';
 export interface MapItemResponseV2
   extends Omit<MapItem, 'mapDrawing' | 'sharingMapId' | 'notice' | 'managerEmail'> {
   mapDrawing: string;
+  slackUrl: string;
 }
 
 export type QueryManagerMapSuccessV2 = MapItemResponseV2;


### PR DESCRIPTION
## 구현 기능
- `ManagerMapEditor` 컴포넌트에 관여된 api를 마이그레이션했습니다.
아래는 마이그레이션한 API 목록입니다. 
자세한 내용은 [API 문서](https://github.com/Songusika/woowa-announcement-attendance/blob/main/docs/contract/zzimkkong-contract.yaml)에서 볼 수 있습니다.
- `CreateMap` : 맵 생성
- `UpdateMap` : 맵 수정
- `findMap` : 맵 단건 조회
## 논의하고 싶은 내용
- 맵 단건 조회 같은 경우는 유스랑 겹칠 것 같은데요! 이번 부분에 일단 필요해서 작성했습니다. merge할 때 다시 살펴봐도 좋을 것 같아요!
- 이번 페이지는 공간 조회 API를 사용하고 있어요. 따라서 mockoon의 mock 데이터와 개발 서버의 데이터 싱크를 맞추는 작업이 필요합니다. 필요하시면 mockoon 파일 드리겠습니다! (mockoon 파일을 공유를 어떻게 할지도 고민해보아야겠네요)

## 공유하고 싶은 내용
- mockoon에서 CORS 이슈로 Location 헤더를 못사용할수도 있는데요, [Access-Control-Expose-Headers](https://developer.mozilla.org/ko/docs/Web/HTTP/Headers/Access-Control-Expose-Headers) 로 해결했습니다. 혹시 Location을 스크립트에서 사용하신다면 참고 하시기 바랍니다~! [문서](https://velog.io/@2yunseong/CORS-%EC%83%81%ED%99%A9%EC%97%90%EC%84%9C-%ED%8A%B9%EC%A0%95-%ED%97%A4%EB%8D%94%EB%A5%BC-%EC%86%8C%EC%8A%A4%EC%BD%94%EB%93%9C%EC%97%90%EC%84%9C-%EC%9D%BD%EC%A7%80-%EB%AA%BB%ED%95%98%EB%8A%94-%EC%98%A4%EB%A5%98)

Close #978 

