### PR TITLE
[ALL] feat: QR/엔트리 기반 회의실 즉석 예약 기능 (#998)

### DIFF
--- a/backend/src/main/java/com/woowacourse/zzimkkong/controller/EntryController.java
+++ b/backend/src/main/java/com/woowacourse/zzimkkong/controller/EntryController.java
@@ -1,0 +1,28 @@
+package com.woowacourse.zzimkkong.controller;
+
+import com.woowacourse.zzimkkong.config.logaspect.LogMethodExecutionTime;
+import com.woowacourse.zzimkkong.dto.space.SpaceEntryResponse;
+import com.woowacourse.zzimkkong.service.SpaceService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@LogMethodExecutionTime(group = "controller")
+@RestController
+@RequestMapping("/api/entry")
+public class EntryController {
+    private final SpaceService spaceService;
+
+    public EntryController(final SpaceService spaceService) {
+        this.spaceService = spaceService;
+    }
+
+    @GetMapping("/spaces")
+    public ResponseEntity<SpaceEntryResponse> findSpaceByShareId(
+            @RequestParam final String sharingSpaceId) {
+        SpaceEntryResponse spaceEntryResponse = spaceService.findSpaceBySharingId(sharingSpaceId);
+        return ResponseEntity.ok().body(spaceEntryResponse);
+    }
+}

--- a/backend/src/main/java/com/woowacourse/zzimkkong/controller/ManagerSpaceController.java
+++ b/backend/src/main/java/com/woowacourse/zzimkkong/controller/ManagerSpaceController.java
@@ -49,6 +49,15 @@ public class ManagerSpaceController {
         return ResponseEntity.ok().body(spaceFindDetailResponse);
     }
 
+    @GetMapping("/{spaceId}/sharing-id")
+    public ResponseEntity<SharingSpaceIdResponse> getSharingSpaceId(
+            @PathVariable final Long mapId,
+            @PathVariable final Long spaceId,
+            @LoginEmail final LoginUserEmail loginUserEmail) {
+        SharingSpaceIdResponse response = spaceService.getSharingSpaceId(mapId, spaceId, loginUserEmail);
+        return ResponseEntity.ok().body(response);
+    }
+
     @PutMapping("/{spaceId}")
     public ResponseEntity<Void> update(
             @PathVariable final Long mapId,

--- a/backend/src/main/java/com/woowacourse/zzimkkong/dto/space/SharingSpaceIdResponse.java
+++ b/backend/src/main/java/com/woowacourse/zzimkkong/dto/space/SharingSpaceIdResponse.java
@@ -1,0 +1,18 @@
+package com.woowacourse.zzimkkong.dto.space;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class SharingSpaceIdResponse {
+    private String sharingSpaceId;
+
+    private SharingSpaceIdResponse(final String sharingSpaceId) {
+        this.sharingSpaceId = sharingSpaceId;
+    }
+
+    public static SharingSpaceIdResponse from(final String sharingSpaceId) {
+        return new SharingSpaceIdResponse(sharingSpaceId);
+    }
+}

--- a/backend/src/main/java/com/woowacourse/zzimkkong/dto/space/SpaceEntryResponse.java
+++ b/backend/src/main/java/com/woowacourse/zzimkkong/dto/space/SpaceEntryResponse.java
@@ -1,0 +1,82 @@
+package com.woowacourse.zzimkkong.dto.space;
+
+import com.woowacourse.zzimkkong.domain.Group;
+import com.woowacourse.zzimkkong.domain.Reservation;
+import com.woowacourse.zzimkkong.domain.Space;
+import com.woowacourse.zzimkkong.dto.reservation.ReservationResponse;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@NoArgsConstructor
+public class SpaceEntryResponse {
+    private Long spaceId;
+    private String spaceName;
+    private String spaceColor;
+    private Boolean reservationEnable;
+    private List<SettingResponse> settings;
+    private List<Group> allowedGroups;
+    private Long mapId;
+    private String mapName;
+    private String sharingMapId;
+    private List<ReservationResponse> todayReservations;
+
+    private SpaceEntryResponse(
+            final Long spaceId,
+            final String spaceName,
+            final String spaceColor,
+            final Boolean reservationEnable,
+            final List<SettingResponse> settings,
+            final List<Group> allowedGroups,
+            final Long mapId,
+            final String mapName,
+            final String sharingMapId,
+            final List<ReservationResponse> todayReservations) {
+        this.spaceId = spaceId;
+        this.spaceName = spaceName;
+        this.spaceColor = spaceColor;
+        this.reservationEnable = reservationEnable;
+        this.settings = settings;
+        this.allowedGroups = allowedGroups;
+        this.mapId = mapId;
+        this.mapName = mapName;
+        this.sharingMapId = sharingMapId;
+        this.todayReservations = todayReservations;
+    }
+
+    public static SpaceEntryResponse of(
+            final Space space,
+            final String sharingMapId,
+            final List<Reservation> todayReservations) {
+        List<SettingResponse> settingResponses = space.getSpaceSettings().getSettings()
+                .stream()
+                .map(SettingResponse::from)
+                .collect(Collectors.toList());
+
+        List<Group> allowedGroups = space.getAllowedGroups()
+                .stream()
+                .map(allowedGroup -> allowedGroup.getGroup())
+                .collect(Collectors.toList());
+
+        todayReservations.sort(Comparator.comparing(Reservation::getStartTime));
+        List<ReservationResponse> reservationResponses = todayReservations.stream()
+                .map(reservation -> ReservationResponse.from(reservation, null))
+                .collect(Collectors.toList());
+
+        return new SpaceEntryResponse(
+                space.getId(),
+                space.getName(),
+                space.getColor(),
+                space.getReservationEnable(),
+                settingResponses,
+                allowedGroups,
+                space.getMap().getId(),
+                space.getMap().getName(),
+                sharingMapId,
+                reservationResponses);
+    }
+}

--- a/backend/src/main/java/com/woowacourse/zzimkkong/infrastructure/sharingid/SharingIdGenerator.java
+++ b/backend/src/main/java/com/woowacourse/zzimkkong/infrastructure/sharingid/SharingIdGenerator.java
@@ -2,6 +2,7 @@ package com.woowacourse.zzimkkong.infrastructure.sharingid;
 
 import com.woowacourse.zzimkkong.config.logaspect.LogMethodExecutionTime;
 import com.woowacourse.zzimkkong.domain.Map;
+import com.woowacourse.zzimkkong.domain.Space;
 import com.woowacourse.zzimkkong.exception.infrastructure.DecodingException;
 import com.woowacourse.zzimkkong.exception.map.InvalidAccessLinkException;
 import org.springframework.stereotype.Component;
@@ -9,6 +10,8 @@ import org.springframework.stereotype.Component;
 @Component
 @LogMethodExecutionTime(group = "infrastructure")
 public class SharingIdGenerator {
+    private static final String SPACE_PREFIX = "space:";
+
     private final Transcoder transcoder;
 
     public SharingIdGenerator(final Transcoder transcoder) {
@@ -23,6 +26,22 @@ public class SharingIdGenerator {
         try {
             String decoded = transcoder.decode(publicId);
             return Long.parseLong(decoded);
+        } catch (DecodingException | NumberFormatException exception) {
+            throw new InvalidAccessLinkException();
+        }
+    }
+
+    public String fromSpace(final Space space) {
+        return transcoder.encode(SPACE_PREFIX + space.getId());
+    }
+
+    public Long parseSpaceIdFrom(final String sharingSpaceId) {
+        try {
+            String decoded = transcoder.decode(sharingSpaceId);
+            if (!decoded.startsWith(SPACE_PREFIX)) {
+                throw new InvalidAccessLinkException();
+            }
+            return Long.parseLong(decoded.substring(SPACE_PREFIX.length()));
         } catch (DecodingException | NumberFormatException exception) {
             throw new InvalidAccessLinkException();
         }

--- a/backend/src/main/java/com/woowacourse/zzimkkong/service/SpaceService.java
+++ b/backend/src/main/java/com/woowacourse/zzimkkong/service/SpaceService.java
@@ -7,6 +7,7 @@ import com.woowacourse.zzimkkong.dto.space.*;
 import com.woowacourse.zzimkkong.exception.map.NoSuchMapException;
 import com.woowacourse.zzimkkong.exception.space.NoSuchSpaceException;
 import com.woowacourse.zzimkkong.exception.space.ReservationExistOnSpaceException;
+import com.woowacourse.zzimkkong.infrastructure.sharingid.SharingIdGenerator;
 import com.woowacourse.zzimkkong.repository.MapRepository;
 import com.woowacourse.zzimkkong.repository.ReservationRepository;
 import com.woowacourse.zzimkkong.repository.SpaceRepository;
@@ -14,8 +15,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.DayOfWeek;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.util.AbstractMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -27,14 +28,17 @@ public class SpaceService {
     private final MapRepository maps;
     private final SpaceRepository spaces;
     private final ReservationRepository reservations;
+    private final SharingIdGenerator sharingIdGenerator;
 
     public SpaceService(
             final MapRepository maps,
             final SpaceRepository spaces,
-            final ReservationRepository reservations) {
+            final ReservationRepository reservations,
+            final SharingIdGenerator sharingIdGenerator) {
         this.maps = maps;
         this.spaces = spaces;
         this.reservations = reservations;
+        this.sharingIdGenerator = sharingIdGenerator;
     }
 
     public SpaceCreateResponse saveSpace(
@@ -193,6 +197,38 @@ public class SpaceService {
         if (reservations.existsBySpaceIdAndReservationTimeEndTimeAfter(spaceId, LocalDateTime.now())) {
             throw new ReservationExistOnSpaceException();
         }
+    }
+
+    @Transactional(readOnly = true)
+    public SpaceEntryResponse findSpaceBySharingId(final String sharingSpaceId) {
+        Long spaceId = sharingIdGenerator.parseSpaceIdFrom(sharingSpaceId);
+        Space space = spaces.findById(spaceId)
+                .orElseThrow(NoSuchSpaceException::new);
+
+        Map map = space.getMap();
+        String sharingMapId = sharingIdGenerator.from(map);
+
+        LocalDate today = LocalDate.now();
+        Set<Long> spaceIdSet = Set.of(spaceId);
+        List<Reservation> todayReservations = reservations.findAllBySpaceIdInAndReservationTimeDate(spaceIdSet, today);
+
+        return SpaceEntryResponse.of(space, sharingMapId, todayReservations);
+    }
+
+    @Transactional(readOnly = true)
+    public SharingSpaceIdResponse getSharingSpaceId(
+            final Long mapId,
+            final Long spaceId,
+            final LoginUserEmail loginUserEmail) {
+        Map map = maps.findByIdFetch(mapId)
+                .orElseThrow(NoSuchMapException::new);
+        validateManagerOfMap(map, loginUserEmail.getEmail());
+
+        Space space = map.findSpaceById(spaceId)
+                .orElseThrow(NoSuchSpaceException::new);
+
+        String sharingSpaceId = sharingIdGenerator.fromSpace(space);
+        return SharingSpaceIdResponse.from(sharingSpaceId);
     }
 
     private void validateManagerOfMap(final Map map, final String email) {

--- a/backend/src/test/java/com/woowacourse/zzimkkong/infrastructure/sharingid/SharingIdGeneratorTest.java
+++ b/backend/src/test/java/com/woowacourse/zzimkkong/infrastructure/sharingid/SharingIdGeneratorTest.java
@@ -3,6 +3,7 @@ package com.woowacourse.zzimkkong.infrastructure.sharingid;
 import com.woowacourse.zzimkkong.domain.Map;
 import com.woowacourse.zzimkkong.domain.Member;
 import com.woowacourse.zzimkkong.domain.ProfileEmoji;
+import com.woowacourse.zzimkkong.domain.Space;
 import com.woowacourse.zzimkkong.exception.map.InvalidAccessLinkException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -20,6 +21,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 class SharingIdGeneratorTest {
     private Member pobi;
     private Map luther;
+    private Space be;
 
     @Autowired
     SharingIdGenerator sharingIdGenerator;
@@ -42,6 +44,13 @@ class SharingIdGeneratorTest {
                 MAP_DRAWING_DATA,
                 MAP_SVG,
                 pobi);
+        be = Space.builder()
+                .id(1L)
+                .name(BE_NAME)
+                .map(luther)
+                .area(SPACE_DRAWING)
+                .reservationEnable(BE_RESERVATION_ENABLE)
+                .build();
     }
 
     @Test
@@ -88,6 +97,63 @@ class SharingIdGeneratorTest {
 
         // when, then
         assertThatThrownBy(() -> sharingIdGenerator.parseIdFrom(encoded))
+                .isInstanceOf(InvalidAccessLinkException.class);
+    }
+
+    @Test
+    @DisplayName("Space 도메인 객체로부터 인코딩된 Sharing Space Id를 만들어낸다.")
+    void generateSharingIdFromSpace() {
+        // given, when
+        String sharingSpaceId = sharingIdGenerator.fromSpace(be);
+
+        // then
+        assertThat(sharingSpaceId).isNotEmpty();
+    }
+
+    @Test
+    @DisplayName("인코딩된 Sharing Space Id로부터 Space Id를 얻어낸다.")
+    void parseSpaceIdFromEncodedString() {
+        // given
+        String sharingSpaceId = sharingIdGenerator.fromSpace(be);
+
+        // when
+        Long actual = sharingIdGenerator.parseSpaceIdFrom(sharingSpaceId);
+        Long expected = be.getId();
+
+        // then
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    @DisplayName("Map Sharing Id와 Space Sharing Id는 같은 DB Id여도 다른 값을 생성한다.")
+    void mapAndSpaceSharingIdAreDifferent() {
+        // given, when
+        String sharingMapId = sharingIdGenerator.from(luther);
+        String sharingSpaceId = sharingIdGenerator.fromSpace(be);
+
+        // then (같은 id=1이지만 prefix가 다르므로 다른 값)
+        assertThat(sharingMapId).isNotEqualTo(sharingSpaceId);
+    }
+
+    @Test
+    @DisplayName("Map Sharing Id를 Space Id로 파싱하려고 하면 예외가 발생한다.")
+    void parseMapSharingIdAsSpaceIdFails() {
+        // given
+        String sharingMapId = sharingIdGenerator.from(luther);
+
+        // when, then
+        assertThatThrownBy(() -> sharingIdGenerator.parseSpaceIdFrom(sharingMapId))
+                .isInstanceOf(InvalidAccessLinkException.class);
+    }
+
+    @Test
+    @DisplayName("디코딩 할 수 없는 문자열이 Space Sharing Id로 주어지면 예외를 발생시킨다.")
+    void parseSpaceIdFromInvalidToDecode() {
+        // given
+        String wrongSharingId = "zzimkkong";
+
+        // when, then
+        assertThatThrownBy(() -> sharingIdGenerator.parseSpaceIdFrom(wrongSharingId))
                 .isInstanceOf(InvalidAccessLinkException.class);
     }
 }

--- a/backend/src/test/java/com/woowacourse/zzimkkong/service/SpaceServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/zzimkkong/service/SpaceServiceTest.java
@@ -17,6 +17,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -31,6 +32,9 @@ import static org.mockito.BDDMockito.given;
 class SpaceServiceTest extends ServiceTest {
     @Autowired
     private SpaceService spaceService;
+
+    @Autowired
+    private com.woowacourse.zzimkkong.infrastructure.sharingid.SharingIdGenerator sharingIdGenerator;
 
     private final SettingRequest settingRequest = new SettingRequest(
             BE_AVAILABLE_START_TIME,
@@ -399,5 +403,65 @@ class SpaceServiceTest extends ServiceTest {
                 Set.of(be));
 
         assertThat(actualResult).usingRecursiveComparison().isEqualTo(expectedResult);
+    }
+
+    @Test
+    @DisplayName("Sharing Space Id로 공간을 조회하면 공간 정보와 당일 예약 현황을 반환한다.")
+    void findSpaceBySharingId() {
+        // given
+        given(spaces.findById(anyLong()))
+                .willReturn(Optional.of(be));
+        given(reservations.findAllBySpaceIdInAndReservationTimeDate(anyCollection(), any()))
+                .willReturn(Collections.emptyList());
+
+        // when
+        SpaceEntryResponse response = spaceService.findSpaceBySharingId(
+                sharingIdGenerator.fromSpace(be));
+
+        // then
+        assertThat(response.getSpaceId()).isEqualTo(be.getId());
+        assertThat(response.getSpaceName()).isEqualTo(be.getName());
+        assertThat(response.getMapId()).isEqualTo(luther.getId());
+        assertThat(response.getMapName()).isEqualTo(luther.getName());
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 Space의 Sharing Id로 조회하면 예외가 발생한다.")
+    void findSpaceBySharingIdNotExist() {
+        // given
+        given(spaces.findById(anyLong()))
+                .willReturn(Optional.empty());
+
+        String sharingSpaceId = sharingIdGenerator.fromSpace(be);
+
+        // when, then
+        assertThatThrownBy(() -> spaceService.findSpaceBySharingId(sharingSpaceId))
+                .isInstanceOf(NoSuchSpaceException.class);
+    }
+
+    @Test
+    @DisplayName("매니저가 공간의 Sharing Space Id를 조회한다.")
+    void getSharingSpaceId() {
+        // given
+        given(maps.findByIdFetch(anyLong()))
+                .willReturn(Optional.of(luther));
+
+        // when
+        SharingSpaceIdResponse response = spaceService.getSharingSpaceId(lutherId, beId, pobiEmail);
+
+        // then
+        assertThat(response.getSharingSpaceId()).isNotEmpty();
+    }
+
+    @Test
+    @DisplayName("매니저가 아닌 사용자가 Sharing Space Id를 조회하면 예외가 발생한다.")
+    void getSharingSpaceIdNoAuthority() {
+        // given
+        given(maps.findByIdFetch(anyLong()))
+                .willReturn(Optional.of(luther));
+
+        // when, then
+        assertThatThrownBy(() -> spaceService.getSharingSpaceId(lutherId, beId, sakjungEmail))
+                .isInstanceOf(NoAuthorityOnMapException.class);
     }
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -37,6 +37,7 @@
   "dependencies": {
     "@toss/utils": "^1.3.1",
     "axios": "^0.21.1",
+    "qrcode.react": "^3.1.0",
     "dayjs": "^1.10.7",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",

--- a/frontend/src/api/entry.ts
+++ b/frontend/src/api/entry.ts
@@ -1,0 +1,50 @@
+import { AxiosResponse } from 'axios';
+import { QueryFunction, QueryKey } from 'react-query';
+import { Reservation, SpaceSetting, Group } from 'types/common';
+import api from './api';
+
+export interface SpaceEntryData {
+  spaceId: number;
+  spaceName: string;
+  spaceColor: string;
+  reservationEnable: boolean;
+  settings: SpaceSetting[];
+  allowedGroups: Group[];
+  mapId: number;
+  mapName: string;
+  sharingMapId: string;
+  todayReservations: Reservation[];
+}
+
+export interface QuerySpaceEntryParams {
+  sharingSpaceId: string;
+}
+
+export interface QuerySharingSpaceIdParams {
+  mapId: number;
+  spaceId: number;
+}
+
+export interface SharingSpaceIdData {
+  sharingSpaceId: string;
+}
+
+export const querySpaceEntry: QueryFunction<
+  AxiosResponse<SpaceEntryData>,
+  [QueryKey, QuerySpaceEntryParams]
+> = ({ queryKey }) => {
+  const [, data] = queryKey;
+  const { sharingSpaceId } = data;
+
+  return api.get(`/entry/spaces?sharingSpaceId=${sharingSpaceId}`);
+};
+
+export const querySharingSpaceId: QueryFunction<
+  AxiosResponse<SharingSpaceIdData>,
+  [QueryKey, QuerySharingSpaceIdParams]
+> = ({ queryKey }) => {
+  const [, data] = queryKey;
+  const { mapId, spaceId } = data;
+
+  return api.get(`/managers/maps/${mapId}/spaces/${spaceId}/sharing-id`);
+};

--- a/frontend/src/components/QRCode/QRCode.styles.ts
+++ b/frontend/src/components/QRCode/QRCode.styles.ts
@@ -1,0 +1,26 @@
+import styled from 'styled-components';
+
+export const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
+`;
+
+export const QRWrapper = styled.div`
+  padding: 1rem;
+  background: white;
+  border-radius: 0.5rem;
+  border: 1px solid ${({ theme }) => theme.gray[300]};
+`;
+
+export const SpaceName = styled.p`
+  font-size: 0.875rem;
+  color: ${({ theme }) => theme.gray[500]};
+  text-align: center;
+`;
+
+export const ButtonWrapper = styled.div`
+  display: flex;
+  gap: 0.5rem;
+`;

--- a/frontend/src/components/QRCode/QRCode.tsx
+++ b/frontend/src/components/QRCode/QRCode.tsx
@@ -48,15 +48,27 @@ const QRCode = ({
     if (!canvas) return;
 
     const dataUrl = canvas.toDataURL('image/png');
-    const printWindow = window.open('', '_blank');
-    if (!printWindow) return;
 
-    const doc = printWindow.document;
+    const iframe = document.createElement('iframe');
+    iframe.style.position = 'fixed';
+    iframe.style.top = '-10000px';
+    iframe.style.left = '-10000px';
+    iframe.style.width = '0';
+    iframe.style.height = '0';
+    document.body.appendChild(iframe);
+
+    const doc = iframe.contentDocument ?? iframe.contentWindow?.document;
+    if (!doc) {
+      document.body.removeChild(iframe);
+      return;
+    }
+
+    doc.open();
     doc.write(`
       <html>
         <head>
-          <title>QR - ${spaceName}</title>
           <style>
+            @page { margin: 10mm; }
             body {
               display: flex;
               flex-direction: column;
@@ -66,13 +78,18 @@ const QRCode = ({
               margin: 0;
               font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
             }
-            img { margin-bottom: 1rem; }
-            h2 { font-size: 1.5rem; margin: 0 0 0.5rem; }
-            p { color: #666; font-size: 0.875rem; margin: 0; }
+            img {
+              width: 100%;
+              max-width: 100vw;
+              height: auto;
+              margin-bottom: 0;
+            }
+            h2 { font-size: 2rem; margin: 0 0 0.5rem; }
+            p { color: #666; font-size: 1.25rem; margin: 0; }
           </style>
         </head>
         <body>
-          <img id="qr" src="${dataUrl}" width="${size}" height="${size}" />
+          <img src="${dataUrl}" />
           <h2>${spaceName}</h2>
           ${description ? `<p>${description}</p>` : ''}
         </body>
@@ -80,19 +97,12 @@ const QRCode = ({
     `);
     doc.close();
 
-    const img = doc.getElementById('qr') as HTMLImageElement;
-    const doPrint = () => {
-      printWindow.focus();
-      printWindow.print();
-      printWindow.close();
-    };
-
-    if (img.complete) {
-      doPrint();
-    } else {
-      img.onload = doPrint;
-    }
-  }, [spaceName, description, size]);
+    setTimeout(() => {
+      iframe.contentWindow?.focus();
+      iframe.contentWindow?.print();
+      document.body.removeChild(iframe);
+    }, 100);
+  }, [spaceName, description]);
 
   return (
     <Styled.Container>

--- a/frontend/src/components/QRCode/QRCode.tsx
+++ b/frontend/src/components/QRCode/QRCode.tsx
@@ -1,0 +1,118 @@
+import { QRCodeCanvas } from 'qrcode.react';
+import { useCallback, useRef } from 'react';
+import Button from 'components/Button/Button';
+import { HREF } from 'constants/path';
+import * as Styled from './QRCode.styles';
+
+interface QRCodeProps {
+  sharingSpaceId: string;
+  spaceName: string;
+  description?: string;
+  size?: number;
+}
+
+const QRCode = ({
+  sharingSpaceId,
+  spaceName,
+  description,
+  size = 200,
+}: QRCodeProps): JSX.Element => {
+  const canvasRef = useRef<HTMLDivElement>(null);
+
+  const basePath = HREF.SPACE_ENTRY(sharingSpaceId);
+  const query = description ? `?description=${encodeURIComponent(description)}` : '';
+  const entryUrl = `${window.location.origin}${basePath}${query}`;
+
+  const handleDownload = useCallback(() => {
+    const canvas = canvasRef.current?.querySelector('canvas');
+    if (!canvas) return;
+
+    const dataUrl = canvas.toDataURL('image/png');
+    const link = document.createElement('a');
+    link.download = `qr-${spaceName}.png`;
+    link.href = dataUrl;
+    link.click();
+  }, [spaceName]);
+
+  const handleCopyUrl = useCallback(async () => {
+    try {
+      await navigator.clipboard.writeText(entryUrl);
+      alert('엔트리 URL이 클립보드에 복사되었습니다.');
+    } catch {
+      alert('URL 복사에 실패했습니다.');
+    }
+  }, [entryUrl]);
+
+  const handlePrint = useCallback(() => {
+    const canvas = canvasRef.current?.querySelector('canvas');
+    if (!canvas) return;
+
+    const dataUrl = canvas.toDataURL('image/png');
+    const printWindow = window.open('', '_blank');
+    if (!printWindow) return;
+
+    const doc = printWindow.document;
+    doc.write(`
+      <html>
+        <head>
+          <title>QR - ${spaceName}</title>
+          <style>
+            body {
+              display: flex;
+              flex-direction: column;
+              align-items: center;
+              justify-content: center;
+              min-height: 100vh;
+              margin: 0;
+              font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+            }
+            img { margin-bottom: 1rem; }
+            h2 { font-size: 1.5rem; margin: 0 0 0.5rem; }
+            p { color: #666; font-size: 0.875rem; margin: 0; }
+          </style>
+        </head>
+        <body>
+          <img id="qr" src="${dataUrl}" width="${size}" height="${size}" />
+          <h2>${spaceName}</h2>
+          ${description ? `<p>${description}</p>` : ''}
+        </body>
+      </html>
+    `);
+    doc.close();
+
+    const img = doc.getElementById('qr') as HTMLImageElement;
+    const doPrint = () => {
+      printWindow.focus();
+      printWindow.print();
+      printWindow.close();
+    };
+
+    if (img.complete) {
+      doPrint();
+    } else {
+      img.onload = doPrint;
+    }
+  }, [spaceName, description, size]);
+
+  return (
+    <Styled.Container>
+      <Styled.QRWrapper ref={canvasRef}>
+        <QRCodeCanvas value={entryUrl} size={size} level="M" includeMargin />
+      </Styled.QRWrapper>
+      <Styled.SpaceName>{spaceName}</Styled.SpaceName>
+      <Styled.ButtonWrapper>
+        <Button variant="primary" size="small" onClick={handleDownload}>
+          다운로드
+        </Button>
+        <Button variant="inverse" size="small" onClick={handleCopyUrl}>
+          URL 복사
+        </Button>
+        <Button variant="inverse" size="small" onClick={handlePrint}>
+          프린트
+        </Button>
+      </Styled.ButtonWrapper>
+    </Styled.Container>
+  );
+};
+
+export default QRCode;

--- a/frontend/src/components/QRCode/QRCodeModal.tsx
+++ b/frontend/src/components/QRCode/QRCodeModal.tsx
@@ -1,0 +1,65 @@
+import { useState } from 'react';
+import Input from 'components/Input/Input';
+import Modal from 'components/Modal/Modal';
+import QRCode from 'components/QRCode/QRCode';
+import useSharingSpaceId from 'hooks/query/useSharingSpaceId';
+
+interface QRCodeModalProps {
+  open: boolean;
+  onClose: () => void;
+  mapId: number;
+  spaceId: number;
+  spaceName: string;
+}
+
+const QRCodeModal = ({
+  open,
+  onClose,
+  mapId,
+  spaceId,
+  spaceName,
+}: QRCodeModalProps): JSX.Element => {
+  const [description, setDescription] = useState('');
+
+  const getSharingSpaceId = useSharingSpaceId(
+    { mapId, spaceId },
+    {
+      enabled: open,
+      retry: false,
+    }
+  );
+
+  const sharingSpaceId = getSharingSpaceId.data?.data?.sharingSpaceId;
+
+  return (
+    <Modal open={open} onClose={onClose} isClosableDimmer showCloseButton>
+      <Modal.Inner>
+        <Modal.Header>QR 코드 - {spaceName}</Modal.Header>
+        <Modal.Content>
+          {getSharingSpaceId.isLoading && <p>QR 코드를 생성하는 중...</p>}
+          {getSharingSpaceId.isError && <p>QR 코드를 생성하는 데 실패했습니다.</p>}
+          {sharingSpaceId && (
+            <>
+              <div style={{ padding: '0 1rem 1rem' }}>
+                <Input
+                  label="기본 사용 목적 (선택)"
+                  name="description"
+                  value={description}
+                  onChange={(e) => setDescription(e.target.value)}
+                  placeholder="예: 코치 회의"
+                />
+              </div>
+              <QRCode
+                sharingSpaceId={sharingSpaceId}
+                spaceName={spaceName}
+                description={description}
+              />
+            </>
+          )}
+        </Modal.Content>
+      </Modal.Inner>
+    </Modal>
+  );
+};
+
+export default QRCodeModal;

--- a/frontend/src/constants/path.ts
+++ b/frontend/src/constants/path.ts
@@ -42,6 +42,7 @@ const PATH = {
   GUEST_RESERVATION_EDIT: '/guest/:sharingMapId/reservation/edit',
   GUEST_RESERVATION_SUCCESS: '/guest/:sharingMapId/success',
   GUEST_NON_LOGIN_RESERVATION_SEARCH: '/guest/non-login/reservation/search',
+  SPACE_ENTRY: '/entry/:sharingSpaceId',
   NOT_FOUND: '/not-found',
   GITHUB_LOGIN: `https://github.com/login/oauth/authorize?client_id=${GITHUB_OAUTH_KEY}&redirect_uri=${REDIRECT_URI}/login/oauth/github`,
   GOOGLE_LOGIN:
@@ -69,6 +70,8 @@ export const HREF = {
     PATH.GUEST_RESERVATION_EDIT.replace(':sharingMapId', `${sharingMapId}`),
   GUEST_RESERVATION_SUCCESS: (sharingMapId: string): string =>
     PATH.GUEST_RESERVATION_SUCCESS.replace(':sharingMapId', `${sharingMapId}`),
+  SPACE_ENTRY: (sharingSpaceId: string): string =>
+    PATH.SPACE_ENTRY.replace(':sharingSpaceId', `${sharingSpaceId}`),
 };
 
 export default PATH;

--- a/frontend/src/constants/routes.tsx
+++ b/frontend/src/constants/routes.tsx
@@ -6,7 +6,6 @@ import ManagerPasswordEdit from 'pages/ManagerPasswordEdit/ManagerPasswordEdit';
 import ManagerProfileEdit from 'pages/ManagerProfileEdit/ManagerProfileEdit';
 import PATH from './path';
 
-const GuestMap = React.lazy(() => import('pages/GuestMap/GuestMap'));
 const GuestReservation = React.lazy(() => import('pages/GuestReservation/GuestReservation'));
 const GuestReservationSuccess = React.lazy(
   () => import('pages/GuestReservation/GuestReservationSuccess')
@@ -24,6 +23,7 @@ const GoogleOAuthRedirect = React.lazy(() => import('pages/OAuthRedirect/GoogleO
 const GuestNonLoginReservationSearch = React.lazy(
   () => import('pages/GuestNonLoginReservationSearch/GuestNonLoginReservationSearch')
 );
+const SpaceEntry = React.lazy(() => import('pages/SpaceEntry/SpaceEntry'));
 
 interface Route {
   path: string;
@@ -78,6 +78,10 @@ export const PUBLIC_ROUTES: Route[] = [
   {
     path: PATH.GUEST_NON_LOGIN_RESERVATION_SEARCH,
     component: <GuestNonLoginReservationSearch />,
+  },
+  {
+    path: PATH.SPACE_ENTRY,
+    component: <SpaceEntry />,
   },
 ];
 

--- a/frontend/src/hooks/query/useSharingSpaceId.ts
+++ b/frontend/src/hooks/query/useSharingSpaceId.ts
@@ -1,0 +1,17 @@
+import { AxiosError, AxiosResponse } from 'axios';
+import { QueryKey, useQuery, UseQueryOptions, UseQueryResult } from 'react-query';
+import { querySharingSpaceId, QuerySharingSpaceIdParams, SharingSpaceIdData } from 'api/entry';
+import { ErrorResponse } from 'types/response';
+
+const useSharingSpaceId = <TData = AxiosResponse<SharingSpaceIdData>>(
+  { mapId, spaceId }: QuerySharingSpaceIdParams,
+  options?: UseQueryOptions<
+    AxiosResponse<SharingSpaceIdData>,
+    AxiosError<ErrorResponse>,
+    TData,
+    [QueryKey, QuerySharingSpaceIdParams]
+  >
+): UseQueryResult<TData, AxiosError<ErrorResponse>> =>
+  useQuery(['getSharingSpaceId', { mapId, spaceId }], querySharingSpaceId, options);
+
+export default useSharingSpaceId;

--- a/frontend/src/hooks/query/useSpaceEntry.ts
+++ b/frontend/src/hooks/query/useSpaceEntry.ts
@@ -1,0 +1,17 @@
+import { AxiosError, AxiosResponse } from 'axios';
+import { QueryKey, useQuery, UseQueryOptions, UseQueryResult } from 'react-query';
+import { querySpaceEntry, QuerySpaceEntryParams, SpaceEntryData } from 'api/entry';
+import { ErrorResponse } from 'types/response';
+
+const useSpaceEntry = <TData = AxiosResponse<SpaceEntryData>>(
+  { sharingSpaceId }: QuerySpaceEntryParams,
+  options?: UseQueryOptions<
+    AxiosResponse<SpaceEntryData>,
+    AxiosError<ErrorResponse>,
+    TData,
+    [QueryKey, QuerySpaceEntryParams]
+  >
+): UseQueryResult<TData, AxiosError<ErrorResponse>> =>
+  useQuery(['getSpaceEntry', { sharingSpaceId }], querySpaceEntry, options);
+
+export default useSpaceEntry;

--- a/frontend/src/pages/GuestReservation/GuestReservation.tsx
+++ b/frontend/src/pages/GuestReservation/GuestReservation.tsx
@@ -40,6 +40,7 @@ interface GuestReservationState {
   selectedDate: string;
   scrollPosition?: ScrollPosition;
   reservation?: Reservation;
+  defaultDescription?: string;
 }
 
 export interface EditGuestReservationParams extends GuestReservationParams {
@@ -61,7 +62,8 @@ const GuestReservation = (): JSX.Element => {
     history.replace(HREF.GUEST_MAP(sharingMapId));
   }
 
-  const { mapId, spaceId, selectedDate, scrollPosition, reservation } = location.state;
+  const { mapId, spaceId, selectedDate, scrollPosition, reservation, defaultDescription } =
+    location.state;
   const [date, , setDate] = useInput(selectedDate);
 
   const isEditMode = !!reservation;
@@ -292,6 +294,7 @@ const GuestReservation = (): JSX.Element => {
                 reservation={reservation}
                 date={date}
                 userName={userName ?? ''}
+                defaultDescription={defaultDescription}
                 onChangeDate={handleChangeDate}
                 onSubmit={handleSubmitMemberGuest}
               />
@@ -301,6 +304,7 @@ const GuestReservation = (): JSX.Element => {
                 space={getSpace.data?.data}
                 reservation={reservation}
                 date={date}
+                defaultDescription={defaultDescription}
                 onChangeDate={handleChangeDate}
                 onSubmit={handleSubmitGuest}
               />

--- a/frontend/src/pages/GuestReservation/units/GuestReservationForm.tsx
+++ b/frontend/src/pages/GuestReservation/units/GuestReservationForm.tsx
@@ -26,6 +26,7 @@ interface Props {
   space: Pick<Space, 'settings'>;
   reservation?: Reservation;
   date: string;
+  defaultDescription?: string;
   onChangeDate: ChangeEventHandler<HTMLInputElement>;
   onSubmit: (
     event: React.FormEvent<HTMLFormElement>,
@@ -44,6 +45,7 @@ const GuestReservationForm = ({
   space,
   date,
   reservation,
+  defaultDescription,
   onSubmit,
   onChangeDate,
 }: Props): JSX.Element => {
@@ -81,7 +83,7 @@ const GuestReservationForm = ({
 
   const [{ name, description, password }, onChangeForm] = useInputs<Form>({
     name: reservation?.name ?? '',
-    description: reservation?.description ?? '',
+    description: reservation?.description ?? defaultDescription ?? '',
     password: '',
   });
 

--- a/frontend/src/pages/GuestReservation/units/MemberGuestReservationForm.tsx
+++ b/frontend/src/pages/GuestReservation/units/MemberGuestReservationForm.tsx
@@ -26,6 +26,7 @@ interface Props {
   reservation?: Reservation;
   date: string;
   userName: string;
+  defaultDescription?: string;
   onChangeDate: ChangeEventHandler<HTMLInputElement>;
   onSubmit: (
     event: React.FormEvent<HTMLFormElement>,
@@ -43,6 +44,7 @@ const MemberGuestReservationForm = ({
   date,
   reservation,
   userName,
+  defaultDescription,
   onSubmit,
   onChangeDate,
 }: Props): JSX.Element => {
@@ -79,7 +81,7 @@ const MemberGuestReservationForm = ({
   });
 
   const [{ description }, onChangeForm] = useInputs<Form>({
-    description: reservation?.description ?? '',
+    description: reservation?.description ?? defaultDescription ?? '',
   });
 
   const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {

--- a/frontend/src/pages/Login/Login.tsx
+++ b/frontend/src/pages/Login/Login.tsx
@@ -9,8 +9,10 @@ import Layout from 'components/Layout/Layout';
 import SocialLoginButton from 'components/SocialAuthButton/SocialLoginButton';
 import MESSAGE from 'constants/message';
 import PATH from 'constants/path';
+import { LOCAL_STORAGE_KEY } from 'constants/storage';
 import { AccessTokenContext } from 'providers/AccessTokenProvider';
 import { ErrorResponse, LoginSuccess } from 'types/response';
+import { getLocalStorageItem, removeLocalStorageItem } from 'utils/localStorage';
 import * as Styled from './Login.styles';
 import LoginForm from './units/LoginForm';
 
@@ -45,6 +47,17 @@ const Login = (): JSX.Element => {
       const { accessToken } = response.data;
 
       setAccessToken(accessToken);
+
+      const afterLoginPath = getLocalStorageItem({
+        key: LOCAL_STORAGE_KEY.AFTER_LOGIN_PATH,
+        defaultValue: '',
+      });
+
+      if (afterLoginPath && typeof afterLoginPath === 'string') {
+        removeLocalStorageItem({ key: LOCAL_STORAGE_KEY.AFTER_LOGIN_PATH });
+        history.push(afterLoginPath);
+        return;
+      }
 
       history.push(PATH.MANAGER_MAP_LIST);
     },

--- a/frontend/src/pages/ManagerMapDetail/units/ReservationList.styles.ts
+++ b/frontend/src/pages/ManagerMapDetail/units/ReservationList.styles.ts
@@ -29,6 +29,12 @@ export const PanelHeadWrapper = styled.div`
   justify-content: space-between;
 `;
 
+export const PanelHeadButtons = styled.div`
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+`;
+
 export const PanelMessage = styled.p`
   padding: 1rem 0.75rem;
   font-size: 0.875rem;

--- a/frontend/src/pages/ManagerMapDetail/units/ReservationList.tsx
+++ b/frontend/src/pages/ManagerMapDetail/units/ReservationList.tsx
@@ -5,6 +5,7 @@ import Button from 'components/Button/Button';
 import IconButton from 'components/IconButton/IconButton';
 import ManagerReservationListItem from 'components/ManagerReservationListItem/ManagerReservationListItem';
 import Panel from 'components/Panel/Panel';
+import QRCodeModal from 'components/QRCode/QRCodeModal';
 import PATH, { HREF } from 'constants/path';
 import { Order, Reservation, SpaceReservation } from 'types/common';
 import { getReservationStatus } from 'utils/reservation';
@@ -29,6 +30,10 @@ const ReservationList = ({
   onDeleteReservation,
 }: Props): JSX.Element => {
   const [spacesOrder, setSpacesOrder] = useState<Order>(Order.Ascending);
+  const [qrModalSpace, setQrModalSpace] = useState<{
+    spaceId: number;
+    spaceName: string;
+  } | null>(null);
 
   const sortedReservations = useMemo(
     () => sortReservations(reservations, spacesOrder),
@@ -76,13 +81,22 @@ const ReservationList = ({
                 <Panel.Header dotColor={spaceColor}>
                   <Styled.PanelHeadWrapper>
                     <Panel.Title>{spaceName}</Panel.Title>
-                    <Button
-                      variant="primary-text"
-                      size="dense"
-                      onClick={() => onCreateReservation(spaceId)}
-                    >
-                      예약 추가하기
-                    </Button>
+                    <Styled.PanelHeadButtons>
+                      <Button
+                        variant="text"
+                        size="dense"
+                        onClick={() => setQrModalSpace({ spaceId, spaceName })}
+                      >
+                        QR
+                      </Button>
+                      <Button
+                        variant="primary-text"
+                        size="dense"
+                        onClick={() => onCreateReservation(spaceId)}
+                      >
+                        예약 추가하기
+                      </Button>
+                    </Styled.PanelHeadButtons>
                   </Styled.PanelHeadWrapper>
                 </Panel.Header>
                 <Panel.Content>
@@ -124,6 +138,16 @@ const ReservationList = ({
             ))}
         </Styled.SpaceList>
       </Styled.ReservationsContainer>
+
+      {qrModalSpace && (
+        <QRCodeModal
+          open={!!qrModalSpace}
+          onClose={() => setQrModalSpace(null)}
+          mapId={selectedMapId}
+          spaceId={qrModalSpace.spaceId}
+          spaceName={qrModalSpace.spaceName}
+        />
+      )}
     </>
   );
 };

--- a/frontend/src/pages/SpaceEntry/SpaceEntry.styles.ts
+++ b/frontend/src/pages/SpaceEntry/SpaceEntry.styles.ts
@@ -1,0 +1,140 @@
+import { Link } from 'react-router-dom';
+import styled, { css } from 'styled-components';
+import ColorDotComponent from 'components/ColorDot/ColorDot';
+import { FORM_MAX_WIDTH } from 'constants/style';
+
+export const Container = styled.div`
+  max-width: ${FORM_MAX_WIDTH};
+  margin: 0 auto;
+  padding-bottom: 4rem;
+`;
+
+export const SpaceHeader = styled.div`
+  text-align: center;
+  margin: 2rem 0 1.5rem;
+`;
+
+export const MapName = styled.p`
+  font-size: 0.875rem;
+  color: ${({ theme }) => theme.gray[500]};
+  margin-bottom: 0.5rem;
+`;
+
+export const SpaceNameWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.75rem;
+`;
+
+export const SpaceName = styled.h2`
+  font-size: 1.625rem;
+  font-weight: 700;
+`;
+
+export const ColorDot = styled(ColorDotComponent)`
+  flex-shrink: 0;
+`;
+
+export const StatusBadge = styled.span<{ available: boolean }>`
+  display: inline-block;
+  padding: 0.25rem 0.75rem;
+  border-radius: 1rem;
+  font-size: 0.875rem;
+  font-weight: 600;
+  margin-top: 0.75rem;
+
+  ${({ available, theme }) =>
+    available
+      ? css`
+          background-color: ${theme.primary[100]};
+          color: ${theme.primary[400]};
+        `
+      : css`
+          background-color: ${theme.gray[200]};
+          color: ${theme.gray[500]};
+        `}
+`;
+
+export const ReserveButtonWrapper = styled.div`
+  margin: 1.5rem 0;
+`;
+
+export const Section = styled.section`
+  margin: 1.5rem 0;
+`;
+
+export const SectionTitle = styled.h3`
+  font-size: 1.125rem;
+  font-weight: 700;
+  margin-bottom: 1rem;
+  padding-bottom: 0.5rem;
+  border-bottom: 2px solid ${({ theme }) => theme.primary[400]};
+`;
+
+export const ReservationList = styled.div`
+  border-top: 1px solid ${({ theme }) => theme.gray[400]};
+`;
+
+export const Message = styled.p`
+  white-space: pre-wrap;
+  color: ${({ theme }) => theme.gray[500]};
+  text-align: center;
+  padding: 2rem 0;
+`;
+
+export const SettingInfo = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  margin-bottom: 1rem;
+`;
+
+export const SettingText = styled.p`
+  font-size: 0.875rem;
+  color: ${({ theme }) => theme.gray[500]};
+`;
+
+export const LoadingContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 50vh;
+`;
+
+export const LoadingMessage = styled.p`
+  font-size: 1.125rem;
+  color: ${({ theme }) => theme.gray[500]};
+  margin-top: 1rem;
+`;
+
+export const ErrorContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 50vh;
+  text-align: center;
+`;
+
+export const ErrorMessage = styled.p`
+  font-size: 1.125rem;
+  color: ${({ theme }) => theme.gray[500]};
+  margin-bottom: 1.5rem;
+  white-space: pre-wrap;
+`;
+
+export const HomeLink = styled(Link)`
+  color: ${({ theme }) => theme.primary[400]};
+  text-decoration: underline;
+  font-size: 1rem;
+`;
+
+export const MapLink = styled(Link)`
+  display: inline-block;
+  color: ${({ theme }) => theme.primary[400]};
+  font-size: 0.875rem;
+  margin-top: 0.5rem;
+  text-decoration: underline;
+`;

--- a/frontend/src/pages/SpaceEntry/SpaceEntry.tsx
+++ b/frontend/src/pages/SpaceEntry/SpaceEntry.tsx
@@ -1,0 +1,171 @@
+import dayjs from 'dayjs';
+import { useContext } from 'react';
+import { useHistory, useLocation, useParams } from 'react-router-dom';
+import Button from 'components/Button/Button';
+import Header from 'components/Header/Header';
+import Layout from 'components/Layout/Layout';
+import ManagerReservationListItem from 'components/ManagerReservationListItem/ManagerReservationListItem';
+import MESSAGE from 'constants/message';
+import PATH, { HREF } from 'constants/path';
+import { LOCAL_STORAGE_KEY } from 'constants/storage';
+import useSpaceEntry from 'hooks/query/useSpaceEntry';
+import { AccessTokenContext } from 'providers/AccessTokenProvider';
+import { Reservation } from 'types/common';
+import { formatDate, formatTimePrettier } from 'utils/datetime';
+import { setLocalStorageItem } from 'utils/localStorage';
+import { getReservationStatus } from 'utils/reservation';
+import * as Styled from './SpaceEntry.styles';
+
+interface SpaceEntryParams {
+  sharingSpaceId: string;
+}
+
+const SpaceEntry = (): JSX.Element => {
+  const { accessToken } = useContext(AccessTokenContext);
+  const history = useHistory();
+  const location = useLocation();
+  const { sharingSpaceId } = useParams<SpaceEntryParams>();
+
+  const queryParams = new URLSearchParams(location.search);
+  const defaultDescription = queryParams.get('description') ?? '';
+
+  const getSpaceEntry = useSpaceEntry(
+    { sharingSpaceId },
+    {
+      retry: false,
+    }
+  );
+
+  const spaceEntry = getSpaceEntry.data?.data;
+
+  const today = formatDate(dayjs().tz());
+  const todayReservations: Reservation[] = spaceEntry?.todayReservations ?? [];
+
+  const handleReserve = () => {
+    if (!spaceEntry) return;
+
+    if (!accessToken) {
+      setLocalStorageItem({
+        key: LOCAL_STORAGE_KEY.AFTER_LOGIN_PATH,
+        item: location.pathname + location.search,
+      });
+      history.push(PATH.LOGIN);
+      return;
+    }
+
+    history.push({
+      pathname: HREF.GUEST_RESERVATION(spaceEntry.sharingMapId),
+      state: {
+        mapId: spaceEntry.mapId,
+        spaceId: spaceEntry.spaceId,
+        selectedDate: today,
+        defaultDescription,
+      },
+    });
+  };
+
+  if (getSpaceEntry.isLoading) {
+    return (
+      <>
+        <Header />
+        <Layout>
+          <Styled.LoadingContainer>
+            <Styled.LoadingMessage>공간 정보를 불러오는 중입니다...</Styled.LoadingMessage>
+          </Styled.LoadingContainer>
+        </Layout>
+      </>
+    );
+  }
+
+  if (getSpaceEntry.isError || !spaceEntry) {
+    return (
+      <>
+        <Header />
+        <Layout>
+          <Styled.ErrorContainer>
+            <Styled.ErrorMessage>
+              {'공간 정보를 찾을 수 없습니다.\n올바른 QR 코드인지 확인해주세요.'}
+            </Styled.ErrorMessage>
+            <Styled.HomeLink to={PATH.MAIN}>홈으로 이동하기</Styled.HomeLink>
+          </Styled.ErrorContainer>
+        </Layout>
+      </>
+    );
+  }
+
+  return (
+    <>
+      <Header />
+      <Layout>
+        <Styled.Container>
+          <Styled.SpaceHeader>
+            <Styled.MapName>{spaceEntry.mapName}</Styled.MapName>
+            <Styled.SpaceNameWrapper>
+              <Styled.ColorDot color={spaceEntry.spaceColor} size="large" />
+              <Styled.SpaceName>{spaceEntry.spaceName}</Styled.SpaceName>
+            </Styled.SpaceNameWrapper>
+            <Styled.StatusBadge available={spaceEntry.reservationEnable}>
+              {spaceEntry.reservationEnable ? '예약 가능' : '예약 불가'}
+            </Styled.StatusBadge>
+            <br />
+            <Styled.MapLink to={HREF.GUEST_MAP(spaceEntry.sharingMapId)}>
+              전체 맵 보기
+            </Styled.MapLink>
+          </Styled.SpaceHeader>
+
+          <Styled.ReserveButtonWrapper>
+            <Button
+              variant="primary"
+              size="large"
+              fullWidth
+              disabled={!spaceEntry.reservationEnable}
+              onClick={handleReserve}
+            >
+              {accessToken ? '즉석 예약하기' : '로그인 후 예약하기'}
+            </Button>
+          </Styled.ReserveButtonWrapper>
+
+          {spaceEntry.settings.length > 0 && (
+            <Styled.Section>
+              <Styled.SectionTitle>예약 가능 시간</Styled.SectionTitle>
+              <Styled.SettingInfo>
+                {spaceEntry.settings.map((setting, index) => (
+                  <Styled.SettingText key={index}>
+                    {setting.settingStartTime.slice(0, 5)} ~ {setting.settingEndTime.slice(0, 5)}
+                    {' ('}
+                    최소 {formatTimePrettier(setting.reservationMinimumTimeUnit)}, 최대{' '}
+                    {formatTimePrettier(setting.reservationMaximumTimeUnit)}
+                    {')'}
+                  </Styled.SettingText>
+                ))}
+              </Styled.SettingInfo>
+            </Styled.Section>
+          )}
+
+          <Styled.Section>
+            <Styled.SectionTitle>오늘의 예약 현황</Styled.SectionTitle>
+            {todayReservations.length === 0 && (
+              <Styled.Message>{MESSAGE.RESERVATION.SUGGESTION}</Styled.Message>
+            )}
+            {todayReservations.length > 0 && (
+              <Styled.ReservationList role="list">
+                {todayReservations.map((reservation) => (
+                  <ManagerReservationListItem
+                    key={reservation.id}
+                    reservation={reservation}
+                    status={getReservationStatus(
+                      reservation.startDateTime,
+                      reservation.endDateTime
+                    )}
+                  />
+                ))}
+              </Styled.ReservationList>
+            )}
+          </Styled.Section>
+        </Styled.Container>
+      </Layout>
+    </>
+  );
+};
+
+export default SpaceEntry;

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -11668,6 +11668,11 @@ q@^1.1.2:
   resolved "https://registry.npmjs.org/q/-/q-1.5.1.tgz"
   integrity sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=
 
+qrcode.react@^3.1.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/qrcode.react/-/qrcode.react-3.2.0.tgz#97daabd4ff641a3f3c678f87be106ebc55f9cd07"
+  integrity sha512-YietHHltOHA4+l5na1srdaMx4sVSOjV9tamHs+mwiLWAMr6QVACRUw1Neax5CptFILcNoITctJY0Ipyn5enQ8g==
+
 qs@6.7.0:
   version "6.7.0"
   resolved "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz"


### PR DESCRIPTION
## Summary
회의실(Space) 단위의 엔트리 URL과 QR 코드를 도입하여, 회의실 입구에서 QR 스캔만으로 즉석 예약이 가능하도록 합니다.

## Changes
### Backend
- `SharingIdGenerator` 확장: `fromSpace()`, `parseSpaceIdFrom()` 추가 (`space:` prefix로 Map/Space ID 충돌 방지)
- `EntryController` 신규: `GET /api/entry/spaces?sharingSpaceId={id}` (인증 불필요, 공개 API)
- `ManagerSpaceController` 확장: `GET /api/managers/maps/{mapId}/spaces/{spaceId}/sharing-id` (JWT 필수)
- `SpaceEntryResponse`, `SharingSpaceIdResponse` DTO 신규
- `SpaceService`에 `findSpaceBySharingId()`, `getSharingSpaceId()` 추가
- 테스트 추가: `SharingIdGeneratorTest`, `SpaceServiceTest`

### Frontend - 엔트리 페이지
- `/entry/:sharingSpaceId` 라우트 추가
- `SpaceEntry` 페이지: 회의실 정보, 예약 현황, 이용 가능 여부 표시
- 인증 분기: 로그인 사용자 → 즉석 예약, 비로그인 → 로그인 후 리다이렉트
- `?description=` 쿼리 파라미터로 기본 사용 목적 전달 지원
- `Login.tsx`에 `AFTER_LOGIN_PATH` 기반 로그인 후 리다이렉트 추가

### Frontend - QR 코드
- `qrcode.react` v3.2.0 도입
- `QRCode` 컴포넌트: 다운로드, URL 복사, 프린트 기능
- `QRCodeModal`: 기본 사용 목적 입력 필드 포함
- 매니저 예약 목록에 Space별 QR 생성 버튼 추가
### 기본 사용 목적 (defaultDescription) 흐름
- URL `?description=X` → SpaceEntry → GuestReservation → 예약 폼 초기값
- 기존 예약 흐름에 영향 없음 (undefined → 빈 문자열)

## Design Decisions
- **DB 스키마 변경 없음**: `sharingSpaceId`는 런타임에 `SharingIdGenerator`로 생성 (기존 Map sharingId와 동일 패턴)
- **인증 불필요**: `/api/entry/**`는 `AuthenticationPrincipalConfig`의 인터셉터 범위 밖
- **`space:` prefix**: Map sharingId와 Space sharingId 충돌 방지를 위한 구분자

## Test
- [x] Backend 529 테스트 모두 통과
- [x] 신규 테스트 케이스 추가 (SharingIdGeneratorTest, SpaceServiceTest)
- [x] 로컬 환경 E2E 테스트 완료 (QR 생성/다운로드/프린트, 엔트리 페이지, 로그인 리다이렉트)

Closes #998