### PR TITLE
fix: Connection Prematurely Closed issue 대응 작업

### DIFF
--- a/backend/src/main/java/com/woowacourse/zzimkkong/service/SlackService.java
+++ b/backend/src/main/java/com/woowacourse/zzimkkong/service/SlackService.java
@@ -4,10 +4,14 @@ import com.woowacourse.zzimkkong.dto.slack.Attachments;
 import com.woowacourse.zzimkkong.dto.slack.SlackResponse;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.MediaType;
+import org.springframework.http.client.reactive.ReactorClientHttpConnector;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.reactive.function.client.WebClient;
+import reactor.netty.http.client.HttpClient;
+import reactor.netty.resources.ConnectionProvider;
 
+import java.time.Duration;
 import java.util.Objects;
 
 @Service
@@ -19,7 +23,14 @@ public class SlackService {
     public SlackService(@Value("${service.url}") final String titleLink,
                         final WebClient webClient) {
         this.titleLink = titleLink;
-        slackWebClient = webClient;
+        ConnectionProvider provider = ConnectionProvider.builder("slack-pool")
+                .maxConnections(10)
+                .maxIdleTime(Duration.ofSeconds(2L))
+                .maxLifeTime(Duration.ofSeconds(2L))
+                .lifo()
+                .build();
+        HttpClient httpClient = HttpClient.create(provider);
+        slackWebClient = webClient.mutate().clientConnector(new ReactorClientHttpConnector(httpClient)).build();
     }
 
     public void sendCreateMessage(SlackResponse slackResponse) {
@@ -39,10 +50,8 @@ public class SlackService {
 
     private void send(final Attachments attachments, final String slackUrl) {
         if (!Objects.isNull(slackUrl)) {
-            slackWebClient.mutate()
-                    .baseUrl(slackUrl)
-                    .build()
-                    .post()
+            slackWebClient.post()
+                    .uri(slackUrl)
                     .contentType(MediaType.APPLICATION_JSON)
                     .bodyValue(attachments.toString())
                     .retrieve()


### PR DESCRIPTION
## 구현 기능
- Connection Prematurely Closed BEFORE response 에러 나지않도록 작업

### 현재 작업으로 문제가 해결되지 않을 가능성도 있으므로 배포 후 장기간 (N month) 모니터링 필요

----

## 공유하고 싶은 내용
slack 서버의 네트워크 관련 구성, 설정등을 알 수 없음. 따라서, [Reactor Netty Docs](https://projectreactor.io/docs/netty/1.0.21/reference/index.html#faq.connection-closed) 의 내용을 토대로 원인을 추정하여 대응한다.
### 추정 원인
#### 1. idle timeout (the connection is closed when there is no incoming data for a certain period of time)
즉, target server (i.e. Slack) 의 keep-alive timeout config 와 우리의 connection idle timeout config 가 맞지않아 (호환되지 않게끔 설정) 발생하는 케이스. tcpdump 와 로그등을 분석해본 결과, **이 케이스가 가장 유력**하다고 보임.

tcpdump 를 보았을 때, 3초간 3번 정도의 TCP keep alive check (probe packet) 통신 후 target server 측에서 보낸 RST 패킷을 통해 커넥션이 premature 하게 끊어짐. 따라서, 우리 측에서는 `maxIdelTimeout` 설정값을 2초 정도로 잡아서 우리가 먼저 connection 을 알아서 끊도록 함.

#### 2. max keep alive requests (the connection is closed when the requests reach the configured maximum number)

원인이 아니겠지만, docs 를 보다보니 관련 설정도 해주는게 좋을것 같아서 수정함. 트래픽이 많지 않은데 connection pool 을 크게 가져갈 필요가 없는 것 같아서 `maxConnections` 값 10으로 설정.

Close #985 
